### PR TITLE
set default build type to Release

### DIFF
--- a/src/CMake/VariorumBuildType.cmake
+++ b/src/CMake/VariorumBuildType.cmake
@@ -1,0 +1,13 @@
+#==============================================================================
+# Set a default build type if none was specified
+#==============================================================================
+
+set(default_build_type "Release")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,8 @@ option(VARIORUM_LOG         "Enable logging statements"    ON)
 
 include(CMake/CMakeBasics.cmake)
 
+include(CMake/VariorumBuildType.cmake)
+
 include(CMake/Setup3rdParty.cmake)
 
 include(CMake/SetupTests.cmake)


### PR DESCRIPTION
If `CMAKE_BUILD_TYPE` is not specified, set it to `Release`