### PR TITLE
astyle: add --unpad-paren parameter

### DIFF
--- a/scripts/astyle-format.sh
+++ b/scripts/astyle-format.sh
@@ -18,6 +18,7 @@ TMP=$(astyle --errors-to-stdout \
              --max-instatement-indent=40 \
              --pad-oper \
              --pad-header \
+             --unpad-paren \
              --align-pointer=name \
              --align-reference=name \
              --break-closing-brackets \

--- a/src/powmon/power_wrapper_dynamic.c
+++ b/src/powmon/power_wrapper_dynamic.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
                         "\n";
     if (argc == 1 || (argc > 1 && (
                           strncmp(argv[1], "--help", strlen("--help")) == 0 ||
-                          strncmp(argv[1], "-h", strlen("-h")) == 0 )))
+                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
     {
         printf("%s", usage);
         return 0;

--- a/src/powmon/power_wrapper_static.c
+++ b/src/powmon/power_wrapper_static.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
                         "\n";
     if (argc == 1 || (argc > 1 && (
                           strncmp(argv[1], "--help", strlen("--help")) == 0 ||
-                          strncmp(argv[1], "-h", strlen("-h")) == 0 )))
+                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
     {
         printf("%s", usage);
         return 0;

--- a/src/powmon/powmon.c
+++ b/src/powmon/powmon.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
                         "\n";
     if (argc == 1 || (argc > 1 && (
                           strncmp(argv[1], "--help", strlen("--help")) == 0 ||
-                          strncmp(argv[1], "-h", strlen("-h")) == 0 )))
+                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
     {
         printf("%s", usage);
         return 0;

--- a/src/tests/t_msr_driver.cpp
+++ b/src/tests/t_msr_driver.cpp
@@ -82,55 +82,55 @@ class MsrDriverTest : public ::testing::TestWithParam<int>
 {
 };
 
-TEST_P (MsrDriverTest, Exists)
+TEST_P(MsrDriverTest, Exists)
 {
     int testparam = GetParam();
     char *filename;
 
     asprintf(&filename, "/dev/cpu/%d/msr", testparam);
-    EXPECT_EQ (0, is_file_exist(filename));
+    EXPECT_EQ(0, is_file_exist(filename));
     free(filename);
 }
 
-TEST_P (MsrDriverTest, UserID)
+TEST_P(MsrDriverTest, UserID)
 {
     int testparam = GetParam();
     char *filename;
 
     asprintf(&filename, "/dev/cpu/%d/msr", testparam);
     /* Check if user owner is root */
-    EXPECT_EQ (0, check_user_id(filename));
+    EXPECT_EQ(0, check_user_id(filename));
     free(filename);
 }
 
-TEST_P (MsrDriverTest, UserPerms)
+TEST_P(MsrDriverTest, UserPerms)
 {
     int testparam = GetParam();
     char *filename;
 
     asprintf(&filename, "/dev/cpu/%d/msr", testparam);
-    EXPECT_EQ (1, check_user_permissions(filename));
+    EXPECT_EQ(1, check_user_permissions(filename));
     free(filename);
 }
 
-TEST_P (MsrDriverTest, GroupID)
+TEST_P(MsrDriverTest, GroupID)
 {
     int testparam = GetParam();
     char *filename;
 
     asprintf(&filename, "/dev/cpu/%d/msr", testparam);
     /* Check if group owner is root */
-    EXPECT_EQ (0, check_group_id(filename));
+    EXPECT_EQ(0, check_group_id(filename));
     free(filename);
 }
 
-TEST_P (MsrDriverTest, GroupPerms)
+TEST_P(MsrDriverTest, GroupPerms)
 {
     int testparam = GetParam();
     char *filename;
 
     asprintf(&filename, "/dev/cpu/%d/msr", testparam);
-    EXPECT_EQ (1, check_group_permissions(filename));
+    EXPECT_EQ(1, check_group_permissions(filename));
     free(filename);
 }
 

--- a/src/tests/t_msr_safe_driver.cpp
+++ b/src/tests/t_msr_safe_driver.cpp
@@ -64,7 +64,7 @@ TEST_P(MsrDriverTest, Exists)
     char *filename;
 
     asprintf(&filename, "/dev/cpu/%d/msr_safe", testparam);
-    EXPECT_EQ (0, is_file_exist(filename));
+    EXPECT_EQ(0, is_file_exist(filename));
     free(filename);
 }
 
@@ -75,7 +75,7 @@ TEST_P(MsrDriverTest, GroupID)
 
     asprintf(&filename, "/dev/cpu/%d/msr_safe", testparam);
     /* Check if group owner is not root */
-    EXPECT_NE (0, check_group_id(filename));
+    EXPECT_NE(0, check_group_id(filename));
     free(filename);
 }
 
@@ -86,7 +86,7 @@ TEST_P(MsrDriverTest, GroupPerms)
 
     asprintf(&filename, "/dev/cpu/%d/msr_safe", testparam);
     /* Check if group owner is not root */
-    EXPECT_EQ (1, check_group_permissions(filename));
+    EXPECT_EQ(1, check_group_permissions(filename));
     free(filename);
 }
 

--- a/src/tests/t_msr_whitelist.cpp
+++ b/src/tests/t_msr_whitelist.cpp
@@ -68,7 +68,7 @@ int whitelist_size(const char *file)
     return statbuf.st_size;
 }
 
