### PR TITLE
Supports batches that have both read and write ops.

### DIFF
--- a/src/variorum/Intel/counters_features.c
+++ b/src/variorum/Intel/counters_features.c
@@ -53,10 +53,13 @@ void fixed_counter_storage(struct fixed_counter **ctr0,
         init_fixed_counter(&c0);
         init_fixed_counter(&c1);
         init_fixed_counter(&c2);
-        allocate_batch(FIXED_COUNTERS_DATA, 3UL * nthreads);
-        load_thread_batch(msrs_fixed_ctrs[0], c0.value, FIXED_COUNTERS_DATA);
-        load_thread_batch(msrs_fixed_ctrs[1], c1.value, FIXED_COUNTERS_DATA);
-        load_thread_batch(msrs_fixed_ctrs[2], c2.value, FIXED_COUNTERS_DATA);
+        allocate_batch(RD_FIXED_COUNTERS_DATA, 3UL * nthreads);
+        load_thread_batch(msrs_fixed_ctrs[0], c0.value, BATCH_READ,
+                          RD_FIXED_COUNTERS_DATA);
+        load_thread_batch(msrs_fixed_ctrs[1], c1.value, BATCH_READ,
+                          RD_FIXED_COUNTERS_DATA);
+        load_thread_batch(msrs_fixed_ctrs[2], c2.value, BATCH_READ,
+                          RD_FIXED_COUNTERS_DATA);
     }
     if (ctr0 != NULL)
     {
@@ -144,7 +147,7 @@ void set_fixed_counter_ctrl(struct fixed_counter *ctr0,
     variorum_set_topology(NULL, NULL, &nthreads);
 
     /* Don't need to read counters data, we are just zeroing things out. */
-    read_batch(FIXED_COUNTERS_CTRL_DATA);
+    execute_batch(RD_FIXED_COUNTERS_CTRL_DATA);
 
     for (i = 0; i < nthreads; i++)
     {
@@ -179,8 +182,7 @@ void set_fixed_counter_ctrl(struct fixed_counter *ctr0,
         *fixed_ctr_ctrl[i] = (*fixed_ctr_ctrl[i] & (~(1ULL << 11))) |
                              (ctr2->pmi[i] << 11);
     }
-    write_batch(FIXED_COUNTERS_CTRL_DATA);
-    //write_batch(FIXED_COUNTERS_DATA);
+    execute_batch(WR_FIXED_COUNTERS_CTRL_DATA);
 }
 
 void fixed_counter_ctrl_storage(uint64_t ***perf_ctrl, uint64_t ***fixed_ctrl,
@@ -196,11 +198,16 @@ void fixed_counter_ctrl_storage(uint64_t ***perf_ctrl, uint64_t ***fixed_ctrl,
         variorum_set_topology(NULL, NULL, &nthreads);
         perf_global_ctrl = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
         fixed_ctr_ctrl = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
-        allocate_batch(FIXED_COUNTERS_CTRL_DATA, 2UL * nthreads);
-        load_thread_batch(msr_perf_global_ctrl, perf_global_ctrl,
-                          FIXED_COUNTERS_CTRL_DATA);
-        load_thread_batch(msr_fixed_counter_ctrl, fixed_ctr_ctrl,
-                          FIXED_COUNTERS_CTRL_DATA);
+        allocate_batch(RD_FIXED_COUNTERS_CTRL_DATA, 2UL * nthreads);
+        allocate_batch(WR_FIXED_COUNTERS_CTRL_DATA, 2UL * nthreads);
+        load_thread_batch(msr_perf_global_ctrl, perf_global_ctrl, BATCH_READ,
+                          RD_FIXED_COUNTERS_CTRL_DATA);
+        load_thread_batch(msr_fixed_counter_ctrl, fixed_ctr_ctrl, BATCH_READ,
+                          RD_FIXED_COUNTERS_CTRL_DATA);
+        load_thread_batch(msr_perf_global_ctrl, perf_global_ctrl, BATCH_WRITE,
+                          WR_FIXED_COUNTERS_CTRL_DATA);
+        load_thread_batch(msr_fixed_counter_ctrl, fixed_ctr_ctrl, BATCH_WRITE,
+                          WR_FIXED_COUNTERS_CTRL_DATA);
         init = 1;
     }
     if (perf_ctrl != NULL)
@@ -254,7 +261,7 @@ void dump_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
     gethostname(hostname, 1024);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
 
-    read_batch(FIXED_COUNTERS_DATA);
+    execute_batch(RD_FIXED_COUNTERS_DATA);
     for (i = 0; i < nthreads; i++)
     {
         fprintf(writedest, "_FIXED_COUNTERS %s %d %lu %lu %lu\n", hostname, i,
@@ -319,7 +326,7 @@ void dump_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
         init = 1;
     }
 
-    read_batch(COUNTERS_DATA);
+    execute_batch(RD_COUNTERS_DATA);
     for (i = 0; i < nthreads; i++)
     {
         switch (avail)
@@ -384,7 +391,7 @@ void print_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
     gethostname(hostname, 1024);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
 
-    read_batch(FIXED_COUNTERS_DATA);
+    execute_batch(RD_FIXED_COUNTERS_DATA);
     for (i = 0; i < nthreads; i++)
     {
         fprintf(writedest,
@@ -416,7 +423,7 @@ void print_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
         init = 1;
     }
 
-    read_batch(COUNTERS_DATA);
+    execute_batch(RD_COUNTERS_DATA);
     for (i = 0; i < nthreads; i++)
     {
         switch (avail)
@@ -509,25 +516,34 @@ static int init_pmc(struct pmc *p, off_t *msrs_perfmon_ctrs)
         case 1:
             p->pmc0 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
     }
-    allocate_batch(COUNTERS_DATA, avail * nthreads);
+    allocate_batch(RD_COUNTERS_DATA, avail * nthreads);
+    allocate_batch(WR_COUNTERS_DATA, avail * nthreads);
     switch (avail)
     {
         case 8:
-            load_thread_batch(msrs_perfmon_ctrs[7], p->pmc7, COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[7], p->pmc7, BATCH_READ, RD_COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[7], p->pmc7, BATCH_WRITE, WR_COUNTERS_DATA);
         case 7:
-            load_thread_batch(msrs_perfmon_ctrs[6], p->pmc6, COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[6], p->pmc6, BATCH_READ, RD_COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[6], p->pmc6, BATCH_WRITE, WR_COUNTERS_DATA);
         case 6:
-            load_thread_batch(msrs_perfmon_ctrs[5], p->pmc5, COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[5], p->pmc5, BATCH_READ, RD_COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[5], p->pmc5, BATCH_WRITE, WR_COUNTERS_DATA);
         case 5:
-            load_thread_batch(msrs_perfmon_ctrs[4], p->pmc4, COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[4], p->pmc4, BATCH_READ, RD_COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[4], p->pmc4, BATCH_WRITE, WR_COUNTERS_DATA);
         case 4:
-            load_thread_batch(msrs_perfmon_ctrs[3], p->pmc3, COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[3], p->pmc3, BATCH_READ, RD_COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[3], p->pmc3, BATCH_WRITE, WR_COUNTERS_DATA);
         case 3:
-            load_thread_batch(msrs_perfmon_ctrs[2], p->pmc2, COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[2], p->pmc2, BATCH_READ, RD_COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[2], p->pmc2, BATCH_WRITE, WR_COUNTERS_DATA);
         case 2:
-            load_thread_batch(msrs_perfmon_ctrs[1], p->pmc1, COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[1], p->pmc1, BATCH_READ, RD_COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[1], p->pmc1, BATCH_WRITE, WR_COUNTERS_DATA);
         case 1:
-            load_thread_batch(msrs_perfmon_ctrs[0], p->pmc0, COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[0], p->pmc0, BATCH_READ, RD_COUNTERS_DATA);
+            load_thread_batch(msrs_perfmon_ctrs[0], p->pmc0, BATCH_WRITE, WR_COUNTERS_DATA);
     }
     return 0;
 }
@@ -570,25 +586,50 @@ static int init_perfevtsel(struct perfevtsel *evt, off_t *msrs_perfevtsel_ctrs)
         case 1:
             evt->perf_evtsel0 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
     }
-    allocate_batch(COUNTERS_CTRL, avail * nthreads);
+    allocate_batch(RD_COUNTERS_CTRL, avail * nthreads);
+    allocate_batch(WR_COUNTERS_CTRL, avail * nthreads);
     switch (avail)
     {
         case 8:
-            load_thread_batch(msrs_perfevtsel_ctrs[7], evt->perf_evtsel7, COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[7], evt->perf_evtsel7, BATCH_READ,
+                              RD_COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[7], evt->perf_evtsel7, BATCH_WRITE,
+                              WR_COUNTERS_CTRL);
         case 7:
-            load_thread_batch(msrs_perfevtsel_ctrs[6], evt->perf_evtsel6, COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[6], evt->perf_evtsel6, BATCH_READ,
+                              RD_COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[6], evt->perf_evtsel6, BATCH_WRITE,
+                              WR_COUNTERS_CTRL);
         case 6:
-            load_thread_batch(msrs_perfevtsel_ctrs[5], evt->perf_evtsel5, COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[5], evt->perf_evtsel5, BATCH_READ,
+                              RD_COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[5], evt->perf_evtsel5, BATCH_WRITE,
+                              WR_COUNTERS_CTRL);
         case 5:
-            load_thread_batch(msrs_perfevtsel_ctrs[4], evt->perf_evtsel4, COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[4], evt->perf_evtsel4, BATCH_READ,
+                              RD_COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[4], evt->perf_evtsel4, BATCH_WRITE,
+                              WR_COUNTERS_CTRL);
         case 4:
-            load_thread_batch(msrs_perfevtsel_ctrs[3], evt->perf_evtsel3, COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[3], evt->perf_evtsel3, BATCH_READ,
+                              RD_COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[3], evt->perf_evtsel3, BATCH_WRITE,
+                              WR_COUNTERS_CTRL);
         case 3:
-            load_thread_batch(msrs_perfevtsel_ctrs[2], evt->perf_evtsel2, COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[2], evt->perf_evtsel2, BATCH_READ,
+                              RD_COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[2], evt->perf_evtsel2, BATCH_WRITE,
+                              WR_COUNTERS_CTRL);
         case 2:
-            load_thread_batch(msrs_perfevtsel_ctrs[1], evt->perf_evtsel1, COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[1], evt->perf_evtsel1, BATCH_READ,
+                              RD_COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[1], evt->perf_evtsel1, BATCH_WRITE,
+                              WR_COUNTERS_CTRL);
         case 1:
-            load_thread_batch(msrs_perfevtsel_ctrs[0], evt->perf_evtsel0, COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[0], evt->perf_evtsel0, BATCH_READ,
+                              RD_COUNTERS_CTRL);
+            load_thread_batch(msrs_perfevtsel_ctrs[0], evt->perf_evtsel0, BATCH_WRITE,
+                              WR_COUNTERS_CTRL);
     }
     return 0;
 }
@@ -621,7 +662,7 @@ int enable_pmc(off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs)
         }
         perfevtsel_storage(&evt, msrs_perfevtsel_ctrs);
     }
-    write_batch(COUNTERS_CTRL);
+    execute_batch(WR_COUNTERS_CTRL);
     clear_all_pmc(msrs_perfmon_ctrs);
     return 0;
 }
