### PR TITLE
use spack mirror for travis builds

### DIFF
--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -22,6 +22,9 @@ mv spack-0.14.0 spack
 
 export PATH=${PWD}/spack/bin:${PATH}
 
+# setup mirror, so we don't have to download the file
+spack mirror add local_filesystem file:///home/travis/build/LLNL/variorum/scripts/mirrors
+
 # hwloc
 spack install hwloc
 export HWLOC_DIR=`ls -d ${TRAVIS_BUILD_DIR}/travis-spack-env/spack/opt/spack/*/*/hwloc-*`


### PR DESCRIPTION
A spack mirror allows you to download and save a source tar file in advance,
useful to avoid downloading the same file over and over.

Our build infrastructure is fragile, as spack will often fail for transitory network problems. This is especially true for packages with many dependencies.