### PR TITLE
Changing variorum_set_topology() to use "get".

### DIFF
--- a/src/examples/ex-disable-turbo.c
+++ b/src/examples/ex-disable-turbo.c
@@ -11,10 +11,10 @@ int main(int argc, char **argv)
 {
     int ret;
 
-	ret = variorum_disable_turbo();
-	if (ret != 0)
+    ret = variorum_disable_turbo();
+    if (ret != 0)
     {
-		printf("Disable turbo failed!\n");
-	}
+        printf("Disable turbo failed!\n");
+    }
     return ret;
 }

--- a/src/examples/ex-enable-turbo.c
+++ b/src/examples/ex-enable-turbo.c
@@ -11,10 +11,10 @@ int main(int argc, char **argv)
 {
     int ret;
 
-	ret = variorum_enable_turbo();
-	if (ret != 0)
+    ret = variorum_enable_turbo();
+    if (ret != 0)
     {
-		printf("Enable turbo failed!\n");
-	}
+        printf("Enable turbo failed!\n");
+    }
     return ret;
 }

--- a/src/examples/ex-print-topology.c
+++ b/src/examples/ex-print-topology.c
@@ -9,12 +9,7 @@
 
 int main(int argc, char **argv)
 {
-    int ret;
 
-    ret = variorum_print_topology();
-    if (ret != 0)
-    {
-        printf("Print topology failed!\n");
-    }
-    return ret;
+    variorum_print_topology();
+    return 0;
 }

--- a/src/examples/ex-print-turbo.c
+++ b/src/examples/ex-print-turbo.c
@@ -11,10 +11,10 @@ int main(int argc, char **argv)
 {
     int ret;
 
-	ret = variorum_print_turbo();
-	if (ret != 0)
+    ret = variorum_print_turbo();
+    if (ret != 0)
     {
-		printf("Print turbo failed!\n");
-	}
+        printf("Print turbo failed!\n");
+    }
     return ret;
 }

--- a/src/powmon/power_wrapper_dynamic.c
+++ b/src/powmon/power_wrapper_dynamic.c
@@ -132,33 +132,33 @@ int main(int argc, char**argv)
     {
         switch(opt)
         {
-            case 'c':
-                highlander_clean();
-                printf("Exiting power_wrapper_dynamic...\n");
-                return 0;
-            case 'a':
-                app = optarg;
-                break;
-            case 'w':
-                watt_cap = atoi(optarg);
-                break;
-            case '?':
-                if (optopt == 'w' || optopt == 'a')
-                {
-                    fprintf(stderr, "Option -%c requires an argument.\n", optopt);
-                }
-                else if (isprint(optopt))
-                {
-                    fprintf(stderr, "\nError: unknown parameter \"-%c\"\n", optopt);
-                }
-                else
-                {
-                    fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
-                }
-                fprintf(stderr, "%s", usage);
-                return 1;
-            default:
-                return 1;
+        case 'c':
+            highlander_clean();
+            printf("Exiting power_wrapper_dynamic...\n");
+            return 0;
+        case 'a':
+            app = optarg;
+            break;
+        case 'w':
+            watt_cap = atoi(optarg);
+            break;
+        case '?':
+            if (optopt == 'w' || optopt == 'a')
+            {
+                fprintf(stderr, "Option -%c requires an argument.\n", optopt);
+            }
+            else if (isprint(optopt))
+            {
+                fprintf(stderr, "\nError: unknown parameter \"-%c\"\n", optopt);
+            }
+            else
+            {
+                fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
+            }
+            fprintf(stderr, "%s", usage);
+            return 1;
+        default:
+            return 1;
         }
     }
 

--- a/src/powmon/power_wrapper_static.c
+++ b/src/powmon/power_wrapper_static.c
@@ -91,31 +91,31 @@ int main(int argc, char **argv)
     {
         switch(opt)
         {
-            case 'c':
-                highlander_clean();
-                printf("Exiting power_wrapper_static...\n");
-                return 0;
-            case 'a':
-                app = optarg;
-                break;
-            case 'w':
-                watt_cap = atoi(optarg);
-                break;
-            case '?':
-                if (optopt == 'w' || optopt == 'a')
-                {
-                    fprintf(stderr, "Option -%c requires an argument.\n", optopt);
-                }
-                else if (isprint(optopt))
-                {
-                    fprintf(stderr, "\nError: unknown parameter \"-%c\"\n", optopt);
-                }
-                else
-                {
-                    fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
-                }
-                fprintf(stderr, "%s", usage);
-                return 1;
+        case 'c':
+            highlander_clean();
+            printf("Exiting power_wrapper_static...\n");
+            return 0;
+        case 'a':
+            app = optarg;
+            break;
+        case 'w':
+            watt_cap = atoi(optarg);
+            break;
+        case '?':
+            if (optopt == 'w' || optopt == 'a')
+            {
+                fprintf(stderr, "Option -%c requires an argument.\n", optopt);
+            }
+            else if (isprint(optopt))
+            {
+                fprintf(stderr, "\nError: unknown parameter \"-%c\"\n", optopt);
+            }
+            else
+            {
+                fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
+            }
+            fprintf(stderr, "%s", usage);
+            return 1;
         }
     }
 

--- a/src/powmon/powmon.c
+++ b/src/powmon/powmon.c
@@ -99,42 +99,42 @@ int main(int argc, char **argv)
     {
         switch(opt)
         {
-            case 'c':
-                highlander_clean();
-                printf("Exiting powmon...\n");
-                return 0;
-            case 'a':
-                app = optarg;
-                set_app = 1;
-                break;
-            case 'p':
-                logpath = strdup(optarg);
-                break;
-            case 'i':
-                sample_interval = atol(optarg);
-                if (sample_interval < FASTEST_SAMPLE_INTERVAL_MS)
-                {
-                    printf("Warning: Specified sample interval (-i) is faster than default. Setting to default sampling interval of %d milliseconds.\n", FASTEST_SAMPLE_INTERVAL_MS);
-                    sample_interval = FASTEST_SAMPLE_INTERVAL_MS;
-                }
-                break;
-            case '?':
-                if (optopt == 'a')
-                {
-                    fprintf(stderr, "Option -%c requires an argument.\n", optopt);
-                }
-                else if (isprint(optopt))
-                {
-                    fprintf(stderr, "\nError: unknown parameter \"-%c\"\n", optopt);
-                }
-                else
-                {
-                    fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
-                }
-                fprintf(stderr, "%s", usage);
-                return 1;
-            default:
-                return 1;
+        case 'c':
+            highlander_clean();
+            printf("Exiting powmon...\n");
+            return 0;
+        case 'a':
+            app = optarg;
+            set_app = 1;
+            break;
+        case 'p':
+            logpath = strdup(optarg);
+            break;
+        case 'i':
+            sample_interval = atol(optarg);
+            if (sample_interval < FASTEST_SAMPLE_INTERVAL_MS)
+            {
+                printf("Warning: Specified sample interval (-i) is faster than default. Setting to default sampling interval of %d milliseconds.\n", FASTEST_SAMPLE_INTERVAL_MS);
+                sample_interval = FASTEST_SAMPLE_INTERVAL_MS;
+            }
+            break;
+        case '?':
+            if (optopt == 'a')
+            {
+                fprintf(stderr, "Option -%c requires an argument.\n", optopt);
+            }
+            else if (isprint(optopt))
+            {
+                fprintf(stderr, "\nError: unknown parameter \"-%c\"\n", optopt);
+            }
+            else
+            {
+                fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
+            }
+            fprintf(stderr, "%s", usage);
+            return 1;
+        default:
+            return 1;
         }
     }
 

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -24,7 +24,7 @@ int p9_get_power(int long_ver)
     int iter = 0;
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     fd = open("/sys/firmware/opal/exports/occ_inband_sensors", O_RDONLY);
     if (fd < 0)