@@ -744,7 +785,7 @@ void clear_all_pmc(off_t *msrs_perfmon_ctrs)
                 *p->pmc0[i] = 0;
         }
     }
-    write_batch(COUNTERS_DATA);
+    execute_batch(WR_COUNTERS_DATA);
 }
 
 ///*************************************/
@@ -770,11 +811,27 @@ static void init_unc_perfevtsel(struct unc_perfevtsel *uevt,
         uevt->c1 = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
         uevt->c2 = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
         uevt->c3 = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
-        allocate_batch(UNCORE_EVTSEL, 4 * nsockets);
-        load_socket_batch(msrs_pcu_pmon_evtsel[0], uevt->c0, UNCORE_EVTSEL);
-        load_socket_batch(msrs_pcu_pmon_evtsel[1], uevt->c1, UNCORE_EVTSEL);
-        load_socket_batch(msrs_pcu_pmon_evtsel[2], uevt->c2, UNCORE_EVTSEL);
-        load_socket_batch(msrs_pcu_pmon_evtsel[3], uevt->c3, UNCORE_EVTSEL);
+
+        allocate_batch(RD_UNCORE_EVTSEL, 4 * nsockets);
+        load_socket_batch(msrs_pcu_pmon_evtsel[0], uevt->c0, BATCH_READ,
+                          RD_UNCORE_EVTSEL);
+        load_socket_batch(msrs_pcu_pmon_evtsel[1], uevt->c1, BATCH_READ,
+                          RD_UNCORE_EVTSEL);
+        load_socket_batch(msrs_pcu_pmon_evtsel[2], uevt->c2, BATCH_READ,
+                          RD_UNCORE_EVTSEL);
+        load_socket_batch(msrs_pcu_pmon_evtsel[3], uevt->c3, BATCH_READ,
+                          RD_UNCORE_EVTSEL);
+
+        allocate_batch(WR_UNCORE_EVTSEL, 4 * nsockets);
+        load_socket_batch(msrs_pcu_pmon_evtsel[0], uevt->c0, BATCH_WRITE,
+                          WR_UNCORE_EVTSEL);
+        load_socket_batch(msrs_pcu_pmon_evtsel[1], uevt->c1, BATCH_WRITE,
+                          WR_UNCORE_EVTSEL);
+        load_socket_batch(msrs_pcu_pmon_evtsel[2], uevt->c2, BATCH_WRITE,
+                          WR_UNCORE_EVTSEL);
+        load_socket_batch(msrs_pcu_pmon_evtsel[3], uevt->c3, BATCH_WRITE,
+                          WR_UNCORE_EVTSEL);
+
         init = 1;
     }
 }
