### PR TITLE
Reverse the check to enforce the minimum default sampling interval in powmon.

### DIFF
--- a/src/powmon/powmon.c
+++ b/src/powmon/powmon.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
                 break;
             case 'i':
                 sample_interval = atol(optarg);
-                if (sample_interval > FASTEST_SAMPLE_INTERVAL_MS)
+                if (sample_interval < FASTEST_SAMPLE_INTERVAL_MS)
                 {
                     printf("Warning: Specified sample interval (-i) is faster than default. Setting to default sampling interval of %d milliseconds.\n", FASTEST_SAMPLE_INTERVAL_MS);
                     sample_interval = FASTEST_SAMPLE_INTERVAL_MS;


### PR DESCRIPTION
Reversed the check to enforce the minimum default sampling interval in powmon so that a sampling interval shorter than 50 msec isn't allowed. 