@@ -297,7 +297,7 @@ int p9_monitoring(FILE *output)
     int long_ver = 0;
     static int count = 0;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     fd = open("/sys/firmware/opal/exports/occ_inband_sensors", O_RDONLY);
     if (fd < 0)

--- a/src/variorum/IBM/ibm_sensors.c
+++ b/src/variorum/IBM/ibm_sensors.c
@@ -87,12 +87,12 @@ unsigned long read_sensor(const struct occ_sensor_data_header *hb, uint32_t offs
 
     switch (attr)
     {
-        case SENSOR_SAMPLE:
-            return be16toh(sensor->sample);
-        case SENSOR_ACCUMULATOR:
-            return be64toh(sensor->accumulator);
-        default:
-            break;
+    case SENSOR_SAMPLE:
+        return be16toh(sensor->sample);
+    case SENSOR_ACCUMULATOR:
+        return be64toh(sensor->accumulator);
+    default:
+        break;
     }
 
     return 0;

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -72,7 +72,7 @@ int fm_06_4f_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -130,7 +130,7 @@ int fm_06_4f_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -67,7 +67,7 @@ int fm_06_3f_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -125,7 +125,7 @@ int fm_06_3f_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -264,25 +264,25 @@ int fm_06_3f_get_power(int long_ver)
 int fm_06_3f_enable_turbo(void)
 {
 #ifdef VARIORUM_LOG
-	printf("Running %s\n", __FUNCTION__);
+    printf("Running %s\n", __FUNCTION__);
 #endif
 
-	unsigned int turbo_mode_disable_bit = 38;
+    unsigned int turbo_mode_disable_bit = 38;
     set_turbo_on(msrs.ia32_misc_enable, turbo_mode_disable_bit);
 
-	return 0;
+    return 0;
 }
 
 int fm_06_3f_disable_turbo(void)
 {
 #ifdef VARIORUM_LOG
-	printf("Running %s\n", __FUNCTION__);
+    printf("Running %s\n", __FUNCTION__);
 #endif
 
-	unsigned int turbo_mode_disable_bit = 38;
+    unsigned int turbo_mode_disable_bit = 38;
     set_turbo_off(msrs.ia32_misc_enable, turbo_mode_disable_bit);
 
-	return 0;
+    return 0;
 }
 int fm_06_3f_get_turbo_status(void)
 {

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -72,7 +72,7 @@ int fm_06_3e_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -130,7 +130,7 @@ int fm_06_3e_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -67,7 +67,7 @@ int fm_06_9e_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -113,7 +113,7 @@ int fm_06_9e_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -61,7 +61,7 @@ int fm_06_2a_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -119,7 +119,7 @@ int fm_06_2a_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -67,7 +67,7 @@ int fm_06_55_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -113,7 +113,7 @@ int fm_06_55_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -273,7 +273,7 @@ int fm_06_55_monitoring(FILE *output)
 int fm_06_55_set_frequency(int core_freq_mhz)
 {
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/clocks_features.c
+++ b/src/variorum/Intel/clocks_features.c
@@ -23,7 +23,7 @@ void clocks_storage(struct clocks_data **cd, off_t msr_aperf, off_t msr_mperf, o
 
     if (!init)
     {
-        variorum_set_topology(NULL, NULL, &nthreads);
+        variorum_get_topology(NULL, NULL, &nthreads);
         d.aperf = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
         d.mperf = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
         d.tsc = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
@@ -45,7 +45,7 @@ void perf_storage_temp(struct perf_data **pd, off_t msr_perf_status, off_t msr_p
     static struct perf_data d;
     int nsockets, ncores, nthreads;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     if (!init)
     {
@@ -79,7 +79,7 @@ void perf_storage(struct perf_data **pd, off_t msr_perf_status)
 
     if (!nsockets)
     {
-        variorum_set_topology(&nsockets, NULL, NULL);
+        variorum_get_topology(&nsockets, NULL, NULL);
         d.perf_status = (uint64_t **) malloc(nsockets * sizeof(uint64_t *));
         allocate_batch(PERF_DATA, 2UL * nsockets);
         load_socket_batch(msr_perf_status, d.perf_status, PERF_DATA);
@@ -104,7 +104,7 @@ void dump_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t m
     char hostname[1024];
     int max_non_turbo_ratio = get_max_non_turbo_ratio(msr_platform_info);
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     gethostname(hostname, 1024);
     if (!init)
     {
@@ -169,7 +169,7 @@ void print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t 
     char hostname[1024];
     int max_non_turbo_ratio = get_max_non_turbo_ratio(msr_platform_info);
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     gethostname(hostname, 1024);
 
     clocks_storage(&cd, msr_aperf, msr_mperf, msr_tsc);
@@ -223,7 +223,7 @@ void print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t 
 //    char hostname[1024];
 //    int max_non_turbo_ratio = get_max_non_turbo_ratio(msr_platform_info);
 //
-//    variorum_set_topology(&nsockets, &ncores, &nthreads);
+//    variorum_get_topology(&nsockets, &ncores, &nthreads);
 //    gethostname(hostname, 1024);
 //
 //    clocks_storage(&cd, msr_aperf, msr_mperf, msr_tsc);
@@ -254,7 +254,7 @@ void print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t 
 //    char hostname[1024];
 //    int max_non_turbo_ratio = get_max_non_turbo_ratio(msr_platform_info);
 //
-//    variorum_set_topology(&nsockets, &ncores, &nthreads);
+//    variorum_get_topology(&nsockets, &ncores, &nthreads);
 //    gethostname(hostname, 1024);
 //
 //    clocks_storage(&cd, msr_aperf, msr_mperf, msr_tsc);
@@ -282,7 +282,7 @@ void set_p_state(int cpu_freq_mhz, enum ctl_domains_e domain, off_t msr_perf_sta
     static struct perf_data *pd;
     static int init = 0;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     if (!init)
     {
         init = 1;

--- a/src/variorum/Intel/counters_features.c
+++ b/src/variorum/Intel/counters_features.c
@@ -250,30 +250,30 @@ void dump_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs, off
     {
         switch(avail)
         {
-            case 8:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2 PMC3 PMC4 PMC5 PMC6 PMC7\n");
-                break;
-            case 7:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2 PMC3 PMC4 PMC5 PMC6\n");
-                break;
-            case 6:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2 PMC3 PMC4 PMC5\n");
-                break;
-            case 5:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2 PMC3 PMC4\n");
-                break;
-            case 4:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2 PMC3\n");
-                break;
-            case 3:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2\n");
-                break;
-            case 2:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1\n");
-                break;
-            case 1:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0\n");
-                break;
+        case 8:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2 PMC3 PMC4 PMC5 PMC6 PMC7\n");
+            break;
+        case 7:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2 PMC3 PMC4 PMC5 PMC6\n");
+            break;
+        case 6:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2 PMC3 PMC4 PMC5\n");
+            break;
+        case 5:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2 PMC3 PMC4\n");
+            break;
+        case 4:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2 PMC3\n");
+            break;
+        case 3:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1 PMC2\n");
+            break;
+        case 2:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0 PMC1\n");
+            break;
+        case 1:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host Thread PMC0\n");
+            break;
         }
 
         set_all_pmc_ctrl(0x0, 0x67, 0x00, 0xC4, 1, msrs_perfevtsel_ctrs);
@@ -288,38 +288,38 @@ void dump_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs, off
     {
         switch (avail)
         {
-            case 8:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu %lu %lu %lu %lu %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i], *p->pmc6[i], *p->pmc7[i]);
-                break;
-            case 7:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu %lu %lu %lu %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i], *p->pmc6[i]);
-                break;
-            case 6:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu %lu %lu %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i]);
-                break;
-            case 5:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu %lu %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i]);
-                break;
-            case 4:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i]);
-                break;
-            case 3:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i]);
-                break;
-            case 2:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i]);
-                break;
-            case 1:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu\n",
-                        hostname, i, *p->pmc0[i]);
-                break;
+        case 8:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu %lu %lu %lu %lu %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i], *p->pmc6[i], *p->pmc7[i]);
+            break;
+        case 7:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu %lu %lu %lu %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i], *p->pmc6[i]);
+            break;
+        case 6:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu %lu %lu %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i]);
+            break;
+        case 5:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu %lu %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i]);
+            break;
+        case 4:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i]);
+            break;
+        case 3:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i]);
+            break;
+        case 2:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i]);
+            break;
+        case 1:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS %s %d %lu\n",
+                    hostname, i, *p->pmc0[i]);
+            break;
         }
     }
 }