@@ -798,11 +855,19 @@ static void init_unc_counters(struct unc_counters *uc,
         uc->c1 = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
         uc->c2 = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
         uc->c3 = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
-        allocate_batch(UNCORE_COUNT, 4 * nsockets);
-        load_socket_batch(msrs_pcu_pmon_ctrs[0], uc->c0, UNCORE_COUNT);
-        load_socket_batch(msrs_pcu_pmon_ctrs[1], uc->c1, UNCORE_COUNT);
-        load_socket_batch(msrs_pcu_pmon_ctrs[2], uc->c2, UNCORE_COUNT);
-        load_socket_batch(msrs_pcu_pmon_ctrs[3], uc->c3, UNCORE_COUNT);
+
+        allocate_batch(RD_UNCORE_COUNT, 4 * nsockets);
+        load_socket_batch(msrs_pcu_pmon_ctrs[0], uc->c0, BATCH_READ, RD_UNCORE_COUNT);
+        load_socket_batch(msrs_pcu_pmon_ctrs[1], uc->c1, BATCH_READ, RD_UNCORE_COUNT);
+        load_socket_batch(msrs_pcu_pmon_ctrs[2], uc->c2, BATCH_READ, RD_UNCORE_COUNT);
+        load_socket_batch(msrs_pcu_pmon_ctrs[3], uc->c3, BATCH_READ, RD_UNCORE_COUNT);
+
+        allocate_batch(WR_UNCORE_COUNT, 4 * nsockets);
+        load_socket_batch(msrs_pcu_pmon_ctrs[0], uc->c0, BATCH_WRITE, WR_UNCORE_COUNT);
+        load_socket_batch(msrs_pcu_pmon_ctrs[1], uc->c1, BATCH_WRITE, WR_UNCORE_COUNT);
+        load_socket_batch(msrs_pcu_pmon_ctrs[2], uc->c2, BATCH_WRITE, WR_UNCORE_COUNT);
+        load_socket_batch(msrs_pcu_pmon_ctrs[3], uc->c3, BATCH_WRITE, WR_UNCORE_COUNT);
+
         init = 1;
     }
 }