-TEST (MsrWhitelist, Exists)
+TEST(MsrWhitelist, Exists)
 {
     char *filename;
 
@@ -77,7 +77,7 @@ TEST (MsrWhitelist, Exists)
     free(filename);
 }
 
-TEST (MsrWhitelist, Perms)
+TEST(MsrWhitelist, Perms)
 {
     char *filename;
 
@@ -86,7 +86,7 @@ TEST (MsrWhitelist, Perms)
     free(filename);
 }
 
-TEST (MsrWhitelist, Size)
+TEST(MsrWhitelist, Size)
 {
     char *filename;
 

--- a/src/variorum/IBM/ibm_sensors.c
+++ b/src/variorum/IBM/ibm_sensors.c
@@ -166,19 +166,19 @@ void print_power_sensors(int chipid, int long_ver, FILE *output,
 
         if (strcmp(md[i].name, "PWRSYS") == 0)
         {
-            pwrsys = (uint64_t) (sample * TO_FP(scale));
+            pwrsys = (uint64_t)(sample * TO_FP(scale));
         }
         if (strcmp(md[i].name, "PWRPROC") == 0)
         {
-            pwrproc = (uint64_t) (sample * TO_FP(scale));
+            pwrproc = (uint64_t)(sample * TO_FP(scale));
         }
         if (strcmp(md[i].name, "PWRMEM") == 0)
         {
-            pwrmem = (uint64_t) (sample * TO_FP(scale));
+            pwrmem = (uint64_t)(sample * TO_FP(scale));
         }
         if (strcmp(md[i].name, "PWRGPU") == 0)
         {
-            pwrgpu = (uint64_t) (sample * TO_FP(scale));
+            pwrgpu = (uint64_t)(sample * TO_FP(scale));
         }
     }
 

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -26,8 +26,8 @@ uint64_t *detect_intel_arch(void)
 
     asm volatile(
         "cpuid"
-        : "=a" (rax), "=b" (rbx), "=c" (rcx), "=d" (rdx)
-        : "0" (rax), "2" (rcx));
+        : "=a"(rax), "=b"(rbx), "=c"(rcx), "=d"(rdx)
+        : "0"(rax), "2"(rcx));
 
     *model = ((rax >> 12) & 0xF0) | ((rax >> 4) & 0xF);
     return model;

--- a/src/variorum/Intel/variorum_cpuid.c
+++ b/src/variorum/Intel/variorum_cpuid.c
@@ -8,11 +8,11 @@
 void cpuid(uint64_t leaf, uint64_t *rax, uint64_t *rbx, uint64_t *rcx,
            uint64_t *rdx)
 {
-    asm volatile (
+    asm volatile(
         "\txchg %%rbx, %%rdi\n"
         "\tcpuid\n"
         "\txchg %%rbx, %%rdi"
-        : "=a" (*rax), "=D" (*rbx), "=c" (*rcx), "=d" (*rdx)
-        : "a" (leaf)
+        : "=a"(*rax), "=D"(*rbx), "=c"(*rcx), "=d"(*rdx)
+        : "a"(leaf)
     );
 }


### PR DESCRIPTION
This removes extra space padding around parens on the inside and outside, e.g.,
    `bar ( a, b ); --> bar(a, b);`