@@ -375,38 +375,38 @@ void print_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs, of
     {
         switch (avail)
         {
-            case 8:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu PMC3: %lu PMC4: %lu PMC5: %lu PMC6: %lu PMC7: %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i], *p->pmc6[i], *p->pmc7[i]);
-                break;
-            case 7:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu PMC3: %lu PMC4: %lu PMC5: %lu PMC6: %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i], *p->pmc6[i]);
-                break;
-            case 6:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu PMC3: %lu PMC4: %lu PMC5: %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i]);
-                break;
-            case 5:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu PMC3: %lu PMC4: %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i]);
-                break;
-            case 4:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu PMC3: %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i]);
-                break;
-            case 3:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i]);
-                break;
-            case 2:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu\n",
-                        hostname, i, *p->pmc0[i], *p->pmc1[i]);
-                break;
-            case 1:
-                fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu\n",
-                        hostname, i, *p->pmc0[i]);
-                break;
+        case 8:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu PMC3: %lu PMC4: %lu PMC5: %lu PMC6: %lu PMC7: %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i], *p->pmc6[i], *p->pmc7[i]);
+            break;
+        case 7:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu PMC3: %lu PMC4: %lu PMC5: %lu PMC6: %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i], *p->pmc6[i]);
+            break;
+        case 6:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu PMC3: %lu PMC4: %lu PMC5: %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i], *p->pmc5[i]);
+            break;
+        case 5:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu PMC3: %lu PMC4: %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i], *p->pmc4[i]);
+            break;
+        case 4:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu PMC3: %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i], *p->pmc3[i]);
+            break;
+        case 3:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu PMC2: %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i], *p->pmc2[i]);
+            break;
+        case 2:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu PMC1: %lu\n",
+                    hostname, i, *p->pmc0[i], *p->pmc1[i]);
+            break;
+        case 1:
+            fprintf(writedest, "_PERFORMANCE_MONITORING_COUNTERS Host: %s Thread: %d PMC0: %lu\n",
+                    hostname, i, *p->pmc0[i]);
+            break;
         }
     }
 }
@@ -435,42 +435,42 @@ static int init_pmc(struct pmc *p, off_t *msrs_perfmon_ctrs)
     }
     switch (avail)
     {
-        case 8:
-            p->pmc7 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 7:
-            p->pmc6 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 6:
-            p->pmc5 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 5:
-            p->pmc4 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 4:
-            p->pmc3 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 3:
-            p->pmc2 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 2:
-            p->pmc1 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 1:
-            p->pmc0 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 8:
+        p->pmc7 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 7:
+        p->pmc6 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 6:
+        p->pmc5 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 5:
+        p->pmc4 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 4:
+        p->pmc3 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 3:
+        p->pmc2 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 2:
+        p->pmc1 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 1:
+        p->pmc0 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
     }
     allocate_batch(COUNTERS_DATA, avail * nthreads);
     switch (avail)
     {
-        case 8:
-            load_thread_batch(msrs_perfmon_ctrs[7], p->pmc7, COUNTERS_DATA);
-        case 7:
-            load_thread_batch(msrs_perfmon_ctrs[6], p->pmc6, COUNTERS_DATA);
-        case 6:
-            load_thread_batch(msrs_perfmon_ctrs[5], p->pmc5, COUNTERS_DATA);
-        case 5:
-            load_thread_batch(msrs_perfmon_ctrs[4], p->pmc4, COUNTERS_DATA);
-        case 4:
-            load_thread_batch(msrs_perfmon_ctrs[3], p->pmc3, COUNTERS_DATA);
-        case 3:
-            load_thread_batch(msrs_perfmon_ctrs[2], p->pmc2, COUNTERS_DATA);
-        case 2:
-            load_thread_batch(msrs_perfmon_ctrs[1], p->pmc1, COUNTERS_DATA);
-        case 1:
-            load_thread_batch(msrs_perfmon_ctrs[0], p->pmc0, COUNTERS_DATA);
+    case 8:
+        load_thread_batch(msrs_perfmon_ctrs[7], p->pmc7, COUNTERS_DATA);
+    case 7:
+        load_thread_batch(msrs_perfmon_ctrs[6], p->pmc6, COUNTERS_DATA);
+    case 6:
+        load_thread_batch(msrs_perfmon_ctrs[5], p->pmc5, COUNTERS_DATA);
+    case 5:
+        load_thread_batch(msrs_perfmon_ctrs[4], p->pmc4, COUNTERS_DATA);
+    case 4:
+        load_thread_batch(msrs_perfmon_ctrs[3], p->pmc3, COUNTERS_DATA);
+    case 3:
+        load_thread_batch(msrs_perfmon_ctrs[2], p->pmc2, COUNTERS_DATA);
+    case 2:
+        load_thread_batch(msrs_perfmon_ctrs[1], p->pmc1, COUNTERS_DATA);
+    case 1:
+        load_thread_batch(msrs_perfmon_ctrs[0], p->pmc0, COUNTERS_DATA);
     }
     return 0;
 }
