### PR TITLE
Use node topology to enumerate GPU <-> socket mapping.

### DIFF
--- a/src/variorum/Nvidia/Volta.c
+++ b/src/variorum/Nvidia/Volta.c
@@ -16,7 +16,13 @@ int volta_get_power(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    dump_power_data(stdout, long_ver);
+    int iter = 0;
+    int nsockets;
+    variorum_set_topology(&nsockets, NULL, NULL);
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        dump_power_data(iter, long_ver, stdout);
+    }
     return 0;
 }
 
@@ -25,7 +31,14 @@ int volta_get_thermals(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    dump_thermal_data(stdout, long_ver);
+
+    int iter = 0;
+    int nsockets;
+    variorum_set_topology(&nsockets, NULL, NULL);
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        dump_thermal_data(iter, long_ver, stdout);
+    }
     return 0;
 }
 
@@ -34,7 +47,13 @@ int volta_get_clocks(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    dump_clocks_data(stdout, long_ver);
+    int iter = 0;
+    int nsockets;
+    variorum_set_topology(&nsockets, NULL, NULL);
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        dump_clocks_data(iter, long_ver, stdout);
+    }
     return 0;
 }
 
@@ -43,7 +62,13 @@ int volta_get_power_limits(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    dump_power_limits(stdout, long_ver);
+    int iter = 0;
+    int nsockets;
+    variorum_set_topology(&nsockets, NULL, NULL);
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        dump_power_limits(iter, long_ver, stdout);
+    }
     return 0;
 }
 
@@ -52,6 +77,12 @@ int volta_get_gpu_utilization(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    dump_gpu_utilization(stdout, long_ver);
+    int iter = 0;
+    int nsockets;
+    variorum_set_topology(&nsockets, NULL, NULL);
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        dump_gpu_utilization(iter, long_ver, stdout);
+    }
     return 0;
 }

--- a/src/variorum/Nvidia/power_features.c
+++ b/src/variorum/Nvidia/power_features.c
@@ -15,17 +15,17 @@
 void initNVML()
 {
     unsigned int d;
+    int m_num_package;
     /* Initialize GPU reading */
     nvmlReturn_t result = nvmlInit();
     nvmlDeviceGetCount(&m_total_unit_devices);
     m_unit_devices_file_desc = (nvmlDevice_t *) malloc(sizeof(
                                    nvmlDevice_t) * m_total_unit_devices);
 
-    /* get handles to all devices */
+    /* Populate handles to all devices. This assumes block-mapping
+     * between packages and GPUs */
     for (d = 0; d < m_total_unit_devices; ++d)
     {
-        int power;
-
         result = nvmlDeviceGetHandleByIndex(d, &m_unit_devices_file_desc[d]);
         if (result != NVML_SUCCESS)
         {
@@ -33,19 +33,14 @@ void initNVML()
                                    VARIORUM_ERROR_PLATFORM_ENV, getenv("HOSTNAME"), __FILE__, __FUNCTION__,
                                    __LINE__);
         }
-
-        /* check to see whether we can read power */
-        result = nvmlDeviceGetPowerUsage(m_unit_devices_file_desc[d],
-                                         (unsigned int *)&power);
-        if (result != NVML_SUCCESS)
-        {
-            //This needs to print an error with diagnostics and exit, but for now
-            //it just prints an error and proceeds
-            variorum_error_handler("Could not read power/initialize NVML",
-                                   VARIORUM_ERROR_PLATFORM_ENV, getenv("HOSTNAME"), __FILE__, __FUNCTION__,
-                                   __LINE__);
-        }
     }
+
+    /* Collect number of packages and GPUs per package */
+    variorum_set_topology(&m_num_package, NULL, NULL);
+    m_gpus_per_socket = m_total_unit_devices / m_num_package;
+
+    /* Save hostname */
+    gethostname(m_hostname, 1024);
 }
 
 void shutdownNVML()
@@ -53,212 +48,166 @@ void shutdownNVML()
     nvmlShutdown();
 }
 