@@ -845,7 +910,7 @@ void enable_pcu(off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
     {
         unc_perfevtsel_storage(&uevt, msrs_pcu_pmon_evtsel);
     }
-    write_batch(UNCORE_EVTSEL);
+    execute_batch(WR_UNCORE_EVTSEL);
     clear_all_pcu(msrs_pcu_pmon_ctrs);
 }
 
@@ -867,7 +932,7 @@ void clear_all_pcu(off_t *msrs_pcu_pmon_ctrs)
         *uc->c2[i] = 0;
         *uc->c3[i] = 0;
     }
-    write_batch(UNCORE_COUNT);
+    execute_batch(WR_UNCORE_COUNT);
 }
 
 void dump_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel,
@@ -990,8 +1055,8 @@ void get_all_power_data_fixed(FILE *writedest, off_t msr_pkg_power_limit,
         fprintf(writedest, "\n");
     }
 
-    read_batch(FIXED_COUNTERS_DATA);
-    read_batch(CLOCKS_DATA);
+    execute_batch(RD_FIXED_COUNTERS_DATA);
+    execute_batch(RD_CLOCKS_DATA);
     rlim_idx = 0;
     for (i = 0; i < nsockets; i++)
     {

--- a/src/variorum/Intel/misc_features.c
+++ b/src/variorum/Intel/misc_features.c
@@ -22,12 +22,12 @@ int get_max_non_turbo_ratio(off_t msr_platform_info)
     if (!init)
     {
         val = (uint64_t **) malloc(nsockets * sizeof(uint64_t *));
-        allocate_batch(PLATFORM_INFO, nsockets);
-        load_socket_batch(msr_platform_info, val, PLATFORM_INFO);
+        allocate_batch(RD_PLATFORM_INFO, nsockets);
+        load_socket_batch(msr_platform_info, val, BATCH_READ, RD_PLATFORM_INFO);
         init = 1;
     }
 
-    read_batch(PLATFORM_INFO);
+    execute_batch(RD_PLATFORM_INFO);
     max_non_turbo_ratio = (int)(MASK_VAL(*val[0], 15, 8));
     /// Do sockets match?
     if (nsockets != 1)

--- a/src/variorum/Intel/msr_core.h
+++ b/src/variorum/Intel/msr_core.h
@@ -23,81 +23,88 @@ enum variorum_data_type_e
 {
     /// @brief Energy, time, and power measurements of various RAPL power
     /// domains.
-    RAPL_DATA = 0,
+    RD_RAPL_DATA,
     /// @brief Units for energy, time, and power across all RAPL power domains.
-    RAPL_UNIT = 1,
+    RD_RAPL_UNIT,
     /// @brief Fixed-function counter measurements (i.e., instructions retired,
     /// reference clock cycles, CPU cycles).
-    FIXED_COUNTERS_DATA = 2,
+    RD_FIXED_COUNTERS_DATA,
     /// @brief Controls for fixed-function counters (i.e., instructions retired,
     /// reference clock cycles, CPU cycles).
-    FIXED_COUNTERS_CTRL_DATA = 3,
+    RD_FIXED_COUNTERS_CTRL_DATA,
+    WR_FIXED_COUNTERS_CTRL_DATA,
     /// @brief General-purpose performance counter measurements.
-    COUNTERS_DATA = 4,
+    RD_COUNTERS_DATA,
+    WR_COUNTERS_DATA,
     /// @brief Controls for general-purpose performance counters and
     /// performance event select counter measurements.
-    COUNTERS_CTRL = 5,
+    RD_COUNTERS_CTRL,
+    WR_COUNTERS_CTRL,
     /// @brief Clock cycle measurements based on fixed frequency and actual
     /// frequency of the processor.
-    CLOCKS_DATA = 6,
+    RD_CLOCKS_DATA,
     /// @brief Instantaneous operating frequency of the core or socket.
-    PERF_DATA = 7,
+    RD_PERF_DATA,
+    WR_PERF_DATA,
     /// @brief Thermal status of core.
-    THERM_STAT = 8,
+    RD_THERM_STAT,
     /// @brief Interrupts by thermal monitor when thermal sensor on a core is
     /// tripped.
-    THERM_INTERR = 9,
+    THERM_INTERR,
     /// @brief Thermal status of package.
-    PKG_THERM_STAT = 10,
+    RD_PKG_THERM_STAT,
     /// @brief Interrupts by thermal monitor when thermal sensor on the package
     /// is tripped.
-    PKG_THERM_INTERR = 11,
+    PKG_THERM_INTERR,
     /// @brief Current temperature of the package.
-    TEMP_TARGET = 12,
+    RD_TEMP_TARGET,
     /// @brief Software desired operating frequency of the core or socket.
-    PERF_CTRL = 13,
+    RD_PERF_CTRL,
+    WR_PERF_CTRL,
     /// @brief Measured time spent in C-states by the package.
-    PKG_CRESIDENCY = 14,
+    PKG_CRESIDENCY,
     /// @brief Measured time spent in C-states by the core.
-    CORE_CRESIDENCY = 15,
+    CORE_CRESIDENCY,
     /// @brief Uncore performance event select counter measurements.
-    UNCORE_EVTSEL = 16,
+    RD_UNCORE_EVTSEL,
+    WR_UNCORE_EVTSEL,
     /// @brief Uncore general-performance counter measurements.
-    UNCORE_COUNT = 17,
+    RD_UNCORE_COUNT, // FIXME Not the most fortunate of abbrevs.
+    WR_UNCORE_COUNT, // FIXME Not the most fortunate of abbrevs.
     /// @brief User-defined batch MSR data.
-    USR_BATCH0 = 18,
+    USR_BATCH0,
     /// @brief User-defined batch MSR data.
-    USR_BATCH1 = 19,
+    USR_BATCH1,
     /// @brief User-defined batch MSR data.
-    USR_BATCH2 = 20,
+    USR_BATCH2,
     /// @brief User-defined batch MSR data.
-    USR_BATCH3 = 21,
+    USR_BATCH3,
     /// @brief User-defined batch MSR data.
-    USR_BATCH4 = 22,
+    USR_BATCH4,
     /// @brief User-defined batch MSR data.
-    USR_BATCH5 = 23,
+    USR_BATCH5,
     /// @brief User-defined batch MSR data.
-    USR_BATCH6 = 24,
+    USR_BATCH6,
     /// @brief User-defined batch MSR data.
-    USR_BATCH7 = 25,
+    USR_BATCH7,
     /// @brief User-defined batch MSR data.
-    USR_BATCH8 = 26,
+    USR_BATCH8,
     /// @brief User-defined batch MSR data.
-    USR_BATCH9 = 27,
+    USR_BATCH9,
     /// @brief User-defined batch MSR data.
-    USR_BATCH10 = 28,
-    PLATFORM_INFO = 29,
+    USR_BATCH10,
+    RD_PLATFORM_INFO,
 };
 
 /// @brief Enum encompassing batch operations.
+/// These particular values are required by the msr-safe struct msr_batch_op
+/// field isrdmsr.
 enum variorum_batch_op_type_e
 {
-    /// @brief Load batch operation.
-    BATCH_LOAD,
     /// @brief Write batch operation.
-    BATCH_WRITE,
+    BATCH_WRITE = 0,
     /// @brief Read batch operation.
-    BATCH_READ,
+    BATCH_READ = 1,
 };
 
 /// @brief Structure holding multiple read/write operations to various MSRs.
@@ -311,18 +318,18 @@ int write_msr_by_coord(unsigned socket,
 
 int load_thread_batch(off_t msr,
                       uint64_t **val,
+                      int isrdmsr,
                       int batchnum);
 
 int load_socket_batch(off_t msr,
                       uint64_t **val,
+                      int isrdmsr,
                       int batchnum);
 
 int allocate_batch(int batchnum,
                    size_t bsize);
 
-int read_batch(const int batchnum);
-
-int write_batch(const int batchnum);
+int execute_batch(int batchnum);
 
 int create_batch_op(off_t msr,
                     uint64_t cpu,

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -292,7 +292,7 @@ static void create_rapl_data_batch(struct rapl_data *rapl,
     int nsockets;
     variorum_set_topology(&nsockets, NULL, NULL);
 
-    allocate_batch(RAPL_DATA, 2UL * nsockets);
+    allocate_batch(RD_RAPL_DATA, 2UL * nsockets);
 
     rapl->pkg_bits = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
     rapl->pkg_joules = (double *) calloc(nsockets, sizeof(double));
@@ -301,7 +301,8 @@ static void create_rapl_data_batch(struct rapl_data *rapl,
     rapl->pkg_delta_joules = (double *) calloc(nsockets, sizeof(double));
     rapl->pkg_delta_bits = (uint64_t *) calloc(nsockets, sizeof(double));
     rapl->pkg_watts = (double *) calloc(nsockets, sizeof(double));
-    load_socket_batch(msr_pkg_energy_status, rapl->pkg_bits, RAPL_DATA);
+    load_socket_batch(msr_pkg_energy_status, rapl->pkg_bits, BATCH_READ,
+                      RD_RAPL_DATA);
 
     rapl->dram_bits = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
     rapl->old_dram_bits = (uint64_t *) calloc(nsockets, sizeof(uint64_t));
@@ -309,18 +310,9 @@ static void create_rapl_data_batch(struct rapl_data *rapl,
     rapl->old_dram_joules = (double *) calloc(nsockets, sizeof(double));
     rapl->dram_delta_joules = (double *) calloc(nsockets, sizeof(double));
     rapl->dram_watts = (double *) calloc(nsockets, sizeof(double));
-    load_socket_batch(msr_dram_energy_status, rapl->dram_bits, RAPL_DATA);
+    load_socket_batch(msr_dram_energy_status, rapl->dram_bits, BATCH_READ,
+                      RD_RAPL_DATA);
 
-    //if (*rapl_flags & PKG_PERF_STATUS)
-    //{
-    //    rapl->pkg_perf_count = (uint64_t **) libmsr_calloc(sockets * threadsPerCore, sizeof(uint64_t));
-    //    load_socket_batch(MSR_PKG_PERF_STATUS, rapl->pkg_perf_count, RAPL_DATA);
-    //}
-    //if (*rapl_flags & DRAM_PERF_STATUS)
-    //{
-    //    rapl->dram_perf_count = (uint64_t **) libmsr_calloc(sockets * threadsPerCore, sizeof(uint64_t));
-    //    load_socket_batch(MSR_DRAM_PERF_STATUS, rapl->dram_perf_count, RAPL_DATA);
-    //}
 }
 
 int get_rapl_power_unit(struct rapl_units *ru, off_t msr)
@@ -335,10 +327,10 @@ int get_rapl_power_unit(struct rapl_units *ru, off_t msr)
     {
         init_get_rapl_power_unit = 1;
         val = (uint64_t **) malloc(nsockets * sizeof(uint64_t *));
-        allocate_batch(RAPL_UNIT, nsockets);
-        load_socket_batch(msr, val, RAPL_UNIT);
+        allocate_batch(RD_RAPL_UNIT, nsockets);
+        load_socket_batch(msr, val, BATCH_READ, RD_RAPL_UNIT);
     }
-    read_batch(RAPL_UNIT);
+    execute_batch(RD_RAPL_UNIT);
 
     /* Initialize the units used for each socket. */
     for (i = 0; i < nsockets; i++)
@@ -1033,7 +1025,7 @@ int read_rapl_data(off_t msr_rapl_unit, off_t msr_pkg_energy_status,
             //}
         }
     }
-    read_batch(RAPL_DATA);
+    execute_batch(RD_RAPL_DATA);
     for (i = 0; i < nsockets; i++)
     {
         //        if (*rapl_flags & DRAM_ENERGY_STATUS)

--- a/src/variorum/Intel/thermal_features.c
+++ b/src/variorum/Intel/thermal_features.c
@@ -25,11 +25,11 @@ void get_temp_target(struct msr_temp_target *s, off_t msr)
     {
         init_tt = 1;
         val = (uint64_t **) malloc(nsockets * sizeof(uint64_t *));
-        allocate_batch(TEMP_TARGET, nsockets);
-        load_socket_batch(msr, val, TEMP_TARGET);
+        allocate_batch(RD_TEMP_TARGET, nsockets);
+        load_socket_batch(msr, val, BATCH_READ, RD_TEMP_TARGET);
     }
 
-    read_batch(TEMP_TARGET);
+    execute_batch(RD_TEMP_TARGET);
 
     for (i = 0; i < nsockets; i++)
     {
@@ -55,11 +55,11 @@ void get_therm_stat(struct therm_stat *s, off_t msr)
     {
         init_ts = 1;
         val = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
-        allocate_batch(THERM_STAT, nthreads);
-        load_thread_batch(msr, val, THERM_STAT);
+        allocate_batch(RD_THERM_STAT, nthreads);
+        load_thread_batch(msr, val, BATCH_READ, RD_THERM_STAT);
     }
 
-    read_batch(THERM_STAT);
+    execute_batch(RD_THERM_STAT);
 
     for (i = 0; i < nthreads; i++)
     {
@@ -161,11 +161,11 @@ int get_pkg_therm_stat(struct pkg_therm_stat *s, off_t msr)
     {
         init_pkg_ts = 1;
         val = (uint64_t **) malloc(nsockets * sizeof(uint64_t *));
-        allocate_batch(PKG_THERM_STAT, nsockets);
-        load_socket_batch(msr, val, PKG_THERM_STAT);
+        allocate_batch(RD_PKG_THERM_STAT, nsockets);
+        load_socket_batch(msr, val, BATCH_READ, RD_PKG_THERM_STAT);
     }
 
-    read_batch(PKG_THERM_STAT);
+    execute_batch(RD_PKG_THERM_STAT);
     for (i = 0; i < nsockets; i++)
     {
         s[i].raw = *val[i];
@@ -430,7 +430,7 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
 //    int i;
 //    core_config(NULL, &threadsPerCore, NULL, NULL);
 //
-//    read_batch(THERM_INTERR);
+//    execute_batch(THERM_INTERR);
 //    for (i = 0; i < numCores * threadsPerCore; i++)
 //    {
 //        // Allows the BIOS to enable the generation of an interrupt on the
@@ -492,7 +492,7 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
 //    uint64_t sockets = num_sockets();
 //    int i;
 //
-//    read_batch(PKG_THERM_INTERR);
+//    execute_batch(PKG_THERM_INTERR);
 //    for (i = 0; i < sockets; i++)
 //    {
 //        // Allows the BIOS to enable the generation of an interrupt on
@@ -604,7 +604,7 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
 //    uint64_t numCores = num_cores();
 //    int i;
 //
-//    read_batch(THERM_STAT);
+//    execute_batch(THERM_STAT);
 //    for (i = 0; i < numCores; i++)
 //    {
 //        *s->raw[i] = (*s->raw[i] & (~(1<<1))) | (s->status_log[i] << 1);
@@ -614,7 +614,7 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
 //        *s->raw[i] = (*s->raw[i] & (~(1<<9))) | (s->therm_thresh2_log[i] << 1);
 //        *s->raw[i] = (*s->raw[i] & (~(1<<11))) | (s->power_notification_log[i] << 1);
 //    }
-//    write_batch(THERM_STAT);
+//    execute_batch(THERM_STAT);
 //    /* Not sure if I should update the struct here or not. */
 //}
 //
@@ -623,7 +623,7 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
 //    uint64_t numCores = num_cores();
 //    int i;
 //
-//    read_batch(THERM_INTERR);
+//    execute_batch(THERM_INTERR);
 //    for (i = 0; i < numCores; i++)
 //    {
 //        *s->raw[i] = (*s->raw[i] & (~(1<<0))) | (s->high_temp_enable[i] << 0);
@@ -637,7 +637,7 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
 //        *s->raw[i] = (*s->raw[i] & (~(1<<23))) | (s->thresh2_enable[i] << 23);
 //        *s->raw[i] = (*s->raw[i] & (~(1<<24))) | (s->pwr_limit_notification_enable[i] << 24);
 //    }
-//    write_batch(THERM_INTERR);
+//    execute_batch(THERM_INTERR);
 //}
 //
 //void set_pkg_therm_stat(struct pkg_therm_stat *s)
@@ -645,7 +645,7 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
 //    uint64_t sockets = num_sockets();
 //    int i;
 //
-//    read_batch(PKG_THERM_STAT);
+//    execute_batch(PKG_THERM_STAT);
 //    for (i = 0; i < sockets; i++)
 //    {
 //        *s->raw[i] = (*s->raw[i] & (~(1<<1))) | (s->status_log[i] << 1);
@@ -655,13 +655,13 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
 //        *s->raw[i] = (*s->raw[i] & (~(1<<9))) | (s->therm_thresh2_log[i] << 9);
 //        *s->raw[i] = (*s->raw[i] & (~(1<<11))) | (s->power_notification_log[i] << 11);
 //    }
-//    write_batch(PKG_THERM_STAT);
+//    execute_batch(PKG_THERM_STAT);
 //}
 //
 //void set_pkg_therm_interrupt(struct pkg_therm_interrupt *s)
 //{
 //    uint64_t sockets = num_sockets();
-//    read_batch(PKG_THERM_INTERR);
+//    execute_batch(PKG_THERM_INTERR);
 //    int i;
 //    for (i = 0; i < sockets; i++)
 //    {
@@ -675,5 +675,5 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
 //        *s->raw[i] = (*s->raw[i] & (~(1<<23))) | (s->thresh2_enable[i] << 23);
 //        *s->raw[i] = (*s->raw[i] & (~(1<<24))) | (s->pwr_limit_notification_enable[i] << 24);
 //    }
-//    write_batch(PKG_THERM_INTERR);
+//    execute_batch(PKG_THERM_INTERR);
 //}


### PR DESCRIPTION
The previous implementation set up batches but delayed setting the
isrdmsr field until batch execution, setting it depending on
whether or not the executing call was read_batch() or
write_batch(). This is not necessarily a poor design choice, but
it is not obvious which batches are intented to be read only and
which are r/w. Nor does the previous design permit batches that,
say, read and store the previous values of the MSRs before writing
new values.

The implementation contained in this patch forces the user to
declare whether batch operations are read or write when the batch
is initialized. Batches that could formerly be read or written
are now replaced by two distinct batches, one for reading and the
second for writing (e.g., the COUNTERS_CTRL batch has been
replaced by RD_COUNTERS_CTRL and WR_COUNTERS_CTRL).

This patch adds a parameter (int isrdmsr) to load_*_batch.  This
is an intrusive change, as all of the *_features.[ch] code made
use of this API.

This patch also replaces the separate read_batch() and write_batch()
calls with execute_batch().

Fixes #73 