### PR TITLE
Removed references to g_platform.gpu_arch

### DIFF
--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -84,7 +84,7 @@ int variorum_exit(const char *filename, const char *func_name, int line_num)
     free(g_platform.ibm_arch);
 #endif
 #ifdef VARIORUM_WITH_NVIDIA
-    free(g_platform.gpu_arch);
+    free(g_platform.nvidia_arch);
 #endif
 
     return err;
@@ -102,7 +102,7 @@ int variorum_detect_arch(void)
     g_platform.ibm_arch = detect_ibm_arch();
 #endif
 #ifdef VARIORUM_WITH_NVIDIA
-    g_platform.gpu_arch = detect_gpu_arch();
+    g_platform.nvidia_arch = detect_gpu_arch();
 #endif
 
 #if defined(VARIORUM_LOG) && defined(VARIORUM_WITH_INTEL)
@@ -115,8 +115,7 @@ int variorum_detect_arch(void)
     if (g_platform.intel_arch   == NULL &&
         g_platform.amd_arch     == NULL &&
         g_platform.ibm_arch     == NULL &&
-        g_platform.nvidia_arch  == NULL &&
-        g_platform.gpu_arch     == NULL)
+        g_platform.nvidia_arch  == NULL)
     {
         variorum_error_handler("No architectures detected", VARIORUM_ERROR_RUNTIME,
                                getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -193,8 +193,6 @@ struct platform
     uint64_t *ibm_arch;
     /// @brief Identifier for NVIDIA architecture.
     uint64_t *nvidia_arch;
-    /// @brief Identifier for GPU architecture.
-    uint64_t *gpu_arch;
 
     /// @brief Hostname.
     char hostname[1024];


### PR DESCRIPTION
Current Nvidia port causes segfault for all supported APIs because `*g_platform.gpu_arch` is populated in config_architecture.c but `*g_platform.nvidia_arch` is de-referenced in config_nvidia.c. Removed references and definition of gpu_arch variable from `struct platform`. This fixes the aforementioned segfault.