@@ -496,42 +496,42 @@ static int init_perfevtsel(struct perfevtsel *evt, off_t *msrs_perfevtsel_ctrs)
     }
     switch (avail)
     {
-        case 8:
-            evt->perf_evtsel7 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 7:
-            evt->perf_evtsel6 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 6:
-            evt->perf_evtsel5 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 5:
-            evt->perf_evtsel4 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 4:
-            evt->perf_evtsel3 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 3:
-            evt->perf_evtsel2 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 2:
-            evt->perf_evtsel1 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 1:
-            evt->perf_evtsel0 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 8:
+        evt->perf_evtsel7 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 7:
+        evt->perf_evtsel6 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 6:
+        evt->perf_evtsel5 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 5:
+        evt->perf_evtsel4 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 4:
+        evt->perf_evtsel3 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 3:
+        evt->perf_evtsel2 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 2:
+        evt->perf_evtsel1 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    case 1:
+        evt->perf_evtsel0 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
     }
     allocate_batch(COUNTERS_CTRL, avail * nthreads);
     switch (avail)
     {
-        case 8:
-            load_thread_batch(msrs_perfevtsel_ctrs[7], evt->perf_evtsel7, COUNTERS_CTRL);
-        case 7:
-            load_thread_batch(msrs_perfevtsel_ctrs[6], evt->perf_evtsel6, COUNTERS_CTRL);
-        case 6:
-            load_thread_batch(msrs_perfevtsel_ctrs[5], evt->perf_evtsel5, COUNTERS_CTRL);
-        case 5:
-            load_thread_batch(msrs_perfevtsel_ctrs[4], evt->perf_evtsel4, COUNTERS_CTRL);
-        case 4:
-            load_thread_batch(msrs_perfevtsel_ctrs[3], evt->perf_evtsel3, COUNTERS_CTRL);
-        case 3:
-            load_thread_batch(msrs_perfevtsel_ctrs[2], evt->perf_evtsel2, COUNTERS_CTRL);
-        case 2:
-            load_thread_batch(msrs_perfevtsel_ctrs[1], evt->perf_evtsel1, COUNTERS_CTRL);
-        case 1:
-            load_thread_batch(msrs_perfevtsel_ctrs[0], evt->perf_evtsel0, COUNTERS_CTRL);
+    case 8:
+        load_thread_batch(msrs_perfevtsel_ctrs[7], evt->perf_evtsel7, COUNTERS_CTRL);
+    case 7:
+        load_thread_batch(msrs_perfevtsel_ctrs[6], evt->perf_evtsel6, COUNTERS_CTRL);
+    case 6:
+        load_thread_batch(msrs_perfevtsel_ctrs[5], evt->perf_evtsel5, COUNTERS_CTRL);
+    case 5:
+        load_thread_batch(msrs_perfevtsel_ctrs[4], evt->perf_evtsel4, COUNTERS_CTRL);
+    case 4:
+        load_thread_batch(msrs_perfevtsel_ctrs[3], evt->perf_evtsel3, COUNTERS_CTRL);
+    case 3:
+        load_thread_batch(msrs_perfevtsel_ctrs[2], evt->perf_evtsel2, COUNTERS_CTRL);
+    case 2:
+        load_thread_batch(msrs_perfevtsel_ctrs[1], evt->perf_evtsel1, COUNTERS_CTRL);
+    case 1:
+        load_thread_batch(msrs_perfevtsel_ctrs[0], evt->perf_evtsel0, COUNTERS_CTRL);
     }
     return 0;
 }