-void dump_power_data(FILE *writedest, int verbose)
+void dump_power_data(int chipid, int verbose, FILE *output)
 {
     unsigned int power;
-    int m_num_package = 2;
-    int gpus_per_socket = m_total_unit_devices / m_num_package;
     double value = 0.0;
-    int device_index = 1;
     int d;
-    char hostname[1024];
     static int init_output = 0;
 
-    gethostname(hostname, 1024);
-
-    //Iterate over all GPU device handles populated at init and print power
-    for (device_index = 0; device_index < 2; device_index++)
+    //Iterate over all GPU device handles for this socket and print power
+    for (d = chipid * m_gpus_per_socket;
+         d < (chipid + 1) * m_gpus_per_socket; ++d)
     {
-        for (d = device_index * gpus_per_socket;
-             d < (device_index + 1) * gpus_per_socket; ++d)
-        {
-            nvmlDeviceGetPowerUsage(m_unit_devices_file_desc[d], &power);
-            value = 0.0f;
-            value += (double)power * 0.001;
+        nvmlDeviceGetPowerUsage(m_unit_devices_file_desc[d], &power);
+        value = (double)power * 0.001f;
 
-            if (verbose)
+        if (verbose)
+        {
+            fprintf(output,
+                    "_GPU_POWER_USAGE Host: %s, Socket: %d, Device ID: %d, Power: %lf\n",
+                    m_hostname, chipid, d, value);
+        }
+        else
+        {
+            if (!init_output)
             {
-                fprintf(writedest,
-                        "_GPU_POWER_USAGE Host: %s, Socket: %d, Device ID: %d, Power: %lf\n",
-                        hostname, device_index, d, value);
+                fprintf(output, "_GPU_POWER_USAGE Host Socket Device Power\n");
+                init_output = 1;
             }
-            else
-            {
-                if (!init_output)
-                {
-                    fprintf(writedest, "_GPU_POWER_USAGE Host Socket Device Power\n");
-                    init_output = 1;
-                }
-                fprintf(writedest, "_GPU_POWER_USAGE %s %d %d %lf\n",
-                        hostname, device_index, d, value);
-            }
+            fprintf(output, "_GPU_POWER_USAGE %s %d %d %lf\n",
+                    m_hostname, chipid, d, value);
         }
     }
 }
 
-void dump_thermal_data(FILE *writedest, int verbose)
+void dump_thermal_data(int chipid, int verbose, FILE *output)
 {
     unsigned int gpu_temp;
-    int m_num_package = 2;
-    int gpus_per_socket = m_total_unit_devices / m_num_package;
-    int device_index = 1;
     int d;
-    char hostname[1024];
     static int init_output = 0;
 
-    gethostname(hostname, 1024);
-
     /* Iterate over all GPU device handles populated at init and print temperature (SM) */
-    for (device_index = 0; device_index < 2; device_index++)
+    for (d = chipid * m_gpus_per_socket;
+         d < (chipid + 1) * m_gpus_per_socket; ++d)
     {
-        for (d = device_index * gpus_per_socket;
-             d < (device_index + 1) * gpus_per_socket; ++d)
-        {
-            nvmlDeviceGetTemperature(m_unit_devices_file_desc[d], NVML_TEMPERATURE_GPU,
-                                     &gpu_temp);
+        nvmlDeviceGetTemperature(m_unit_devices_file_desc[d], NVML_TEMPERATURE_GPU,
+                                 &gpu_temp);
 
-            if (verbose)
+        if (verbose)
+        {
+            fprintf(output,
+                    "_GPU_TEMPERATURE Host: %s, Socket:%d, Device ID: %d, Temperature: %ld\n",
+                    m_hostname, chipid, d, gpu_temp);
+        }
+        else
+        {
+            if (!init_output)
             {
-                fprintf(writedest,
-                        "_GPU_TEMPERATURE Host: %s, Socket:%d, Device ID: %d, Temperature: %ld\n",
-                        hostname, device_index, d, gpu_temp);
+                fprintf(output, "_GPU_TEMPERATURE Host Socket Device Temperature\n");
+                init_output = 1;
             }
-            else
-            {
-                if (!init_output)
-                {
-                    fprintf(writedest, "_GPU_TEMPERATURE Host Socket Device Temperature\n");
-                    init_output = 1;
-                }
-                fprintf(writedest, "_GPU_TEMPERATURE %s %d %d %ld\n",
-                        hostname, device_index, d, gpu_temp);
-            }
+            fprintf(output, "_GPU_TEMPERATURE %s %d %d %ld\n",
+                    m_hostname, chipid, d, gpu_temp);
         }
     }
 
     /*!@todo: Print GPU memory temperature */
 }
 
-void dump_power_limits(FILE *writedest, int verbose)
+void dump_power_limits(int chipid, int verbose, FILE *output)
 {
     unsigned int power_limit;
-    int m_num_package = 2;
-    int gpus_per_socket = m_total_unit_devices / m_num_package;
     double value = 0.0;
-    int device_index = 1;
     int d;
-    char hostname[1024];
     static int init_output = 0;
 
-    gethostname(hostname, 1024);
-
     /* Iterate over all GPU device handles populated at init and print GPU power limit */
-    for (device_index = 0; device_index < 2; device_index++)
+    for (d = chipid * m_gpus_per_socket;
+         d < (chipid + 1) * m_gpus_per_socket; ++d)
     {
-        for (d = device_index * gpus_per_socket;
-             d < (device_index + 1) * gpus_per_socket; ++d)
-        {
-            nvmlDeviceGetPowerManagementLimit(m_unit_devices_file_desc[d], &power_limit);
-            value = (double) power_limit * 0.001f;
+        nvmlDeviceGetPowerManagementLimit(m_unit_devices_file_desc[d], &power_limit);
+        value = (double) power_limit * 0.001f;
 
-            if (verbose)
+        if (verbose)
+        {
+            fprintf(output,
+                    "_GPU_POWER_LIMIT Host: %s, Socket:%d, Device ID: %d, Power limit: %0.3lf\n",
+                    m_hostname, chipid, d, value);
+        }
+        else
+        {
+            if (!init_output)
             {
-                fprintf(writedest,
-                        "_GPU_POWER_LIMIT Host: %s, Socket:%d, Device ID: %d, Power limit: %0.3lf\n",
-                        hostname, device_index, d, value);
+                fprintf(output, "_GPU_POWER_LIMIT Host Socket Device PowerLimit\n");
+                init_output = 1;
             }
-            else
-            {
-                if (!init_output)
-                {
-                    fprintf(writedest, "_GPU_POWER_LIMIT Host Socket Device PowerLimit\n");
-                    init_output = 1;
-                }
-                fprintf(writedest, "_GPU_POWER_LIMIT %s %d %d %0.3lf\n",
-                        hostname, device_index, d, value);
-            }
+            fprintf(output, "_GPU_POWER_LIMIT %s %d %d %0.3lf\n",
+                    m_hostname, chipid, d, value);
         }
     }
     /*!@todo: Seperate interface for default power limits? */
 }
 
-void dump_clocks_data(FILE *writedest, int verbose)
+void dump_clocks_data(int chipid, int verbose, FILE *output)
 {
     unsigned int gpu_clock;
-    int m_num_package = 2;
-    int gpus_per_socket = m_total_unit_devices / m_num_package;
-    int device_index = 1;
     int d;
-    char hostname[1024];
     static int init_output = 0;
 
-    gethostname(hostname, 1024);
-
-    /* Iterate over all GPU device handles populated at init and print GPU clock */
-    for (device_index = 0; device_index < 2; device_index++)
+    /* Iterate over all GPU device handles and print GPU clock */
+    for (d = chipid * m_gpus_per_socket;
+         d < (chipid + 1) * m_gpus_per_socket; ++d)
     {
-        for (d = device_index * gpus_per_socket;
-             d < (device_index + 1) * gpus_per_socket; ++d)
-        {
-            nvmlDeviceGetClock(m_unit_devices_file_desc[d], NVML_CLOCK_SM,
-                               NVML_CLOCK_ID_CURRENT, &gpu_clock);
+        nvmlDeviceGetClock(m_unit_devices_file_desc[d], NVML_CLOCK_SM,
+                           NVML_CLOCK_ID_CURRENT, &gpu_clock);
 
-            if (verbose)
+        if (verbose)
+        {
+            fprintf(output,
+                    "_GPU_CLOCKS Host: %s, Socket:%d, Device ID: %d, GPU Clock: %d\n",
+                    m_hostname, chipid, d, gpu_clock);
+        }
+        else
+        {
+            if (!init_output)
             {
-                fprintf(writedest,
-                        "_GPU_CLOCKS Host: %s, Socket:%d, Device ID: %d, GPU Clock: %d\n",
-                        hostname, device_index, d, gpu_clock);
+                fprintf(output, "_GPU_CLOCKS Host Socket Device Clock\n");
+                init_output = 1;
             }
-            else
-            {
-                if (!init_output)
-                {
-                    fprintf(writedest, "_GPU_CLOCKS Host Socket Device Clock\n");
-                    init_output = 1;
-                }
-                fprintf(writedest, "_GPU_CLOCKS %s %d %d %d\n",
-                        hostname, device_index, d, gpu_clock);
-            }
+            fprintf(output, "_GPU_CLOCKS %s %d %d %d\n",
+                    m_hostname, chipid, d, gpu_clock);
         }
     }
 }
 
-void dump_gpu_utilization(FILE *writedest, int verbose)
+void dump_gpu_utilization(int chipid, int verbose, FILE *output)
 {
     nvmlUtilization_t util;
-    char hostname[1024];
-    int m_num_package = 2;
-    int gpus_per_socket = m_total_unit_devices / m_num_package;
-    int device_index = 1;
     int d;
     static int init_output = 0;
 
-    gethostname(hostname, 1024);
-
-    /* Iterate over all GPU device handles populated at init and print GPU SM and memory utilization */
-    for (device_index = 0; device_index < 2; device_index++)
+    /* Iterate over all GPU device handles and print GPU SM and memory utilization */
+    for (d = chipid * m_gpus_per_socket;
+         d < (chipid + 1) * m_gpus_per_socket; ++d)
     {
-        for (d = device_index * gpus_per_socket;
-             d < (device_index + 1) * gpus_per_socket; ++d)
-        {
-            nvmlDeviceGetUtilizationRates(m_unit_devices_file_desc[d], &util);
+        nvmlDeviceGetUtilizationRates(m_unit_devices_file_desc[d], &util);
 
-            if (verbose)
+        if (verbose)
+        {
+            fprintf(output,
+                    "_GPU_UTILIZATION Host: %s, Socket: %d, Device ID: %d, GPU Utilization (%): SM: %d, Memory: %d\n",
+                    m_hostname, chipid, d, util.gpu, util.memory);
+        }
+        else
+        {
+            if (!init_output)
             {
-                fprintf(writedest,
-                        "_GPU_UTILIZATION Host: %s, Socket: %d, Device ID: %d, GPU Utilization (%): SM: %d, Memory: %d\n",
-                        hostname, device_index, d, util.gpu, util.memory);
+                fprintf(output, "_GPU_UTILIZATION Host Socket Device SMUtil MemUtil\n");
+                init_output = 1;
             }
-            else
-            {
-                if (!init_output)
-                {
-                    fprintf(writedest, "_GPU_UTILIZATION Host Socket Device SMUtil MemUtil\n");
-                    init_output = 1;
-                }
-                fprintf(writedest, "_GPU_UTILIZATION %s %d %d %d %d\n",
-                        hostname, device_index, d, util.gpu, util.memory);
-            }
+            fprintf(output, "_GPU_UTILIZATION %s %d %d %d %d\n",
+                    m_hostname, chipid, d, util.gpu, util.memory);
         }
     }
 }

--- a/src/variorum/Nvidia/power_features.h
+++ b/src/variorum/Nvidia/power_features.h
@@ -13,19 +13,21 @@
 
 unsigned int m_total_unit_devices;
 nvmlDevice_t *m_unit_devices_file_desc;
+unsigned int m_gpus_per_socket;
+char m_hostname[1024];
 
 void initNVML(void);
 
 void shutdownNVML(void);
 
-void dump_power_data(FILE *writedest, int verbose);
+void dump_power_data(int chipid, int verbose, FILE *output);
 
-void dump_thermal_data(FILE *writedest, int verbose);
+void dump_thermal_data(int chipid, int verbose, FILE *output);
 
-void dump_power_limits(FILE *writedest, int verbose);
+void dump_power_limits(int chipid, int verbose, FILE *output);
 
-void dump_clocks_data(FILE *writedest, int verbose);
+void dump_clocks_data(int chipid, int verbose, FILE *output);
 
-void dump_gpu_utilization(FILE *writedest, int verbose);
+void dump_gpu_utilization(int chipid, int verbose, FILE *output);
 
 #endif


### PR DESCRIPTION
Use node topology information to perform requested operations for the GPUs mapped to specific sockets. The high-level API remains the same.