### PR TITLE
Default to not building VARIORUM_WITH_GPU

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ option(BUILD_TESTS         "Build tests"                 ON)
 option(VARIORUM_WITH_INTEL "Support Intel architectures" ON)
 option(VARIORUM_WITH_AMD   "Support AMD architectures"   ON)
 option(VARIORUM_WITH_IBM   "Support IBM architectures"   ON)
-option(VARIORUM_WITH_GPU   "Support GPU architectures"   ON)
+option(VARIORUM_WITH_GPU   "Support GPU architectures"   OFF)
 option(VARIORUM_DEBUG      "Enable debug statements"     OFF)
 option(VARIORUM_LOG        "Enable logging statements"   ON)
 


### PR DESCRIPTION
I'm concerned that the nvml.h dependence will prevent variorum
from being built out-of-the-box for most users, and that there
is not a simple "apt-get" recipe to fulfill that dependence (as
there is with libhwloc).

This patch turns off VARIORUM_WITH_GPU in src/CMakeLists.txt.

Fixes #55. 