### PR TITLE
Rename variorum_set_topology to variorum_get_topology

### DIFF
--- a/src/examples/variorum-print-topology-example.c
+++ b/src/examples/variorum-print-topology-example.c
@@ -9,12 +9,6 @@
 
 int main(int argc, char **argv)
 {
-    int ret;
-
-    ret = variorum_print_topology();
-    if (ret != 0)
-    {
-        printf("Print topology failed!\n");
-    }
-    return ret;
+    variorum_print_topology();
+    return 0;
 }

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -24,7 +24,7 @@ int p9_get_power(int long_ver)
     int iter = 0;
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     fd = open("/sys/firmware/opal/exports/occ_inband_sensors", O_RDONLY);
     if (fd < 0)
@@ -313,7 +313,7 @@ int p9_monitoring(FILE *output)
     int long_ver = 0;
     static int count = 0;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     fd = open("/sys/firmware/opal/exports/occ_inband_sensors", O_RDONLY);
     if (fd < 0)

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -72,7 +72,7 @@ int fm_06_4f_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -134,7 +134,7 @@ int fm_06_4f_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -67,7 +67,7 @@ int fm_06_3f_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -129,7 +129,7 @@ int fm_06_3f_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -72,7 +72,7 @@ int fm_06_3e_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -134,7 +134,7 @@ int fm_06_3e_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -67,7 +67,7 @@ int fm_06_9e_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -115,7 +115,7 @@ int fm_06_9e_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -61,7 +61,7 @@ int fm_06_2a_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -123,7 +123,7 @@ int fm_06_2a_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -67,7 +67,7 @@ int fm_06_55_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -115,7 +115,7 @@ int fm_06_55_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -340,7 +340,7 @@ int fm_06_55_monitoring(FILE *output)
 int fm_06_55_set_frequency(int core_freq_mhz)
 {
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/clocks_features.c
+++ b/src/variorum/Intel/clocks_features.c
@@ -24,7 +24,7 @@ void clocks_storage(struct clocks_data **cd, off_t msr_aperf, off_t msr_mperf,
 
     if (!init)
     {
-        variorum_set_topology(NULL, NULL, &nthreads);
+        variorum_get_topology(NULL, NULL, &nthreads);
         d.aperf = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
         d.mperf = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
         d.tsc = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
@@ -47,7 +47,7 @@ void perf_storage_temp(struct perf_data **pd, off_t msr_perf_status,
     static struct perf_data d;
     int nsockets, ncores, nthreads;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     if (!init)
     {
@@ -85,7 +85,7 @@ void perf_storage(struct perf_data **pd, off_t msr_perf_status)
 
     if (!nsockets)
     {
-        variorum_set_topology(&nsockets, NULL, NULL);
+        variorum_get_topology(&nsockets, NULL, NULL);
         d.perf_status = (uint64_t **) malloc(nsockets * sizeof(uint64_t *));
         allocate_batch(RD_PERF_DATA, 2UL * nsockets); // FIXME should be 1UL?
         load_socket_batch(msr_perf_status, d.perf_status, BATCH_READ, RD_PERF_DATA);
@@ -109,7 +109,7 @@ void dump_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
     char hostname[1024];
     int max_non_turbo_ratio = get_max_non_turbo_ratio(msr_platform_info);
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     gethostname(hostname, 1024);
     if (!init)
     {
@@ -182,7 +182,7 @@ void print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
     char hostname[1024];
     int max_non_turbo_ratio = get_max_non_turbo_ratio(msr_platform_info);
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     gethostname(hostname, 1024);
 
     clocks_storage(&cd, msr_aperf, msr_mperf, msr_tsc);
@@ -242,7 +242,7 @@ void print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
 //    char hostname[1024];
 //    int max_non_turbo_ratio = get_max_non_turbo_ratio(msr_platform_info);
 //
-//    variorum_set_topology(&nsockets, &ncores, &nthreads);
+//    variorum_get_topology(&nsockets, &ncores, &nthreads);
 //    gethostname(hostname, 1024);
 //
 //    clocks_storage(&cd, msr_aperf, msr_mperf, msr_tsc);
@@ -273,7 +273,7 @@ void print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
 //    char hostname[1024];
 //    int max_non_turbo_ratio = get_max_non_turbo_ratio(msr_platform_info);
 //
-//    variorum_set_topology(&nsockets, &ncores, &nthreads);
+//    variorum_get_topology(&nsockets, &ncores, &nthreads);
 //    gethostname(hostname, 1024);
 //
 //    clocks_storage(&cd, msr_aperf, msr_mperf, msr_tsc);
@@ -302,7 +302,7 @@ void set_p_state(int cpu_freq_mhz, enum ctl_domains_e domain,
     static struct perf_data *pd;
     static int init = 0;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     if (!init)
     {
         init = 1;

--- a/src/variorum/Intel/counters_features.c
+++ b/src/variorum/Intel/counters_features.c
@@ -49,7 +49,7 @@ void fixed_counter_storage(struct fixed_counter **ctr0,
     if (!init)
     {
         init = 1;
-        variorum_set_topology(NULL, NULL, &nthreads);
+        variorum_get_topology(NULL, NULL, &nthreads);
         init_fixed_counter(&c0);
         init_fixed_counter(&c1);
         init_fixed_counter(&c2);
@@ -78,7 +78,7 @@ void fixed_counter_storage(struct fixed_counter **ctr0,
 void init_fixed_counter(struct fixed_counter *ctr)
 {
     int nthreads = 0;
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     ctr->enable = (uint64_t *) malloc(nthreads * sizeof(uint64_t));
 #ifdef VARIORUM_DEBUG
@@ -97,7 +97,7 @@ void enable_fixed_counters(off_t *msrs_fixed_ctrs, off_t msr1, off_t msr2)
     int i;
     int nthreads = 0;
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
 
     for (i = 0; i < nthreads; i++)
@@ -116,7 +116,7 @@ void disable_fixed_counters(off_t *msrs_fixed_ctrs, off_t msr1, off_t msr2)
     int i;
     int nthreads = 0;
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
 
     for (i = 0; i < nthreads; i++)
@@ -144,7 +144,7 @@ void set_fixed_counter_ctrl(struct fixed_counter *ctr0,
         init = 1;
     }
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     /* Don't need to read counters data, we are just zeroing things out. */
     execute_batch(RD_FIXED_COUNTERS_CTRL_DATA);
@@ -195,7 +195,7 @@ void fixed_counter_ctrl_storage(uint64_t ***perf_ctrl, uint64_t ***fixed_ctrl,
 
     if (!init)
     {
-        variorum_set_topology(NULL, NULL, &nthreads);
+        variorum_get_topology(NULL, NULL, &nthreads);
         perf_global_ctrl = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
         fixed_ctr_ctrl = (uint64_t **) malloc(nthreads * sizeof(uint64_t *));
         allocate_batch(RD_FIXED_COUNTERS_CTRL_DATA, 2UL * nthreads);
@@ -257,7 +257,7 @@ void dump_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
                 "_FIXED_COUNTERS Host Thread InstRet UnhaltClkCycles UnhaltRefCycles\n");
         init = 1;
     }
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
     gethostname(hostname, 1024);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
 
@@ -281,7 +281,7 @@ void dump_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
 
     gethostname(hostname, 1024);
     avail = cpuid_num_pmc();
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (p == NULL && !init)
     {
@@ -387,7 +387,7 @@ void print_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
     {
         init = 1;
     }
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
     gethostname(hostname, 1024);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
 
@@ -412,7 +412,7 @@ void print_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
 
     gethostname(hostname, 1024);
     avail = cpuid_num_pmc();
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (p == NULL && !init)
     {
@@ -491,7 +491,7 @@ static int init_pmc(struct pmc *p, off_t *msrs_perfmon_ctrs)
     int nthreads = 0;
     int avail = cpuid_num_pmc();
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (avail < 1)
     {
@@ -561,7 +561,7 @@ static int init_perfevtsel(struct perfevtsel *evt, off_t *msrs_perfevtsel_ctrs)
     int nthreads;
     int avail = cpuid_num_pmc();
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (avail < 1)
     {
@@ -640,7 +640,7 @@ void set_all_pmc_ctrl(uint64_t cmask, uint64_t flags, uint64_t umask,
     int nthreads;
     int i;
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
     for (i = 0; i < nthreads; i++)
     {
         set_pmc_ctrl_flags(cmask, flags, umask, eventsel, pmcnum, i,
@@ -760,7 +760,7 @@ void clear_all_pmc(off_t *msrs_perfmon_ctrs)
     if (p == NULL)
     {
         avail = cpuid_num_pmc();
-        variorum_set_topology(NULL, NULL, &nthreads);
+        variorum_get_topology(NULL, NULL, &nthreads);
         pmc_storage(&p, msrs_perfmon_ctrs);
     }
     for (i = 0; i < nthreads; i++)
@@ -803,7 +803,7 @@ static void init_unc_perfevtsel(struct unc_perfevtsel *uevt,
     static int init = 0;
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     if (!init)
     {
@@ -848,7 +848,7 @@ static void init_unc_counters(struct unc_counters *uc,
     static int init = 0;
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     if (!init)
     {
         uc->c0 = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
@@ -920,7 +920,7 @@ void clear_all_pcu(off_t *msrs_pcu_pmon_ctrs)
     int nsockets = 0;
     int i;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     if (uc == NULL)
     {
         unc_counters_storage(&uc, msrs_pcu_pmon_ctrs);
@@ -944,7 +944,7 @@ void dump_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel,
     int nsockets;
     char hostname[1024];
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     unc_counters_storage(&uc, msrs_pcu_pmon_ctrs);
@@ -969,7 +969,7 @@ void print_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel,
     int nsockets;
     char hostname[1024];
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     unc_counters_storage(&uc, msrs_pcu_pmon_ctrs);
@@ -1000,7 +1000,7 @@ void get_all_power_data_fixed(FILE *writedest, off_t msr_pkg_power_limit,
     int i;
     int rlim_idx = 0;
 
-    variorum_set_topology(&nsockets, NULL, &nthreads);
+    variorum_get_topology(&nsockets, NULL, &nthreads);
     gethostname(hostname, 1024);
 
     get_power(msr_rapl_unit, msr_package_energy_status, msr_dram_energy_status);

--- a/src/variorum/Intel/misc_features.c
+++ b/src/variorum/Intel/misc_features.c
@@ -18,7 +18,7 @@ int get_max_non_turbo_ratio(off_t msr_platform_info)
     static uint64_t **val = NULL;
     int max_non_turbo_ratio;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     if (!init)
     {
         val = (uint64_t **) malloc(nsockets * sizeof(uint64_t *));
@@ -50,7 +50,7 @@ int set_turbo_on(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
     uint64_t mask = 0;
     uint64_t msr_val = 0;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     /// Creates mask for turbo disable bit according to the architecture offset
     /// given.
     mask |= 1LL << turbo_mode_disable_bit;
@@ -95,7 +95,7 @@ int set_turbo_off(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
     uint64_t mask = 0;
     uint64_t msr_val = 0;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     /// Creates mask for turbo disable bit according to the architecture offset
     /// given.
     mask |= 1LL << turbo_mode_disable_bit;
@@ -141,7 +141,7 @@ int dump_turbo_status(FILE *writedest, off_t msr_misc_enable,
     uint64_t mask = 0;
     uint64_t msr_val = 0;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     mask |= 1LL << turbo_mode_disable_bit;
 
     for (socket = 0; socket < nsockets; socket++)

--- a/src/variorum/Intel/msr_core.c
+++ b/src/variorum/Intel/msr_core.c
@@ -26,7 +26,7 @@
 static uint64_t devidx(int socket, int core, int thread)
 {
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     return (thread * nsockets * (ncores / nsockets)) + (socket * ncores / nsockets)
            + core;
 }
@@ -131,7 +131,7 @@ static int *core_fd(const int dev_idx)
     if (!init_core_fd)
     {
         init_core_fd = 1;
-        variorum_set_topology(NULL, NULL, &nthreads);
+        variorum_get_topology(NULL, NULL, &nthreads);
         file_descriptors = (int *) malloc(nthreads * sizeof(int));
     }
     if (dev_idx < nthreads)
@@ -217,7 +217,7 @@ int sockets_assert(const unsigned *socket, const int location, const char *file)
 {
     char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
     int nsockets;
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     if (*socket > nsockets)
     {
@@ -236,7 +236,7 @@ int threads_assert(const unsigned *thread, const int location, const char *file)
 {
     char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
     int nthreads;
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (*thread > nthreads)
     {
@@ -255,7 +255,7 @@ int cores_assert(const unsigned *core, const int location, const char *file)
 {
     char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
     int ncores;
-    variorum_set_topology(NULL, &ncores, NULL);
+    variorum_get_topology(NULL, &ncores, NULL);
 
     if (*core > ncores)
     {
@@ -354,7 +354,7 @@ int finalize_msr(void)
     int *file_descriptor = NULL;
     char *variorum_error_msg = (char *) malloc(NAME_MAX * sizeof(char));
     int nthreads;
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     for (dev_idx = 0; dev_idx < nthreads; dev_idx++)
     {
@@ -390,7 +390,7 @@ int init_msr(void)
     char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
     int nsockets, ncores, nthreads;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     snprintf(filename, FILENAME_SIZE, "/dev/cpu/msr_whitelist");
     stat_module(filename, &kerneltype, 0);
     /* Open the file descriptor for each device's msr interface. */
@@ -569,7 +569,7 @@ int load_socket_batch(off_t msr, uint64_t **val, int isrdmsr, int batchnum)
 {
     int dev_idx, val_idx;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     if (val == NULL)
     {
@@ -591,7 +591,7 @@ int load_thread_batch(off_t msr, uint64_t **val, int isrdmsr, int batchnum)
 {
     int dev_idx, val_idx;
     int nsockets, ncores, nthreads;
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     if (val == NULL)
     {

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -32,7 +32,7 @@ static int translate(const unsigned socket, uint64_t *bits, double *units,
     if (!init_translate)
     {
         init_translate = 1;
-        variorum_set_topology(&nsockets, NULL, NULL);
+        variorum_get_topology(&nsockets, NULL, NULL);
         ru = (struct rapl_units *) malloc(nsockets * sizeof(struct rapl_units));
         get_rapl_power_unit(ru, msr);
     }
@@ -290,7 +290,7 @@ static void create_rapl_data_batch(struct rapl_data *rapl,
                                    off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     int nsockets;
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     allocate_batch(RD_RAPL_DATA, 2UL * nsockets);
 
@@ -322,7 +322,7 @@ int get_rapl_power_unit(struct rapl_units *ru, off_t msr)
     static int nsockets, ncores, nthreads;
     int i;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
     if (!init_get_rapl_power_unit)
     {
         init_get_rapl_power_unit = 1;
@@ -387,7 +387,7 @@ void dump_rapl_power_unit(FILE *writedest, off_t msr)
     char hostname[1024];
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     ru = (struct rapl_units *) malloc(nsockets * sizeof(struct rapl_units));
@@ -411,7 +411,7 @@ void print_rapl_power_unit(FILE *writedest, off_t msr)
     char hostname[1024];
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     ru = (struct rapl_units *) malloc(nsockets * sizeof(struct rapl_units));
@@ -474,7 +474,7 @@ void dump_package_power_limit(FILE *writedest, off_t msr_power_limit,
     char hostname[1024];
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     if (!init_dump_package_power_limit)
@@ -500,7 +500,7 @@ void dump_dram_power_limit(FILE *writedest, off_t msr_power_limit,
     char hostname[1024];
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     if (!init_dump_dram_power_limit)
@@ -679,7 +679,7 @@ int rapl_storage(struct rapl_data **data)
     if (!init)
     {
         init = 1;
-        variorum_set_topology(&nsockets, NULL, NULL);
+        variorum_get_topology(&nsockets, NULL, NULL);
 
         rapl = (struct rapl_data *) malloc(nsockets * sizeof(struct rapl_data));
 
@@ -708,7 +708,7 @@ int get_power(off_t msr_rapl_unit, off_t msr_pkg_energy_status,
     static struct rapl_data *rapl = NULL;
     int nsockets;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
 #ifdef VARIORUM_DEBUG
     fprintf(stderr, "%s %s::%d DEBUG: (get_power) socket=%lu\n", getenv("HOSTNAME"),
@@ -751,7 +751,7 @@ int delta_rapl_data(off_t msr_rapl_unit)
 #endif
     if (!init)
     {
-        variorum_set_topology(&nsockets, NULL, NULL);
+        variorum_get_topology(&nsockets, NULL, NULL);
         if (rapl_storage(&rapl))
         {
             return -1;
@@ -836,7 +836,7 @@ void print_power_data(FILE *writedest, off_t msr_power_limit,
     int i;
 
     gethostname(hostname, 1024);
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     get_power(msr_rapl_unit, msr_pkg_energy_status, msr_dram_energy_status);
 
@@ -878,7 +878,7 @@ void dump_power_data(FILE *writedest, off_t msr_power_limit,
     int i;
 
     gethostname(hostname, 1024);
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     get_power(msr_rapl_unit, msr_pkg_energy_status, msr_dram_energy_status);
 
@@ -962,7 +962,7 @@ int read_rapl_data(off_t msr_rapl_unit, off_t msr_pkg_energy_status,
 
     if (!init)
     {
-        variorum_set_topology(&nsockets, NULL, NULL);
+        variorum_get_topology(&nsockets, NULL, NULL);
         if (rapl_storage(&rapl))
         {
             return -1;
@@ -1069,7 +1069,7 @@ void get_all_power_data(FILE *writedest, off_t msr_pkg_power_limit,
     int i;
     int rlim_idx = 0;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
     get_power(msr_rapl_unit, msr_package_energy_status, msr_dram_energy_status);

--- a/src/variorum/Intel/thermal_features.c
+++ b/src/variorum/Intel/thermal_features.c
@@ -19,7 +19,7 @@ void get_temp_target(struct msr_temp_target *s, off_t msr)
     static int init_tt = 0;
     int i;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     if (!init_tt)
     {
@@ -49,7 +49,7 @@ void get_therm_stat(struct therm_stat *s, off_t msr)
     static int init_ts = 0;
     int i;
 
-    variorum_set_topology(NULL, NULL, &nthreads);
+    variorum_get_topology(NULL, NULL, &nthreads);
 
     if (!init_ts)
     {
@@ -155,7 +155,7 @@ int get_pkg_therm_stat(struct pkg_therm_stat *s, off_t msr)
     static int init_pkg_ts = 0;
     int i;
 
-    variorum_set_topology(&nsockets, NULL, NULL);
+    variorum_get_topology(&nsockets, NULL, NULL);
 
     if (!init_pkg_ts)
     {
@@ -245,7 +245,7 @@ int print_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
     int i, j, k;
     int nsockets, ncores, nthreads;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     pkg_stat = (struct pkg_therm_stat *) malloc(nsockets * sizeof(
                    struct pkg_therm_stat));
@@ -304,7 +304,7 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
     int i, j, k;
     int nsockets, ncores, nthreads;
 
-    variorum_set_topology(&nsockets, &ncores, &nthreads);
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     pkg_stat = (struct pkg_therm_stat *) malloc(nsockets * sizeof(
                    struct pkg_therm_stat));

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -224,9 +224,7 @@ int variorum_exit(const char *filename,
                   const char *func_name,
                   int line_num);
 
-int variorum_get_topology(void);
-
-void variorum_set_topology(int *nsockets,
+void variorum_get_topology(int *nsockets,
                            int *ncores,
                            int *nthreads);
 

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -152,9 +152,8 @@ int variorum_print_verbose_power_limits(void)
     return err;
 }
 
-int variorum_print_topology(void)
+void variorum_print_topology(void)
 {
-    int err = 0;
     int i;
     int hyperthreading = 0;
     hwloc_topology_t topo;
@@ -162,13 +161,7 @@ int variorum_print_topology(void)
     hwloc_topology_init(&topo);
     hwloc_topology_load(topo);
 
-    err = variorum_get_topology();
-    if (err)
-    {
-        variorum_error_handler("Cannot get topology", err, getenv("HOSTNAME"), __FILE__,
-                               __FUNCTION__, __LINE__);
-        return -1;
-    }
+    variorum_get_topology(NULL, NULL, NULL);
 
     fprintf(stdout, "=================\n");
     fprintf(stdout, "Platform Topology\n");
@@ -198,7 +191,7 @@ int variorum_print_topology(void)
 
     hwloc_topology_destroy(topo);
 
-    return err;
+    return;
 }
 
 int variorum_set_node_power_limit(int node_power_limit)

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -137,9 +137,7 @@ int variorum_print_clock_speed(void);
 int variorum_print_hyperthreading(void);
 
 /// @brief Print architecture topology in long format.
-///
-/// @return Error code.
-int variorum_print_topology(void);
+void variorum_print_topology(void);
 
 /// @brief Print list of features available on a particular architecture.
 ///


### PR DESCRIPTION
Supersedes #61. Fixes #57

Removed variorum_set_topology, as the name was confusing

Merged functionality of variorum_set_topology into variorum_get_topology.

variorum_get_topology now executes initialization on first use.

Changed return code to void and added assertions for error checking on the assumption that if the underlying hwloc calls are failing, there's no point in trying to continue and failure should be dramatic.

Updated all calls in variorum to account for the above.