@@ -582,30 +582,30 @@ void set_pmc_ctrl_flags(uint64_t cmask, uint64_t flags, uint64_t umask, uint64_t
     }
     switch(pmcnum)
     {
-        case 8:
-            *evt->perf_evtsel7[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
-            break;
-        case 7:
-            *evt->perf_evtsel6[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
-            break;
-        case 6:
-            *evt->perf_evtsel5[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
-            break;
-        case 5:
-            *evt->perf_evtsel4[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
-            break;
-        case 4:
-            *evt->perf_evtsel3[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
-            break;
-        case 3:
-            *evt->perf_evtsel2[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
-            break;
-        case 2:
-            *evt->perf_evtsel1[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
-            break;
-        case 1:
-            *evt->perf_evtsel0[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
-            break;
+    case 8:
+        *evt->perf_evtsel7[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
+        break;
+    case 7:
+        *evt->perf_evtsel6[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
+        break;
+    case 6:
+        *evt->perf_evtsel5[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
+        break;
+    case 5:
+        *evt->perf_evtsel4[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
+        break;
+    case 4:
+        *evt->perf_evtsel3[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
+        break;
+    case 3:
+        *evt->perf_evtsel2[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
+        break;
+    case 2:
+        *evt->perf_evtsel1[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
+        break;
+    case 1:
+        *evt->perf_evtsel0[thread] = 0UL | (cmask << 24) | (flags << 16) | (umask << 8) | eventsel;
+        break;
     }
 }
 
@@ -658,22 +658,22 @@ void clear_all_pmc(off_t *msrs_perfmon_ctrs)
     {
         switch (avail)
         {
-            case 8:
-                *p->pmc7[i] = 0;
-            case 7:
-                *p->pmc6[i] = 0;
-            case 6:
-                *p->pmc5[i] = 0;
-            case 5:
-                *p->pmc4[i] = 0;
-            case 4:
-                *p->pmc3[i] = 0;
-            case 3:
-                *p->pmc2[i] = 0;
-            case 2:
-                *p->pmc1[i] = 0;
-            case 1:
-                *p->pmc0[i] = 0;
+        case 8:
+            *p->pmc7[i] = 0;
+        case 7:
+            *p->pmc6[i] = 0;
+        case 6:
+            *p->pmc5[i] = 0;
+        case 5:
+            *p->pmc4[i] = 0;
+        case 4:
+            *p->pmc3[i] = 0;
+        case 3:
+            *p->pmc2[i] = 0;
+        case 2:
+            *p->pmc1[i] = 0;
+        case 1:
+            *p->pmc0[i] = 0;
         }
     }
     write_batch(COUNTERS_DATA);

--- a/src/variorum/Intel/counters_features.c
+++ b/src/variorum/Intel/counters_features.c
@@ -47,7 +47,7 @@ void fixed_counter_storage(struct fixed_counter **ctr0, struct fixed_counter **c
     if (!init)
     {
         init = 1;
-        variorum_set_topology(NULL, NULL, &nthreads);
+        variorum_get_topology(NULL, NULL, &nthreads);
         init_fixed_counter(&c0);
         init_fixed_counter(&c1);
         init_fixed_counter(&c2);
@@ -73,7 +73,7 @@ void fixed_counter_storage(struct fixed_counter **ctr0, struct fixed_counter **c
 void init_fixed_counter(struct fixed_counter *ctr)
 {
     int nthreads = 0;
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     ctr->enable = (uint64_t *) malloc(nthreads * sizeof(uint64_t));
 #ifdef VARIORUM_DEBUG
@@ -92,7 +92,7 @@ void enable_fixed_counters(off_t *msrs_fixed_ctrs, off_t msr1, off_t msr2)
     int i;
     int nthreads = 0;
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
 
     for (i = 0; i < nthreads; i++)
@@ -111,7 +111,7 @@ void disable_fixed_counters(off_t *msrs_fixed_ctrs, off_t msr1, off_t msr2)
     int i;
     int nthreads = 0;
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
 
     for (i = 0; i < nthreads; i++)
@@ -138,7 +138,7 @@ void set_fixed_counter_ctrl(struct fixed_counter *ctr0, struct fixed_counter *ct
         init = 1;
     }
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     /* Don't need to read counters data, we are just zeroing things out. */
     read_batch(FIXED_COUNTERS_CTRL_DATA);
@@ -177,7 +177,7 @@ void fixed_counter_ctrl_storage(uint64_t ***perf_ctrl, uint64_t ***fixed_ctrl, o
 
     if (!init)
     {
-        variorum_set_topology(NULL, NULL, &nthreads);
+        variorum_get_topology(NULL, NULL, &nthreads);
         perf_global_ctrl = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
         fixed_ctr_ctrl = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
         allocate_batch(FIXED_COUNTERS_CTRL_DATA, 2UL * nthreads);
@@ -222,7 +222,7 @@ void dump_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs, off_t msr_
         fprintf(writedest, "_FIXED_COUNTERS Host Thread InstRet UnhaltClkCycles UnhaltRefCycles\n");
         init = 1;
     }
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
     gethostname(hostname, 1024);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
 
@@ -244,7 +244,7 @@ void dump_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs, off
 
     gethostname(hostname, 1024);
     avail = cpuid_num_pmc();
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (p == NULL && !init)
     {
@@ -336,7 +336,7 @@ void print_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs, off_t msr
     {
         init = 1;
     }
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
     gethostname(hostname, 1024);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
 
@@ -359,7 +359,7 @@ void print_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs, of
 
     gethostname(hostname, 1024);
     avail = cpuid_num_pmc();
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (p == NULL && !init)
     {
@@ -427,7 +427,7 @@ static int init_pmc(struct pmc *p, off_t *msrs_perfmon_ctrs)
     int nthreads = 0;
     int avail = cpuid_num_pmc();
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (avail < 1)
     {
@@ -488,7 +488,7 @@ static int init_perfevtsel(struct perfevtsel *evt, off_t *msrs_perfevtsel_ctrs)
     int nthreads;
     int avail = cpuid_num_pmc();
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (avail < 1)
     {
@@ -541,7 +541,7 @@ void set_all_pmc_ctrl(uint64_t cmask, uint64_t flags, uint64_t umask, uint64_t e
     int nthreads;
     int i;
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
     for (i = 0; i < nthreads; i++)
     {
         set_pmc_ctrl_flags(cmask, flags, umask, eventsel, pmcnum, i, msrs_perfevtsel_ctrs);
@@ -651,7 +651,7 @@ void clear_all_pmc(off_t *msrs_perfmon_ctrs)
     if (p == NULL)
     {
         avail = cpuid_num_pmc();
-        variorum_set_topology(NULL, NULL, &nthreads);
+        variorum_get_topology(NULL, NULL, &nthreads);
         pmc_storage(&p, msrs_perfmon_ctrs);
     }
     for (i = 0; i < nthreads; i++)
@@ -693,7 +693,7 @@ static void init_unc_perfevtsel(struct unc_perfevtsel *uevt, off_t *msrs_pcu_pmo
     static int init = 0;
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     if (!init)
     {
@@ -721,7 +721,7 @@ static void init_unc_counters(struct unc_counters *uc, off_t *msrs_pcu_pmon_ctrs
     static int init = 0;
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     if (!init)
     {
         uc->c0 = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
@@ -784,7 +784,7 @@ void clear_all_pcu(off_t *msrs_pcu_pmon_ctrs)
     int nsockets = 0;
     int i;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     if (uc == NULL)
     {
         unc_counters_storage(&uc, msrs_pcu_pmon_ctrs);
@@ -807,7 +807,7 @@ void dump_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel, off_t *
     int nsockets;
     char hostname[1024];
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     unc_counters_storage(&uc, msrs_pcu_pmon_ctrs);
@@ -830,7 +830,7 @@ void print_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel, off_t 
     int nsockets;
     char hostname[1024];
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     unc_counters_storage(&uc, msrs_pcu_pmon_ctrs);
@@ -856,7 +856,7 @@ void get_all_power_data_fixed(FILE *writedest, off_t msr_pkg_power_limit, off_t 
     int i;
     int rlim_idx = 0;
 
-    variorum_set_topology(&nsockets, NULL, &nthreads);
+    variorum_get_topology(&nsockets, NULL, &nthreads);
     gethostname(hostname, 1024);
 
     get_power(msr_rapl_unit, msr_package_energy_status, msr_dram_energy_status);

--- a/src/variorum/Intel/misc_features.c
+++ b/src/variorum/Intel/misc_features.c
@@ -18,7 +18,7 @@ int get_max_non_turbo_ratio(off_t msr_platform_info)
     static uint64_t **val = NULL;
     int max_non_turbo_ratio;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     if (!init)
     {
         val = (uint64_t **) malloc(nsockets * sizeof(uint64_t *));
@@ -50,7 +50,7 @@ int set_turbo_on(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
 	uint64_t mask = 0;
 	uint64_t msr_val = 0;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     /// Creates mask for turbo disable bit according to the architecture offset
     /// given.
     mask |= 1LL << turbo_mode_disable_bit;
@@ -93,7 +93,7 @@ int set_turbo_off(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
 	uint64_t mask = 0;
 	uint64_t msr_val = 0;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     /// Creates mask for turbo disable bit according to the architecture offset
     /// given.
 	mask |= 1LL << turbo_mode_disable_bit;
@@ -136,7 +136,7 @@ int dump_turbo_status(FILE *writedest, off_t msr_misc_enable, unsigned int turbo
     uint64_t mask = 0;
     uint64_t msr_val = 0;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     mask |= 1LL << turbo_mode_disable_bit;
 
     for (socket = 0; socket < nsockets; socket++)

--- a/src/variorum/Intel/misc_features.c
+++ b/src/variorum/Intel/misc_features.c
@@ -27,7 +27,7 @@ int get_max_non_turbo_ratio(off_t msr_platform_info)
         init = 1;
     }
 
-	read_batch(PLATFORM_INFO);
+    read_batch(PLATFORM_INFO);
     max_non_turbo_ratio = (int)(MASK_VAL(*val[0], 15, 8));
     /// Do sockets match?
     if (nsockets != 1)
@@ -44,11 +44,11 @@ int get_max_non_turbo_ratio(off_t msr_platform_info)
 /// For socket level
 int set_turbo_on(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
 {
-	int ret = 0;
+    int ret = 0;
     int socket;
     int nsockets;
-	uint64_t mask = 0;
-	uint64_t msr_val = 0;
+    uint64_t mask = 0;
+    uint64_t msr_val = 0;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     /// Creates mask for turbo disable bit according to the architecture offset
@@ -82,21 +82,21 @@ int set_turbo_on(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
             fprintf(stdout, "Turbo enabled on socket %d\n", socket);
         }
     }
-	return ret;
+    return ret;
 }
 
 int set_turbo_off(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
 {
-	int ret = 0;
+    int ret = 0;
     int socket;
     int nsockets;
-	uint64_t mask = 0;
-	uint64_t msr_val = 0;
+    uint64_t mask = 0;
+    uint64_t msr_val = 0;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     /// Creates mask for turbo disable bit according to the architecture offset
     /// given.
-	mask |= 1LL << turbo_mode_disable_bit;
+    mask |= 1LL << turbo_mode_disable_bit;
 
     for (socket = 0; socket < nsockets; socket++)
     {
@@ -125,7 +125,7 @@ int set_turbo_off(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
             fprintf(stdout, "Turbo disabled on socket %d\n", socket);
         }
     }
-	return ret;
+    return ret;
 }
 
 int dump_turbo_status(FILE *writedest, off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)

--- a/src/variorum/Intel/msr_core.c
+++ b/src/variorum/Intel/msr_core.c
@@ -26,7 +26,7 @@
 static uint64_t devidx(int socket, int core, int thread)
 {
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     return (thread * nsockets * (ncores/nsockets)) + (socket * ncores/nsockets) + core;
 }
 
@@ -121,7 +121,7 @@ static int *core_fd(const int dev_idx)
     if (!init_core_fd)
     {
         init_core_fd = 1;
-        variorum_set_topology(NULL, NULL, &nthreads);
+        variorum_get_topology(NULL, NULL, &nthreads);
         file_descriptors = (int *) malloc(nthreads * sizeof(int));
     }
     if (dev_idx < nthreads)
@@ -209,7 +209,7 @@ int sockets_assert(const unsigned *socket, const int location, const char *file)
 {
     char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
     int nsockets;
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     if (*socket > nsockets)
     {
@@ -226,7 +226,7 @@ int threads_assert(const unsigned *thread, const int location, const char *file)
 {
     char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
     int nthreads;
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (*thread > nthreads)
     {
@@ -243,7 +243,7 @@ int cores_assert(const unsigned *core, const int location, const char *file)
 {
     char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
     int ncores;
-    variorum_set_topology(NULL, &ncores, NULL);
+    variorum_get_topology(NULL, &ncores, NULL);
 
     if (*core > ncores)
     {
@@ -326,7 +326,7 @@ int finalize_msr(void)
     int *file_descriptor = NULL;
     char *variorum_error_msg = (char *) malloc(NAME_MAX * sizeof(char));
     int nthreads;
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     for (dev_idx = 0; dev_idx < nthreads; dev_idx++)
     {
@@ -361,7 +361,7 @@ int init_msr(void)
     char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
     int nsockets, ncores, nthreads;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     snprintf(filename, FILENAME_SIZE, "/dev/cpu/msr_whitelist");
     stat_module(filename, &kerneltype, 0);
     /* Open the file descriptor for each device's msr interface. */
@@ -527,7 +527,7 @@ int load_socket_batch(off_t msr, uint64_t **val, int batchnum)
 {
     int dev_idx, val_idx;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     if (val == NULL)
     {
@@ -546,7 +546,7 @@ int load_thread_batch(off_t msr, uint64_t **val, int batchnum)
 {
     int dev_idx, val_idx;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     if (val == NULL)
     {

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -31,7 +31,7 @@ static int translate(const unsigned socket, uint64_t *bits, double *units, int t
     if (!init_translate)
     {
         init_translate = 1;
-        variorum_set_topology(&nsockets, NULL, NULL);
+        variorum_get_topology(&nsockets, NULL, NULL);
         ru = (struct rapl_units *) malloc(nsockets * sizeof(struct rapl_units));
         get_rapl_power_unit(ru, msr);
     }
@@ -269,7 +269,7 @@ static int calc_dram_rapl_limit(const unsigned socket, struct rapl_limit *limit,
 static void create_rapl_data_batch(struct rapl_data *rapl, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     int nsockets;
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     allocate_batch(RAPL_DATA, 2UL * nsockets);
 
@@ -309,7 +309,7 @@ int get_rapl_power_unit(struct rapl_units *ru, off_t msr)
     static int nsockets, ncores, nthreads;
     int i;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     if (!init_get_rapl_power_unit)
     {
         init_get_rapl_power_unit = 1;
@@ -370,7 +370,7 @@ void dump_rapl_power_unit(FILE *writedest, off_t msr)
     char hostname[1024];
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     ru = (struct rapl_units *) malloc(nsockets * sizeof(struct rapl_units));
@@ -391,7 +391,7 @@ void print_rapl_power_unit(FILE *writedest, off_t msr)
     char hostname[1024];
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     ru = (struct rapl_units *) malloc(nsockets * sizeof(struct rapl_units));
@@ -444,7 +444,7 @@ void dump_package_power_limit(FILE *writedest, off_t msr_power_limit, off_t msr_
     char hostname[1024];
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     if (!init_dump_package_power_limit)
@@ -466,7 +466,7 @@ void dump_dram_power_limit(FILE *writedest, off_t msr_power_limit, off_t msr_rap
     char hostname[1024];
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     if (!init_dump_dram_power_limit)
@@ -626,7 +626,7 @@ int rapl_storage(struct rapl_data **data)
     if (!init)
     {
         init = 1;
-        variorum_set_topology(&nsockets, NULL, NULL);
+        variorum_get_topology(&nsockets, NULL, NULL);
 
         rapl = (struct rapl_data *) malloc(nsockets * sizeof(struct rapl_data));
 
@@ -653,7 +653,7 @@ int get_power(off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_e
     static struct rapl_data *rapl = NULL;
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
 #ifdef VARIORUM_DEBUG
     fprintf(stderr, "%s %s::%d DEBUG: (get_power) socket=%lu\n", getenv("HOSTNAME"), __FILE__, __LINE__, nsockets);
@@ -693,7 +693,7 @@ int delta_rapl_data(off_t msr_rapl_unit)
 #endif
     if (!init)
     {
-        variorum_set_topology(&nsockets, NULL, NULL);
+        variorum_get_topology(&nsockets, NULL, NULL);
         if (rapl_storage(&rapl))
         {
             return -1;
@@ -769,7 +769,7 @@ void print_power_data(FILE *writedest, off_t msr_power_limit, off_t msr_rapl_uni
     int i;
 
     gethostname(hostname, 1024);
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     get_power(msr_rapl_unit, msr_pkg_energy_status, msr_dram_energy_status);
 
@@ -803,7 +803,7 @@ void dump_power_data(FILE *writedest, off_t msr_power_limit, off_t msr_rapl_unit
     int i;
 
     gethostname(hostname, 1024);
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     get_power(msr_rapl_unit, msr_pkg_energy_status, msr_dram_energy_status);
 
@@ -880,7 +880,7 @@ int read_rapl_data(off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_d
 
     if (!init)
     {
-        variorum_set_topology(&nsockets, NULL, NULL);
+        variorum_get_topology(&nsockets, NULL, NULL);
         if (rapl_storage(&rapl))
         {
             return -1;
@@ -978,7 +978,7 @@ void get_all_power_data(FILE *writedest, off_t msr_pkg_power_limit, off_t msr_dr
     int i;
     int rlim_idx = 0;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     get_power(msr_rapl_unit, msr_package_energy_status, msr_dram_energy_status);

--- a/src/variorum/Intel/thermal_features.c
+++ b/src/variorum/Intel/thermal_features.c
@@ -19,7 +19,7 @@ void get_temp_target(struct msr_temp_target *s, off_t msr)
     static int init_tt = 0;
     int i;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     if (!init_tt)
     {
@@ -49,7 +49,7 @@ void get_therm_stat(struct therm_stat *s, off_t msr)
     static int init_ts = 0;
     int i;
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (!init_ts)
     {
@@ -155,7 +155,7 @@ int get_pkg_therm_stat(struct pkg_therm_stat *s, off_t msr)
     static int init_pkg_ts = 0;
     int i;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     if (!init_pkg_ts)
     {
@@ -244,7 +244,7 @@ int print_therm_temp_reading(FILE *writedest, off_t msr_therm_stat, off_t msr_pk
     int i, j, k;
     int nsockets, ncores, nthreads;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     pkg_stat = (struct pkg_therm_stat *) malloc(nsockets * sizeof(struct pkg_therm_stat));
     get_pkg_therm_stat(pkg_stat, msr_pkg_therm_stat);
@@ -297,7 +297,7 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat, off_t msr_pkg
     int i, j, k;
     int nsockets, ncores, nthreads;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     pkg_stat = (struct pkg_therm_stat *) malloc(nsockets * sizeof(struct pkg_therm_stat));
     get_pkg_therm_stat(pkg_stat, msr_pkg_therm_stat);

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <hwloc.h>
+#include <assert.h>
 
 #include <config_architecture.h>
 #include <variorum_config.h>
@@ -35,12 +36,7 @@ int variorum_enter(const char *filename, const char *func_name, int line_num)
 
     variorum_init_func_ptrs();
 
-    err = variorum_get_topology();
-    if (err)
-    {
-        variorum_error_handler("Cannot get topology", err, getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
-        return err;
-    }
+    variorum_get_topology(NULL, NULL, NULL); //Triggers initialization on first call.  Errors assert.
     err = variorum_detect_arch();
     if (err)
     {
@@ -122,50 +118,75 @@ int variorum_detect_arch(void)
     return 0;
 }
 
-void variorum_set_topology(int *nsockets, int *ncores, int *nthreads)
-{
-    if (nsockets != NULL)
-    {
-        *nsockets = g_platform.num_sockets;
-    }
-    if (ncores != NULL)
-    {
-        *ncores = g_platform.total_cores;
-    }
-    if (nthreads != NULL)
-    {
-        *nthreads = g_platform.total_threads;
-    }
-}
-
-int variorum_get_topology(void)
+void variorum_get_topology(int *nsockets, int *ncores, int *nthreads)
 {
     hwloc_topology_t topology;
     hwloc_obj_t obj;
     unsigned int i;
     unsigned int core_depth, pu_depth;
-    static int init_variorum_get_toplogy = 0;
+    static int init_variorum_get_topology = 0;
 
     gethostname(g_platform.hostname, 1024);
 
-    if (!init_variorum_get_toplogy)
+    if (!init_variorum_get_topology)
     {
-        hwloc_topology_init(&topology);  // initialization
-        hwloc_topology_load(topology);   // actual detection
+	init_variorum_get_topology = 1;
+	
+	// hwloc should give us expected results on any reasonable arch.
+	// If something goes wrong, there's no sense in trying to keep
+	// marching forward.  Thus the asserts.
+        assert( 0 == hwloc_topology_init(&topology) );
+        assert( 0 == hwloc_topology_load(topology) );
 
+	// The hwloc documentation gives an example of a machine having
+	// depth=0, each package having a depth=1, each cache associated
+	// with a package having depth=2, each core associated with a cache
+	// having a depth=3, and each processing unit (pu) associated with
+	// a core having a depth=4.
         core_depth = hwloc_get_type_depth(topology, HWLOC_OBJ_CORE);
+	assert( HWLOC_TYPE_DEPTH_UNKNOWN != core_depth );
+	assert( HWLOC_TYPE_DEPTH_MULTIPLE != core_depth );
+
         pu_depth = hwloc_get_type_depth(topology, HWLOC_OBJ_PU);
+	assert( HWLOC_TYPE_DEPTH_UNKNOWN != pu_depth );
+	assert( HWLOC_TYPE_DEPTH_MULTIPLE != pu_depth );
 
         g_platform.num_sockets = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
+	assert( -1 != g_platform.num_sockets );	// -1 if Several levels exist with OBJ_SOCKET
+	assert(  0 != g_platform.num_sockets ); //  0 if No levels exist with OBJ_SOCKET
+
         g_platform.total_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+	assert( -1 != g_platform.total_cores );
+	assert(  0 != g_platform.total_cores );
+
         g_platform.total_threads = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
+	assert( -1 != g_platform.total_threads );
+	assert(  0 != g_platform.total_threads );
 
         g_platform.num_cores_per_socket = g_platform.total_cores/g_platform.num_sockets;
+	assert( 0 == g_platform.total_cores % g_platform.num_sockets );
+
         g_platform.num_threads_per_core = g_platform.total_threads/g_platform.total_cores;
+	assert( 0 == g_platform.total_threads % g_platform.total_cores );
 
         hwloc_topology_destroy(topology);
     }
-    return 0;
+
+    if (nsockets != NULL)
+    {
+        *nsockets = g_platform.num_sockets;
+    }
+
+    if (ncores != NULL)
+    {
+        *ncores = g_platform.total_cores;
+    }
+
+    if (nthreads != NULL)
+    {
+        *nthreads = g_platform.total_threads;
+    }
+
 }
 
 void variorum_init_func_ptrs()

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -36,7 +36,7 @@ int variorum_enter(const char *filename, const char *func_name, int line_num)
 
     variorum_init_func_ptrs();
 
-    variorum_get_topology(NULL, NULL, NULL); //Triggers initialization on first call.  Errors assert.
+    variorum_get_topology(NULL, NULL, NULL); // Triggers initialization on first call.  Errors assert.
     err = variorum_detect_arch();
     if (err)
     {
@@ -106,10 +106,10 @@ int variorum_detect_arch(void)
 #endif
 
     if (g_platform.intel_arch   == NULL &&
-        g_platform.amd_arch     == NULL &&
-        g_platform.ibm_arch     == NULL &&
-        g_platform.nvidia_arch  == NULL &&
-        g_platform.gpu_arch     == NULL)
+            g_platform.amd_arch     == NULL &&
+            g_platform.ibm_arch     == NULL &&
+            g_platform.nvidia_arch  == NULL &&
+            g_platform.gpu_arch     == NULL)
     {
         variorum_error_handler("No architectures detected", VARIORUM_ERROR_RUNTIME, getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
         return VARIORUM_ERROR_UNSUPPORTED_ARCH;
@@ -130,44 +130,44 @@ void variorum_get_topology(int *nsockets, int *ncores, int *nthreads)
 
     if (!init_variorum_get_topology)
     {
-	init_variorum_get_topology = 1;
-	
-	// hwloc should give us expected results on any reasonable arch.
-	// If something goes wrong, there's no sense in trying to keep
-	// marching forward.  Thus the asserts.
+        init_variorum_get_topology = 1;
+
+        // hwloc should give us expected results on any reasonable arch.
+        // If something goes wrong, there's no sense in trying to keep
+        // marching forward.  Thus the asserts.
         assert( 0 == hwloc_topology_init(&topology) );
         assert( 0 == hwloc_topology_load(topology) );
 
-	// The hwloc documentation gives an example of a machine having
-	// depth=0, each package having a depth=1, each cache associated
-	// with a package having depth=2, each core associated with a cache
-	// having a depth=3, and each processing unit (pu) associated with
-	// a core having a depth=4.
+        // The hwloc documentation gives an example of a machine having
+        // depth=0, each package having a depth=1, each cache associated
+        // with a package having depth=2, each core associated with a cache
+        // having a depth=3, and each processing unit (pu) associated with
+        // a core having a depth=4.
         core_depth = hwloc_get_type_depth(topology, HWLOC_OBJ_CORE);
-	assert( HWLOC_TYPE_DEPTH_UNKNOWN != core_depth );
-	assert( HWLOC_TYPE_DEPTH_MULTIPLE != core_depth );
+        assert( HWLOC_TYPE_DEPTH_UNKNOWN != core_depth );
+        assert( HWLOC_TYPE_DEPTH_MULTIPLE != core_depth );
 
         pu_depth = hwloc_get_type_depth(topology, HWLOC_OBJ_PU);
-	assert( HWLOC_TYPE_DEPTH_UNKNOWN != pu_depth );
-	assert( HWLOC_TYPE_DEPTH_MULTIPLE != pu_depth );
+        assert( HWLOC_TYPE_DEPTH_UNKNOWN != pu_depth );
+        assert( HWLOC_TYPE_DEPTH_MULTIPLE != pu_depth );
 
         g_platform.num_sockets = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
-	assert( -1 != g_platform.num_sockets );	// -1 if Several levels exist with OBJ_SOCKET
-	assert(  0 != g_platform.num_sockets ); //  0 if No levels exist with OBJ_SOCKET
+        assert( -1 != g_platform.num_sockets );	// -1 if Several levels exist with OBJ_SOCKET
+        assert(  0 != g_platform.num_sockets ); //  0 if No levels exist with OBJ_SOCKET
 
         g_platform.total_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
-	assert( -1 != g_platform.total_cores );
-	assert(  0 != g_platform.total_cores );
+        assert( -1 != g_platform.total_cores );
+        assert(  0 != g_platform.total_cores );
 
         g_platform.total_threads = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
-	assert( -1 != g_platform.total_threads );
-	assert(  0 != g_platform.total_threads );
+        assert( -1 != g_platform.total_threads );
+        assert(  0 != g_platform.total_threads );
 
         g_platform.num_cores_per_socket = g_platform.total_cores/g_platform.num_sockets;
-	assert( 0 == g_platform.total_cores % g_platform.num_sockets );
+        assert( 0 == g_platform.total_cores % g_platform.num_sockets );
 
         g_platform.num_threads_per_core = g_platform.total_threads/g_platform.total_cores;
-	assert( 0 == g_platform.total_threads % g_platform.total_cores );
+        assert( 0 == g_platform.total_threads % g_platform.total_cores );
 
         hwloc_topology_destroy(topology);
     }

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -177,7 +177,7 @@ struct platform
     /// @return Error code.
     int (*dump_turbo)(void);
 
-    /// @brief Function pointer to print GPU utilization. 
+    /// @brief Function pointer to print GPU utilization.
     ///
     /// @return Error code.
     int (*dump_gpu_utilization)(int long_ver);

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -226,9 +226,7 @@ int variorum_exit(const char *filename,
                   const char *func_name,
                   int line_num);
 
-int variorum_get_topology(void);
-
-void variorum_set_topology(int *nsockets,
+void variorum_get_topology(int *nsockets,
                            int *ncores,
                            int *nthreads);
 

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -146,9 +146,8 @@ int variorum_print_verbose_power_limits(void)
     return err;
 }
 
-int variorum_print_topology(void)
+void variorum_print_topology(void)
 {
-    int err = 0;
     int i;
     int hyperthreading = 0;
     hwloc_topology_t topo;
@@ -156,12 +155,7 @@ int variorum_print_topology(void)
     hwloc_topology_init(&topo);
     hwloc_topology_load(topo);
 
-    err = variorum_get_topology();
-    if (err)
-    {
-        variorum_error_handler("Cannot get topology", err, getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
-        return -1;
-    }
+    variorum_get_topology(NULL, NULL, NULL);
 
     fprintf(stdout, "=================\n");
     fprintf(stdout, "Platform Topology\n");
@@ -189,7 +183,7 @@ int variorum_print_topology(void)
 
     hwloc_topology_destroy(topo);
 
-    return err;
+    return;
 }
 
 int variorum_set_node_power_limit(int node_power_limit)

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -129,7 +129,9 @@ int variorum_print_clock_speed(void);
 /// @todo Print discrete frequencies from P0 to Pn.
 ///
 /// @return Error code.
-int variorum_print_available_frequencies(void) { return 0; };
+int variorum_print_available_frequencies(void) {
+    return 0;
+};
 
 /// @brief Print if hyperthreading is enabled or disabled.
 ///
@@ -137,9 +139,7 @@ int variorum_print_available_frequencies(void) { return 0; };
 int variorum_print_hyperthreading(void);
 
 /// @brief Print architecture topology in long format.
-///
-/// @return Error code.
-int variorum_print_topology(void);
+void variorum_print_topology(void);
 
 /// @brief Print list of features available on a particular architecture.
 ///

--- a/src/variorum/variorum_error.c
+++ b/src/variorum/variorum_error.c
@@ -13,48 +13,48 @@ void variorum_error_message(enum variorum_error_e err, char *msg, size_t size)
 {
     switch(err)
     {
-        case VARIORUM_ERROR_RUNTIME:
-            strncpy(msg, "_ERROR_VARIORUM_RUNTIME", size);
-            break;
-        case VARIORUM_ERROR_RAPL_INIT:
-            strncpy(msg, "_ERROR_VARIORUM_RAPL_INIT", size);
-            break;
-        case VARIORUM_ERROR_MSR_CLOSE:
-            strncpy(msg, "_ERROR_VARIORUM_MSR_CLOSE", size);
-            break;
-        case VARIORUM_ERROR_MSR_READ:
-            strncpy(msg, "_ERROR_VARIORUM_MSR_READ", size);
-            break;
-        case VARIORUM_ERROR_MSR_WRITE:
-            strncpy(msg, "_ERROR_VARIORUM_MSR_WRITE", size);
-            break;
-        case VARIORUM_ERROR_MSR_BATCH:
-            strncpy(msg, "_ERROR_VARIORUM_MSR_BATCH", size);
-            break;
-        case VARIORUM_ERROR_ARRAY_BOUNDS:
-            strncpy(msg, "_ERROR_VARIORUM_ARRAY_BOUNDS", size);
-            break;
-        case VARIORUM_ERROR_PLATFORM_ENV:
-            strncpy(msg, "_ERROR_VARIORUM_PLATFORM_ENV", size);
-            break;
-        case VARIORUM_ERROR_MSR_MODULE:
-            strncpy(msg, "_ERROR_VARIORUM_MSR_MODULE", size);
-            break;
-        case VARIORUM_ERROR_INVAL:
-            strncpy(msg, "_ERROR_VARIORUM_INVAL", size);
-            break;
-        case VARIORUM_ERROR_UNSUPPORTED_PLATFORM:
-            strncpy(msg, "_ERROR_VARIORUM_UNSUPPORTED_PLATFORM", size);
-            break;
-        case VARIORUM_ERROR_UNSUPPORTED_ARCH:
-            strncpy(msg, "_ERROR_VARIORUM_UNSUPPORTED_ARCH", size);
-            break;
-        case VARIORUM_ERROR_UNINITIALIZED_FUNC_PTR:
-            strncpy(msg, "_ERROR_VARIORUM_UNINITIALIZED_FUNC_PTR", size);
-            break;
-        default:
-            strncpy(msg, "Unknown variorum error code.", size);
-            break;
+    case VARIORUM_ERROR_RUNTIME:
+        strncpy(msg, "_ERROR_VARIORUM_RUNTIME", size);
+        break;
+    case VARIORUM_ERROR_RAPL_INIT:
+        strncpy(msg, "_ERROR_VARIORUM_RAPL_INIT", size);
+        break;
+    case VARIORUM_ERROR_MSR_CLOSE:
+        strncpy(msg, "_ERROR_VARIORUM_MSR_CLOSE", size);
+        break;
+    case VARIORUM_ERROR_MSR_READ:
+        strncpy(msg, "_ERROR_VARIORUM_MSR_READ", size);
+        break;
+    case VARIORUM_ERROR_MSR_WRITE:
+        strncpy(msg, "_ERROR_VARIORUM_MSR_WRITE", size);
+        break;
+    case VARIORUM_ERROR_MSR_BATCH:
+        strncpy(msg, "_ERROR_VARIORUM_MSR_BATCH", size);
+        break;
+    case VARIORUM_ERROR_ARRAY_BOUNDS:
+        strncpy(msg, "_ERROR_VARIORUM_ARRAY_BOUNDS", size);
+        break;
+    case VARIORUM_ERROR_PLATFORM_ENV:
+        strncpy(msg, "_ERROR_VARIORUM_PLATFORM_ENV", size);
+        break;
+    case VARIORUM_ERROR_MSR_MODULE:
+        strncpy(msg, "_ERROR_VARIORUM_MSR_MODULE", size);
+        break;
+    case VARIORUM_ERROR_INVAL:
+        strncpy(msg, "_ERROR_VARIORUM_INVAL", size);
+        break;
+    case VARIORUM_ERROR_UNSUPPORTED_PLATFORM:
+        strncpy(msg, "_ERROR_VARIORUM_UNSUPPORTED_PLATFORM", size);
+        break;
+    case VARIORUM_ERROR_UNSUPPORTED_ARCH:
+        strncpy(msg, "_ERROR_VARIORUM_UNSUPPORTED_ARCH", size);
+        break;
+    case VARIORUM_ERROR_UNINITIALIZED_FUNC_PTR:
+        strncpy(msg, "_ERROR_VARIORUM_UNINITIALIZED_FUNC_PTR", size);
+        break;
+    default:
+        strncpy(msg, "Unknown variorum error code.", size);
+        break;
     }
     if (size > 0)
     {


### PR DESCRIPTION
Fixes #57

Removed variorum_set_topology, as the name was confusing

Merged functionality of variorum_set_topology into variorum_get_topology.

variorum_get_topology now executes initialization on first use.

Changed return code to void and added assertions for error checking on the assumption that if the underlying hwloc calls are failing, there's no point in trying to continue and failure should be dramatic.

Updated all calls in variorum to account for the above.
