### PR TITLE
remove function definition from variorum header file

### DIFF
--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -129,7 +129,7 @@ int variorum_print_clock_speed(void);
 /// @todo Print discrete frequencies from P0 to Pn.
 ///
 /// @return Error code.
-int variorum_print_available_frequencies(void) { return 0; };
+//int variorum_print_available_frequencies(void) {};
 
 /// @brief Print if hyperthreading is enabled or disabled.
 ///


### PR DESCRIPTION
This resolves building variorum as a static library.