### PR TITLE
Add query frequencies

### DIFF
--- a/host-configs/radon.cmake
+++ b/host-configs/radon.cmake
@@ -1,0 +1,24 @@
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Variorum Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+# c compiler
+set(CMAKE_C_COMPILER "gcc" CACHE PATH "")
+
+# cpp compiler
+set(CMAKE_CXX_COMPILER "g++" CACHE PATH "")
+
+set(ENABLE_FORTRAN OFF CACHE BOOL "")
+set(VARIORUM_LOG OFF CACHE BOOL "")
+
+set(BUILD_DOCS OFF CACHE BOOL "")
+set(BUILD_TESTS OFF CACHE BOOL "")
+
+set(VARIORUM_WITH_AMD OFF CACHE BOOL "")
+set(VARIORUM_WITH_NVIDIA OFF CACHE BOOL "")
+set(VARIORUM_WITH_IBM OFF CACHE BOOL "")
+set(VARIORUM_WITH_INTEL ON CACHE BOOL "")
+
+# path to global hwloc install
+set(HWLOC_DIR "/usr" CACHE PATH "")

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -35,6 +35,7 @@ set(BASIC_EXAMPLES
     variorum-set-best-effort-node-power-limit-example
     variorum-set-socket-power-limits-example
     variorum-get-node-power-json-example
+    variorum-print-available-frequencies-example
 )
 
 message(STATUS "Adding variorum examples")

--- a/src/examples/variorum-print-available-frequencies-example.c
+++ b/src/examples/variorum-print-available-frequencies-example.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+
+#include <variorum.h>
+
+int main(int argc, char **argv)
+{
+    int ret;
+
+    /* 02/25/19 SB
+     * How do we distinguish errors if this function pointer does not exist
+     * because it has not yet been implemented or if it cannot be implemented?
+     */
+    ret = variorum_print_available_frequencies();
+    if (ret != 0)
+    {
+        printf("Print available frequencies failed!\n");
+    }
+    return ret;
+}

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -26,6 +26,9 @@ static struct broadwell_4f_offsets msrs =
     .msr_temperature_target       = 0x1A2,
     .msr_turbo_ratio_limit        = 0x1AD,
     .msr_turbo_ratio_limit1       = 0x1AE,
+    .msr_config_tdp_level1        = 0x649,
+    .msr_config_tdp_level2        = 0x64A,
+    .msr_config_tdp_nominal       = 0x648,
     .ia32_package_therm_status    = 0x1B1,
     .ia32_package_therm_interrupt = 0x1B2,
     .ia32_fixed_counters[0]       = 0x309,
@@ -458,3 +461,15 @@ int fm_06_4f_set_best_effort_node_power_limit(int node_limit)
     return 0;
 }
 
+int fm_06_4f_get_frequencies(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    get_available_frequencies(stdout, &msrs.msr_platform_info,
+                              &msrs.msr_turbo_ratio_limit, &msrs.msr_turbo_ratio_limit1,
+                              &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2,
+                              &msrs.msr_config_tdp_nominal);
+    return 0;
+}

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -13,61 +13,61 @@
 struct broadwell_4f_offsets
 {
     /// @brief Address for MSR_PLATFORM_INFO.
-    const off_t msr_platform_info;
+    off_t msr_platform_info;
     /// @brief Address for IA32_TIME_STAMP_COUNTER.
-    const off_t ia32_time_stamp_counter;
+    off_t ia32_time_stamp_counter;
     /// @brief Address for IA32_PERF_CTL.
-    const off_t ia32_perf_ctl;
+    off_t ia32_perf_ctl;
     /// @brief Address for IA32_PERF_STATUS.
-    const off_t ia32_perf_status;
+    off_t ia32_perf_status;
     /// @brief Address for IA32_THERM_INTERRUPT.
-    const off_t ia32_therm_interrupt;
+    off_t ia32_therm_interrupt;
     /// @brief Address for IA32_THERM_STATUS.
-    const off_t ia32_therm_status;
+    off_t ia32_therm_status;
     /// @brief Address for THERM2_CTL.
-    const off_t msr_therm2_ctl;
+    off_t msr_therm2_ctl;
     /// @brief Address for IA32_MISC_ENABLE.
-    const off_t ia32_misc_enable;
+    off_t ia32_misc_enable;
     /// @brief Address for TEMPERATURE_TARGET.
-    const off_t msr_temperature_target;
+    off_t msr_temperature_target;
     /// @brief Address for TURBO_RATIO_LIMIT.
-    const off_t msr_turbo_ratio_limit;
+    off_t msr_turbo_ratio_limit;
     /// @brief Address for TURBO_RATIO_LIMIT1.
-    const off_t msr_turbo_ratio_limit1;
+    off_t msr_turbo_ratio_limit1;
     /// @brief Address for IA32_PACKAGE_THERM_STATUS.
-    const off_t ia32_package_therm_status;
+    off_t ia32_package_therm_status;
     /// @brief Address for IA32_PACKAGE_THERM_INTERRUPT.
-    const off_t ia32_package_therm_interrupt;
+    off_t ia32_package_therm_interrupt;
     /// @brief Address for IA32_FIXED_CTR_CTRL.
-    const off_t ia32_fixed_ctr_ctrl;
+    off_t ia32_fixed_ctr_ctrl;
     /// @brief Address for IA32_PERF_GLOBAL_STATUS.
-    const off_t ia32_perf_global_status;
+    off_t ia32_perf_global_status;
     /// @brief Address for IA32_PERF_GLOBAL_CTRL.
-    const off_t ia32_perf_global_ctrl;
+    off_t ia32_perf_global_ctrl;
     /// @brief Address for IA32_PERF_GLOBAL_OVF_CTRL.
-    const off_t ia32_perf_global_ovf_ctrl;
+    off_t ia32_perf_global_ovf_ctrl;
     /// @brief Address for RAPL_POWER_UNIT.
-    const off_t msr_rapl_power_unit;
+    off_t msr_rapl_power_unit;
     /// @brief Address for PKG_POWER_LIMIT.
-    const off_t msr_pkg_power_limit;
+    off_t msr_pkg_power_limit;
     /// @brief Address for PKG_ENERGY_STATUS.
-    const off_t msr_pkg_energy_status;
+    off_t msr_pkg_energy_status;
     /// @brief Address for PKG_PERF_STATUS.
-    const off_t msr_pkg_perf_status;
+    off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
-    const off_t msr_pkg_power_info;
+    off_t msr_pkg_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
-    const off_t msr_dram_power_limit;
+    off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.
-    const off_t msr_dram_energy_status;
+    off_t msr_dram_energy_status;
     /// @brief Address for DRAM_PERF_STATUS.
-    const off_t msr_dram_perf_status;
+    off_t msr_dram_perf_status;
     /// @brief Address for TURBO_ACTIVATION_RATIO.
-    const off_t msr_turbo_activation_ratio;
+    off_t msr_turbo_activation_ratio;
     /// @brief Address for IA32_MPERF.
-    const off_t ia32_mperf;
+    off_t ia32_mperf;
     /// @brief Address for IA32_APERF.
-    const off_t ia32_aperf;
+    off_t ia32_aperf;
     /// @brief Array of unique addresses for fixed counters.
     off_t ia32_fixed_counters[3];
     /// @brief Array of unique addresses for perfmon counters.
@@ -76,6 +76,9 @@ struct broadwell_4f_offsets
     off_t ia32_perfevtsel_counters[8];
     /// @brief Array of unique addresses for pmon evtsel.
     off_t msrs_pcu_pmon_evtsel[4];
+    off_t msr_config_tdp_level1;
+    off_t msr_config_tdp_level2;
+    off_t msr_config_tdp_nominal;
 };
 
 int fm_06_4f_get_power_limits(int long_ver);
@@ -105,4 +108,7 @@ int fm_06_4f_monitoring(FILE *output);
 int fm_06_4f_get_node_power_json(json_t *get_power_obj);
 
 int fm_06_4f_set_best_effort_node_power_limit(int node_power_limit);
+
+int fm_06_4f_get_frequencies(void);
+
 #endif

--- a/src/variorum/Intel/CMakeLists.txt
+++ b/src/variorum/Intel/CMakeLists.txt
@@ -10,6 +10,7 @@ set(variorum_intel_headers
   ${CMAKE_CURRENT_SOURCE_DIR}/thermal_features.h
   ${CMAKE_CURRENT_SOURCE_DIR}/misc_features.h
   ${CMAKE_CURRENT_SOURCE_DIR}/SandyBridge_2A.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/SandyBridge_2D.h
   ${CMAKE_CURRENT_SOURCE_DIR}/IvyBridge_3E.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Haswell_3F.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Broadwell_4F.h
@@ -26,6 +27,7 @@ set(variorum_intel_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/thermal_features.c
   ${CMAKE_CURRENT_SOURCE_DIR}/misc_features.c
   ${CMAKE_CURRENT_SOURCE_DIR}/SandyBridge_2A.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/SandyBridge_2D.c
   ${CMAKE_CURRENT_SOURCE_DIR}/IvyBridge_3E.c
   ${CMAKE_CURRENT_SOURCE_DIR}/Haswell_3F.c
   ${CMAKE_CURRENT_SOURCE_DIR}/Broadwell_4F.c

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -25,6 +25,9 @@ static struct haswell_3f_offsets msrs =
     .msr_temperature_target       = 0x1A2,
     .msr_turbo_ratio_limit        = 0x1AD,
     .msr_turbo_ratio_limit1       = 0x1AE,
+    .msr_config_tdp_level1        = 0x649,
+    .msr_config_tdp_level2        = 0x64A,
+    .msr_config_tdp_nominal       = 0x648,
     .ia32_package_therm_status    = 0x1B1,
     .ia32_package_therm_interrupt = 0x1B2,
     .ia32_fixed_counters[0]       = 0x309,
@@ -381,5 +384,18 @@ int fm_06_3f_monitoring(FILE *output)
                              msrs.msr_dram_energy_status, msrs.ia32_fixed_counters,
                              msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl, msrs.ia32_aperf,
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
+    return 0;
+}
+
+int fm_06_3f_get_frequencies(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    get_available_frequencies(stdout, &msrs.msr_platform_info,
+                              &msrs.msr_turbo_ratio_limit, &msrs.msr_turbo_ratio_limit1,
+                              &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2,
+                              &msrs.msr_config_tdp_nominal);
     return 0;
 }

--- a/src/variorum/Intel/Haswell_3F.h
+++ b/src/variorum/Intel/Haswell_3F.h
@@ -12,61 +12,61 @@
 struct haswell_3f_offsets
 {
     /// @brief Address for MSR_PLATFORM_INFO.
-    const off_t msr_platform_info;
+    off_t msr_platform_info;
     /// @brief Address for IA32_TIME_STAMP_COUNTER.
-    const off_t ia32_time_stamp_counter;
+    off_t ia32_time_stamp_counter;
     /// @brief Address for IA32_PERF_CTL.
-    const off_t ia32_perf_ctl;
+    off_t ia32_perf_ctl;
     /// @brief Address for IA32_PERF_STATUS.
-    const off_t ia32_perf_status;
+    off_t ia32_perf_status;
     /// @brief Address for IA32_THERM_INTERRUPT.
-    const off_t ia32_therm_interrupt;
+    off_t ia32_therm_interrupt;
     /// @brief Address for IA32_THERM_STATUS.
-    const off_t ia32_therm_status;
+    off_t ia32_therm_status;
     /// @brief Address for THERM2_CTL.
-    const off_t msr_therm2_ctl;
+    off_t msr_therm2_ctl;
     /// @brief Address for IA32_MISC_ENABLE.
-    const off_t ia32_misc_enable;
+    off_t ia32_misc_enable;
     /// @brief Address for TEMPERATURE_TARGET.
-    const off_t msr_temperature_target;
+    off_t msr_temperature_target;
     /// @brief Address for TURBO_RATIO_LIMIT.
-    const off_t msr_turbo_ratio_limit;
+    off_t msr_turbo_ratio_limit;
     /// @brief Address for TURBO_RATIO_LIMIT1.
-    const off_t msr_turbo_ratio_limit1;
+    off_t msr_turbo_ratio_limit1;
     /// @brief Address for IA32_PACKAGE_THERM_STATUS.
-    const off_t ia32_package_therm_status;
+    off_t ia32_package_therm_status;
     /// @brief Address for IA32_PACKAGE_THERM_INTERRUPT.
-    const off_t ia32_package_therm_interrupt;
+    off_t ia32_package_therm_interrupt;
     /// @brief Address for IA32_FIXED_CTR_CTRL.
-    const off_t ia32_fixed_ctr_ctrl;
+    off_t ia32_fixed_ctr_ctrl;
     /// @brief Address for IA32_PERF_GLOBAL_STATUS.
-    const off_t ia32_perf_global_status;
+    off_t ia32_perf_global_status;
     /// @brief Address for IA32_PERF_GLOBAL_CTRL.
-    const off_t ia32_perf_global_ctrl;
+    off_t ia32_perf_global_ctrl;
     /// @brief Address for IA32_PERF_GLOBAL_OVF_CTRL.
-    const off_t ia32_perf_global_ovf_ctrl;
+    off_t ia32_perf_global_ovf_ctrl;
     /// @brief Address for RAPL_POWER_UNIT.
-    const off_t msr_rapl_power_unit;
+    off_t msr_rapl_power_unit;
     /// @brief Address for PKG_POWER_LIMIT.
-    const off_t msr_pkg_power_limit;
+    off_t msr_pkg_power_limit;
     /// @brief Address for PKG_ENERGY_STATUS.
-    const off_t msr_pkg_energy_status;
+    off_t msr_pkg_energy_status;
     /// @brief Address for PKG_PERF_STATUS.
-    const off_t msr_pkg_perf_status;
+    off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
-    const off_t msr_pkg_power_info;
+    off_t msr_pkg_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
-    const off_t msr_dram_power_limit;
+    off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.
-    const off_t msr_dram_energy_status;
+    off_t msr_dram_energy_status;
     /// @brief Address for DRAM_PERF_STATUS.
-    const off_t msr_dram_perf_status;
+    off_t msr_dram_perf_status;
     /// @brief Address for TURBO_ACTIVATION_RATIO.
-    const off_t msr_turbo_activation_ratio;
+    off_t msr_turbo_activation_ratio;
     /// @brief Address for IA32_MPERF.
-    const off_t ia32_mperf;
+    off_t ia32_mperf;
     /// @brief Address for IA32_APERF.
-    const off_t ia32_aperf;
+    off_t ia32_aperf;
     /// @brief Array of unique addresses for fixed counters.
     off_t ia32_fixed_counters[3];
     /// @brief Array of unique addresses for perfmon counters.
@@ -75,6 +75,9 @@ struct haswell_3f_offsets
     off_t ia32_perfevtsel_counters[8];
     /// @brief Array of unique addresses for pmon evtsel.
     off_t msrs_pcu_pmon_evtsel[4];
+    off_t msr_config_tdp_level1;
+    off_t msr_config_tdp_level2;
+    off_t msr_config_tdp_nominal;
 };
 
 int fm_06_3f_get_power_limits(int long_ver);
@@ -100,4 +103,7 @@ int fm_06_3f_get_turbo_status(void);
 int fm_06_3f_poll_power(FILE *output);
 
 int fm_06_3f_monitoring(FILE *output);
+
+int fm_06_3f_get_frequencies(void);
+
 #endif

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <IvyBridge_3E.h>
 #include <clocks_features.h>
@@ -12,6 +13,7 @@
 #include <misc_features.h>
 #include <power_features.h>
 #include <thermal_features.h>
+#include <variorum_error.h>
 
 static struct ivybridge_3e_offsets msrs =
 {
@@ -396,5 +398,45 @@ int fm_06_3e_monitoring(FILE *output)
                              msrs.msr_dram_energy_status, msrs.ia32_fixed_counters,
                              msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl, msrs.ia32_aperf,
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
+    return 0;
+}
+
+int fm_06_3e_get_frequencies(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    get_available_frequencies(stdout, &msrs.msr_platform_info,
+                              &msrs.msr_turbo_ratio_limit, &msrs.msr_turbo_ratio_limit1,
+                              NULL, NULL, NULL);
+    //    /* Turbo Range
+    //     * Default ratio for 1C Max Turbo == P01
+    //     * All core turbo == P0n
+    //     * MSR_TURBO_RATIO_LIMIT_CORES for Skylake (1AEh)
+    //     */
+    //    fprintf(stdout, "=== Turbo Schedule ===\n");
+    //    if (get_turbo_ratio_limits(msrs.msr_turbo_ratio_limit,
+    //                               msrs.msr_turbo_ratio_limit1) != 0)
+    //    {
+    //        variorum_error_handler("Values do not match across sockets",
+    //                               VARIORUM_ERROR_INVAL, getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+    //    }
+    //    fprintf(stdout, "\n");
+    //
+    //    /* P-State Table -- P1, Pn, and Pm
+    //     * Read IA32_PLATFORM_INFO 0xCE
+    //     * Field "Maximum Efficiency Ratio: Bits 47:40 == Pn
+    //     * Field "Maximum Non-Turbo Ratio: Bits 15:8 == P1
+    //     * Field "Minimum Operating Ratio: Bits 55:48 == Pm
+    //     */
+    //    fprintf(stdout, "=== P-State Table ===\n");
+    //    fprintf(stdout, "Max Efficiency Ratio = %d MHz\n",
+    //            get_max_non_turbo_ratio(msrs.msr_platform_info));
+    //    fprintf(stdout, "Max Non-Turbo Ratio  = %d MHz\n",
+    //            get_max_efficiency_ratio(msrs.msr_platform_info));
+    //    fprintf(stdout, "Min Operating Ratio  = %d MHz\n",
+    //            get_min_operating_ratio(msrs.msr_platform_info));
+
     return 0;
 }

--- a/src/variorum/Intel/IvyBridge_3E.h
+++ b/src/variorum/Intel/IvyBridge_3E.h
@@ -12,61 +12,61 @@
 struct ivybridge_3e_offsets
 {
     /// @brief Address for MSR_PLATFORM_INFO.
-    const off_t msr_platform_info;
+    off_t msr_platform_info;
     /// @brief Address for IA32_TIME_STAMP_COUNTER.
-    const off_t ia32_time_stamp_counter;
+    off_t ia32_time_stamp_counter;
     /// @brief Address for IA32_PERF_CTL.
-    const off_t ia32_perf_ctl;
+    off_t ia32_perf_ctl;
     /// @brief Address for IA32_PERF_STATUS.
-    const off_t ia32_perf_status;
+    off_t ia32_perf_status;
     /// @brief Address for IA32_THERM_INTERRUPT.
-    const off_t ia32_therm_interrupt;
+    off_t ia32_therm_interrupt;
     /// @brief Address for IA32_THERM_STATUS.
-    const off_t ia32_therm_status;
+    off_t ia32_therm_status;
     /// @brief Address for THERM2_CTL.
-    const off_t msr_therm2_ctl;
+    off_t msr_therm2_ctl;
     /// @brief Address for IA32_MISC_ENABLE.
-    const off_t ia32_misc_enable;
+    off_t ia32_misc_enable;
     /// @brief Address for TEMPERATURE_TARGET.
-    const off_t msr_temperature_target;
+    off_t msr_temperature_target;
     /// @brief Address for TURBO_RATIO_LIMIT.
-    const off_t msr_turbo_ratio_limit;
+    off_t msr_turbo_ratio_limit;
     /// @brief Address for TURBO_RATIO_LIMIT1.
-    const off_t msr_turbo_ratio_limit1;
+    off_t msr_turbo_ratio_limit1;
     /// @brief Address for IA32_PACKAGE_THERM_STATUS.
-    const off_t ia32_package_therm_status;
+    off_t ia32_package_therm_status;
     /// @brief Address for IA32_PACKAGE_THERM_INTERRUPT.
-    const off_t ia32_package_therm_interrupt;
+    off_t ia32_package_therm_interrupt;
     /// @brief Address for IA32_FIXED_CTR_CTRL.
-    const off_t ia32_fixed_ctr_ctrl;
+    off_t ia32_fixed_ctr_ctrl;
     /// @brief Address for IA32_PERF_GLOBAL_STATUS.
-    const off_t ia32_perf_global_status;
+    off_t ia32_perf_global_status;
     /// @brief Address for IA32_PERF_GLOBAL_CTRL.
-    const off_t ia32_perf_global_ctrl;
+    off_t ia32_perf_global_ctrl;
     /// @brief Address for IA32_PERF_GLOBAL_OVF_CTRL.
-    const off_t ia32_perf_global_ovf_ctrl;
+    off_t ia32_perf_global_ovf_ctrl;
     /// @brief Address for RAPL_POWER_UNIT.
-    const off_t msr_rapl_power_unit;
+    off_t msr_rapl_power_unit;
     /// @brief Address for PKG_POWER_LIMIT.
-    const off_t msr_pkg_power_limit;
+    off_t msr_pkg_power_limit;
     /// @brief Address for PKG_ENERGY_STATUS.
-    const off_t msr_pkg_energy_status;
+    off_t msr_pkg_energy_status;
     /// @brief Address for PKG_PERF_STATUS.
-    const off_t msr_pkg_perf_status;
+    off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
-    const off_t msr_pkg_power_info;
+    off_t msr_pkg_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
-    const off_t msr_dram_power_limit;
+    off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.
-    const off_t msr_dram_energy_status;
+    off_t msr_dram_energy_status;
     /// @brief Address for DRAM_PERF_STATUS.
-    const off_t msr_dram_perf_status;
+    off_t msr_dram_perf_status;
     /// @brief Address for TURBO_ACTIVATION_RATIO.
-    const off_t msr_turbo_activation_ratio;
+    off_t msr_turbo_activation_ratio;
     /// @brief Address for IA32_MPERF.
-    const off_t ia32_mperf;
+    off_t ia32_mperf;
     /// @brief Address for IA32_APERF.
-    const off_t ia32_aperf;
+    off_t ia32_aperf;
     /// @brief Array of unique addresses for fixed counters.
     off_t ia32_fixed_counters[3];
     /// @brief Array of unique addresses for perfmon counters.
@@ -75,6 +75,7 @@ struct ivybridge_3e_offsets
     off_t ia32_perfevtsel_counters[8];
     /// @brief Array of unique addresses for pmon evtsel.
     off_t msrs_pcu_pmon_evtsel[4];
+    off_t msr_config_tdp_nominal;
 };
 
 int fm_06_3e_get_power_limits(int long_ver);
@@ -100,5 +101,7 @@ int fm_06_3e_get_turbo_status(void);
 int fm_06_3e_poll_power(FILE *output);
 
 int fm_06_3e_monitoring(FILE *output);
+
+int fm_06_3e_get_frequencies(void);
 
 #endif

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -24,7 +24,10 @@ static struct kabylake_9e_offsets msrs =
     .ia32_misc_enable             = 0x1A0,
     .msr_temperature_target       = 0x1A2,
     .msr_turbo_ratio_limit        = 0x1AD,
-    .msr_turbo_ratio_limit1       = 0x1AE,
+    .msr_turbo_ratio_limit_cores  = 0x1AE,
+    .msr_config_tdp_level1        = 0x649,
+    .msr_config_tdp_level2        = 0x64A,
+    .msr_config_tdp_nominal       = 0x648,
     .ia32_package_therm_status    = 0x1B1,
     .ia32_package_therm_interrupt = 0x1B2,
     .ia32_fixed_counters[0]       = 0x309,
@@ -153,8 +156,8 @@ int fm_06_9e_get_features(void)
             msrs.msr_temperature_target);
     fprintf(stdout, "msr_turbo_ratio_limit        = 0x%lx\n",
             msrs.msr_turbo_ratio_limit);
-    fprintf(stdout, "msr_turbo_ratio_limit1       = 0x%lx\n",
-            msrs.msr_turbo_ratio_limit1);
+    fprintf(stdout, "msr_turbo_ratio_limit_cores  = 0x%lx\n",
+            msrs.msr_turbo_ratio_limit_cores);
     fprintf(stdout, "ia32_package_therm_status    = 0x%lx\n",
             msrs.ia32_package_therm_status);
     fprintf(stdout, "ia32_package_therm_interrupt = 0x%lx\n",
@@ -333,5 +336,18 @@ int fm_06_9e_monitoring(FILE *output)
                              msrs.msr_dram_energy_status, msrs.ia32_fixed_counters,
                              msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl, msrs.ia32_aperf,
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
+    return 0;
+}
+
+int fm_06_9e_get_frequencies(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    get_available_frequencies_skx(stdout, &msrs.msr_platform_info,
+                                  &msrs.msr_turbo_ratio_limit, &msrs.msr_turbo_ratio_limit_cores,
+                                  &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2,
+                                  &msrs.msr_config_tdp_nominal);
     return 0;
 }

--- a/src/variorum/Intel/KabyLake_9E.h
+++ b/src/variorum/Intel/KabyLake_9E.h
@@ -12,61 +12,61 @@
 struct kabylake_9e_offsets
 {
     /// @brief Address for MSR_PLATFORM_INFO.
-    const off_t msr_platform_info;
+    off_t msr_platform_info;
     /// @brief Address for IA32_TIME_STAMP_COUNTER.
-    const off_t ia32_time_stamp_counter;
+    off_t ia32_time_stamp_counter;
     /// @brief Address for IA32_PERF_CTL.
-    const off_t ia32_perf_ctl;
+    off_t ia32_perf_ctl;
     /// @brief Address for IA32_PERF_STATUS.
-    const off_t ia32_perf_status;
+    off_t ia32_perf_status;
     /// @brief Address for IA32_THERM_INTERRUPT.
-    const off_t ia32_therm_interrupt;
+    off_t ia32_therm_interrupt;
     /// @brief Address for IA32_THERM_STATUS.
-    const off_t ia32_therm_status;
+    off_t ia32_therm_status;
     /// @brief Address for THERM2_CTL.
-    const off_t msr_therm2_ctl;
+    off_t msr_therm2_ctl;
     /// @brief Address for IA32_MISC_ENABLE.
-    const off_t ia32_misc_enable;
+    off_t ia32_misc_enable;
     /// @brief Address for TEMPERATURE_TARGET.
-    const off_t msr_temperature_target;
+    off_t msr_temperature_target;
     /// @brief Address for TURBO_RATIO_LIMIT.
-    const off_t msr_turbo_ratio_limit;
-    /// @brief Address for TURBO_RATIO_LIMIT1.
-    const off_t msr_turbo_ratio_limit1;
+    off_t msr_turbo_ratio_limit;
+    /// @brief Address for TURBO_RATIO_LIMIT_CORES.
+    off_t msr_turbo_ratio_limit_cores;
     /// @brief Address for IA32_PACKAGE_THERM_STATUS.
-    const off_t ia32_package_therm_status;
+    off_t ia32_package_therm_status;
     /// @brief Address for IA32_PACKAGE_THERM_INTERRUPT.
-    const off_t ia32_package_therm_interrupt;
+    off_t ia32_package_therm_interrupt;
     /// @brief Address for IA32_FIXED_CTR_CTRL.
-    const off_t ia32_fixed_ctr_ctrl;
+    off_t ia32_fixed_ctr_ctrl;
     /// @brief Address for IA32_PERF_GLOBAL_STATUS.
-    const off_t ia32_perf_global_status;
+    off_t ia32_perf_global_status;
     /// @brief Address for IA32_PERF_GLOBAL_CTRL.
-    const off_t ia32_perf_global_ctrl;
+    off_t ia32_perf_global_ctrl;
     /// @brief Address for IA32_PERF_GLOBAL_OVF_CTRL.
-    const off_t ia32_perf_global_ovf_ctrl;
+    off_t ia32_perf_global_ovf_ctrl;
     /// @brief Address for RAPL_POWER_UNIT.
-    const off_t msr_rapl_power_unit;
+    off_t msr_rapl_power_unit;
     /// @brief Address for PKG_POWER_LIMIT.
-    const off_t msr_pkg_power_limit;
+    off_t msr_pkg_power_limit;
     /// @brief Address for PKG_ENERGY_STATUS.
-    const off_t msr_pkg_energy_status;
+    off_t msr_pkg_energy_status;
     /// @brief Address for PKG_PERF_STATUS.
-    const off_t msr_pkg_perf_status;
+    off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
-    const off_t msr_pkg_power_info;
+    off_t msr_pkg_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
-    const off_t msr_dram_power_limit;
+    off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.
-    const off_t msr_dram_energy_status;
+    off_t msr_dram_energy_status;
     /// @brief Address for DRAM_PERF_STATUS.
-    const off_t msr_dram_perf_status;
+    off_t msr_dram_perf_status;
     /// @brief Address for TURBO_ACTIVATION_RATIO.
-    const off_t msr_turbo_activation_ratio;
+    off_t msr_turbo_activation_ratio;
     /// @brief Address for IA32_MPERF.
-    const off_t ia32_mperf;
+    off_t ia32_mperf;
     /// @brief Address for IA32_APERF.
-    const off_t ia32_aperf;
+    off_t ia32_aperf;
     /// @brief Array of unique addresses for fixed counters.
     off_t ia32_fixed_counters[3];
     /// @brief Array of unique addresses for perfmon counters.
@@ -75,6 +75,9 @@ struct kabylake_9e_offsets
     off_t ia32_perfevtsel_counters[8];
     /// @brief Array of unique addresses for pmon evtsel.
     off_t msrs_pcu_pmon_evtsel[4];
+    off_t msr_config_tdp_level1;
+    off_t msr_config_tdp_level2;
+    off_t msr_config_tdp_nominal;
 };
 
 int fm_06_9e_get_power_limits(int long_ver);
@@ -94,5 +97,7 @@ int fm_06_9e_get_power(int long_ver);
 int fm_06_9e_poll_power(FILE *output);
 
 int fm_06_9e_monitoring(FILE *output);
+
+int fm_06_9e_get_frequencies(void);
 
 #endif

--- a/src/variorum/Intel/SandyBridge_2A.h
+++ b/src/variorum/Intel/SandyBridge_2A.h
@@ -12,61 +12,59 @@
 struct sandybridge_2a_offsets
 {
     /// @brief Address for MSR_PLATFORM_INFO.
-    const off_t msr_platform_info;
+    off_t msr_platform_info;
     /// @brief Address for IA32_TIME_STAMP_COUNTER.
-    const off_t ia32_time_stamp_counter;
+    off_t ia32_time_stamp_counter;
     /// @brief Address for IA32_PERF_CTL.
-    const off_t ia32_perf_ctl;
+    off_t ia32_perf_ctl;
     /// @brief Address for IA32_PERF_STATUS.
-    const off_t ia32_perf_status;
+    off_t ia32_perf_status;
     /// @brief Address for IA32_THERM_INTERRUPT.
-    const off_t ia32_therm_interrupt;
+    off_t ia32_therm_interrupt;
     /// @brief Address for IA32_THERM_STATUS.
-    const off_t ia32_therm_status;
+    off_t ia32_therm_status;
     /// @brief Address for THERM2_CTL.
-    const off_t msr_therm2_ctl;
+    off_t msr_therm2_ctl;
     /// @brief Address for IA32_MISC_ENABLE.
-    const off_t ia32_misc_enable;
+    off_t ia32_misc_enable;
     /// @brief Address for TEMPERATURE_TARGET.
-    const off_t msr_temperature_target;
+    off_t msr_temperature_target;
     /// @brief Address for TURBO_RATIO_LIMIT.
-    const off_t msr_turbo_ratio_limit;
-    /// @brief Address for TURBO_RATIO_LIMIT1.
-    const off_t msr_turbo_ratio_limit1;
+    off_t msr_turbo_ratio_limit;
     /// @brief Address for IA32_PACKAGE_THERM_STATUS.
-    const off_t ia32_package_therm_status;
+    off_t ia32_package_therm_status;
     /// @brief Address for IA32_PACKAGE_THERM_INTERRUPT.
-    const off_t ia32_package_therm_interrupt;
+    off_t ia32_package_therm_interrupt;
     /// @brief Address for IA32_FIXED_CTR_CTRL.
-    const off_t ia32_fixed_ctr_ctrl;
+    off_t ia32_fixed_ctr_ctrl;
     /// @brief Address for IA32_PERF_GLOBAL_STATUS.
-    const off_t ia32_perf_global_status;
+    off_t ia32_perf_global_status;
     /// @brief Address for IA32_PERF_GLOBAL_CTRL.
-    const off_t ia32_perf_global_ctrl;
+    off_t ia32_perf_global_ctrl;
     /// @brief Address for IA32_PERF_GLOBAL_OVF_CTRL.
-    const off_t ia32_perf_global_ovf_ctrl;
+    off_t ia32_perf_global_ovf_ctrl;
     /// @brief Address for RAPL_POWER_UNIT.
-    const off_t msr_rapl_power_unit;
+    off_t msr_rapl_power_unit;
     /// @brief Address for PKG_POWER_LIMIT.
-    const off_t msr_pkg_power_limit;
+    off_t msr_pkg_power_limit;
     /// @brief Address for PKG_ENERGY_STATUS.
-    const off_t msr_pkg_energy_status;
+    off_t msr_pkg_energy_status;
     /// @brief Address for PKG_PERF_STATUS.
-    const off_t msr_pkg_perf_status;
+    off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
-    const off_t msr_pkg_power_info;
+    off_t msr_pkg_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
-    const off_t msr_dram_power_limit;
+    off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.
-    const off_t msr_dram_energy_status;
+    off_t msr_dram_energy_status;
     /// @brief Address for DRAM_PERF_STATUS.
-    const off_t msr_dram_perf_status;
+    off_t msr_dram_perf_status;
     /// @brief Address for TURBO_ACTIVATION_RATIO.
-    const off_t msr_turbo_activation_ratio;
+    off_t msr_turbo_activation_ratio;
     /// @brief Address for IA32_MPERF.
-    const off_t ia32_mperf;
+    off_t ia32_mperf;
     /// @brief Address for IA32_APERF.
-    const off_t ia32_aperf;
+    off_t ia32_aperf;
     /// @brief Array of unique addresses for fixed counters.
     off_t ia32_fixed_counters[3];
     /// @brief Array of unique addresses for perfmon counters.
@@ -100,5 +98,7 @@ int fm_06_2a_get_turbo_status(void);
 int fm_06_2a_poll_power(FILE *output);
 
 int fm_06_2a_monitoring(FILE *output);
+
+int fm_06_2a_get_frequencies(void);
 
 #endif

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <SandyBridge_2A.h>
+#include <SandyBridge_2D.h>
 #include <clocks_features.h>
 #include <config_architecture.h>
 #include <counters_features.h>
@@ -15,7 +15,7 @@
 #include <thermal_features.h>
 #include <variorum_error.h>
 
-static struct sandybridge_2a_offsets msrs =
+static struct sandybridge_2d_offsets msrs =
 {
     .msr_platform_info            = 0xCE,
     .ia32_time_stamp_counter      = 0x10,
@@ -26,6 +26,7 @@ static struct sandybridge_2a_offsets msrs =
     .ia32_misc_enable             = 0x1A0,
     .msr_temperature_target       = 0x1A2,
     .msr_turbo_ratio_limit        = 0x1AD,
+    .msr_turbo_ratio_limit1       = 0x1AE,
     .ia32_package_therm_status    = 0x1B1,
     .ia32_package_therm_interrupt = 0x1B2,
     .ia32_fixed_counters[0]       = 0x309,
@@ -59,7 +60,7 @@ static struct sandybridge_2a_offsets msrs =
     .ia32_perfevtsel_counters[7]  = 0x18D,
 };
 
-int fm_06_2a_get_power_limits(int long_ver)
+int fm_06_2d_get_power_limits(int long_ver)
 {
     int socket;
     int nsockets, ncores, nthreads;
@@ -121,7 +122,7 @@ int fm_06_2a_get_power_limits(int long_ver)
     return 0;
 }
 
-int fm_06_2a_set_power_limits(int package_power_limit)
+int fm_06_2d_set_power_limits(int package_power_limit)
 {
     int socket;
     int nsockets, ncores, nthreads;
@@ -139,7 +140,7 @@ int fm_06_2a_set_power_limits(int package_power_limit)
     return 0;
 }
 
-int fm_06_2a_get_features(void)
+int fm_06_2d_get_features(void)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -162,6 +163,8 @@ int fm_06_2a_get_features(void)
             msrs.msr_temperature_target);
     fprintf(stdout, "msr_turbo_ratio_limit        = 0x%lx\n",
             msrs.msr_turbo_ratio_limit);
+    fprintf(stdout, "msr_turbo_ratio_limit1       = 0x%lx\n",
+            msrs.msr_turbo_ratio_limit1);
     fprintf(stdout, "ia32_package_therm_status    = 0x%lx\n",
             msrs.ia32_package_therm_status);
     fprintf(stdout, "ia32_package_therm_interrupt = 0x%lx\n",
@@ -225,7 +228,7 @@ int fm_06_2a_get_features(void)
     return 0;
 }
 
-int fm_06_2a_get_thermals(int long_ver)
+int fm_06_2d_get_thermals(int long_ver)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -244,7 +247,7 @@ int fm_06_2a_get_thermals(int long_ver)
     return 0;
 }
 
-int fm_06_2a_get_counters(int long_ver)
+int fm_06_2d_get_counters(int long_ver)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -267,7 +270,7 @@ int fm_06_2a_get_counters(int long_ver)
     return 0;
 }
 
-int fm_06_2a_get_clocks(int long_ver)
+int fm_06_2d_get_clocks(int long_ver)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -288,7 +291,7 @@ int fm_06_2a_get_clocks(int long_ver)
     return 0;
 }
 
-int fm_06_2a_get_power(int long_ver)
+int fm_06_2d_get_power(int long_ver)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -307,7 +310,7 @@ int fm_06_2a_get_power(int long_ver)
     return 0;
 }
 
-int fm_06_2a_enable_turbo(void)
+int fm_06_2d_enable_turbo(void)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -319,7 +322,7 @@ int fm_06_2a_enable_turbo(void)
     return 0;
 }
 
-int fm_06_2a_disable_turbo(void)
+int fm_06_2d_disable_turbo(void)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -331,7 +334,7 @@ int fm_06_2a_disable_turbo(void)
     return 0;
 }
 
-int fm_06_2a_get_turbo_status(void)
+int fm_06_2d_get_turbo_status(void)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -343,7 +346,7 @@ int fm_06_2a_get_turbo_status(void)
     return 0;
 }
 
-int fm_06_2a_poll_power(FILE *output)
+int fm_06_2d_poll_power(FILE *output)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -355,7 +358,7 @@ int fm_06_2a_poll_power(FILE *output)
     return 0;
 }
 
-int fm_06_2a_monitoring(FILE *output)
+int fm_06_2d_monitoring(FILE *output)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -369,7 +372,7 @@ int fm_06_2a_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_2a_get_frequencies(void)
+int fm_06_2d_get_frequencies(void)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -378,6 +381,7 @@ int fm_06_2a_get_frequencies(void)
     get_available_frequencies(stdout, &msrs.msr_platform_info,
                               &msrs.msr_turbo_ratio_limit, NULL,
                               NULL, NULL, NULL);
+
     //    /* Turbo Range
     //     * Default ratio for 1C Max Turbo == P01
     //     * All core turbo == P0n

--- a/src/variorum/Intel/SandyBridge_2D.h
+++ b/src/variorum/Intel/SandyBridge_2D.h
@@ -3,13 +3,13 @@
 //
 // SPDX-License-Identifier: MIT
 
-#ifndef SKYLAKE_55_H_INCLUDE
-#define SKYLAKE_55_H_INCLUDE
+#ifndef SANDYBRIDGE_2D_H_INCLUDE
+#define SANDYBRIDGE_2D_H_INCLUDE
 
 #include <sys/types.h>
 
-/// @brief List of unique addresses for Skylake Family/Model 55H.
-struct skylake_55_offsets
+/// @brief List of unique addresses for Sandy Bridge Family/Model 2DH.
+struct sandybridge_2d_offsets
 {
     /// @brief Address for MSR_PLATFORM_INFO.
     off_t msr_platform_info;
@@ -31,8 +31,8 @@ struct skylake_55_offsets
     off_t msr_temperature_target;
     /// @brief Address for TURBO_RATIO_LIMIT.
     off_t msr_turbo_ratio_limit;
-    /// @brief Address for TURBO_RATIO_LIMIT_CORES.
-    off_t msr_turbo_ratio_limit_cores;
+    /// @brief Address for TURBO_RATIO_LIMIT1.
+    off_t msr_turbo_ratio_limit1;
     /// @brief Address for IA32_PACKAGE_THERM_STATUS.
     off_t ia32_package_therm_status;
     /// @brief Address for IA32_PACKAGE_THERM_INTERRUPT.
@@ -75,31 +75,32 @@ struct skylake_55_offsets
     off_t ia32_perfevtsel_counters[8];
     /// @brief Array of unique addresses for pmon evtsel.
     off_t msrs_pcu_pmon_evtsel[4];
-    off_t msr_config_tdp_level1;
-    off_t msr_config_tdp_level2;
-    off_t msr_config_tdp_nominal;
 };
 
-int fm_06_55_get_power_limits(int long_ver);
+int fm_06_2d_get_power_limits(int long_ver);
 
-int fm_06_55_set_power_limits(int package_power_limit);
+int fm_06_2d_set_power_limits(int package_power_limit);
 
-int fm_06_55_get_features(void);
+int fm_06_2d_get_features(void);
 
-int fm_06_55_get_thermals(int long_ver);
+int fm_06_2d_get_thermals(int long_ver);
 
-int fm_06_55_get_counters(int long_ver);
+int fm_06_2d_get_counters(int long_ver);
 
-int fm_06_55_get_clocks(int long_ver);
+int fm_06_2d_get_clocks(int long_ver);
 
-int fm_06_55_get_power(int long_ver);
+int fm_06_2d_get_power(int long_ver);
 
-int fm_06_55_poll_power(FILE *output);
+int fm_06_2d_enable_turbo(void);
 
-int fm_06_55_monitoring(FILE *output);
+int fm_06_2d_disable_turbo(void);
 
-int fm_06_55_set_frequency(int core_freq_mhz);
+int fm_06_2d_get_turbo_status(void);
 
-int fm_06_55_get_frequencies(void);
+int fm_06_2d_poll_power(FILE *output);
+
+int fm_06_2d_monitoring(FILE *output);
+
+int fm_06_2d_get_frequencies(void);
 
 #endif

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -23,8 +23,10 @@ static struct skylake_55_offsets msrs =
     .ia32_misc_enable             = 0x1A0,
     .msr_temperature_target       = 0x1A2,
     .msr_turbo_ratio_limit        = 0x1AD,
-    .msr_turbo_ratio_limit1       = 0x1AE,
-    .msr_turbo_ratio_limit2       = 0x1AF,
+    .msr_turbo_ratio_limit_cores  = 0x1AE,
+    .msr_config_tdp_level1        = 0x649,
+    .msr_config_tdp_level2        = 0x64A,
+    .msr_config_tdp_nominal       = 0x648,
     .ia32_package_therm_status    = 0x1B1,
     .ia32_package_therm_interrupt = 0x1B2,
     .ia32_fixed_counters[0]       = 0x309,
@@ -152,10 +154,8 @@ int fm_06_55_get_features(void)
             msrs.msr_temperature_target);
     fprintf(stdout, "msr_turbo_ratio_limit        = 0x%lx\n",
             msrs.msr_turbo_ratio_limit);
-    fprintf(stdout, "msr_turbo_ratio_limit1       = 0x%lx\n",
-            msrs.msr_turbo_ratio_limit1);
-    fprintf(stdout, "msr_turbo_ratio_limit2       = 0x%lx\n",
-            msrs.msr_turbo_ratio_limit2);
+    fprintf(stdout, "msr_turbo_ratio_limit_cores  = 0x%lx\n",
+            msrs.msr_turbo_ratio_limit_cores);
     fprintf(stdout, "ia32_package_therm_status    = 0x%lx\n",
             msrs.ia32_package_therm_status);
     fprintf(stdout, "ia32_package_therm_interrupt = 0x%lx\n",
@@ -347,5 +347,18 @@ int fm_06_55_set_frequency(int core_freq_mhz)
 #endif
 
     set_p_state(core_freq_mhz, CORE, msrs.ia32_perf_status, msrs.ia32_perf_ctl);
+    return 0;
+}
+
+int fm_06_55_get_frequencies(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    get_available_frequencies_skx(stdout, &msrs.msr_platform_info,
+                                  &msrs.msr_turbo_ratio_limit, &msrs.msr_turbo_ratio_limit_cores,
+                                  &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2,
+                                  &msrs.msr_config_tdp_nominal);
     return 0;
 }

--- a/src/variorum/Intel/clocks_features.h
+++ b/src/variorum/Intel/clocks_features.h
@@ -117,6 +117,22 @@ void print_clocks_data(FILE *writedest,
                        off_t msr_platform_info,
                        enum ctl_domains_e control_domain);
 
+void get_available_frequencies(FILE *writedest,
+                               off_t *msr_platform_info,
+                               off_t *msr_turbo_ratio_limit,
+                               off_t *msr_turbo_ratio_limit_cores,
+                               off_t *msr_config_tdp_l1,
+                               off_t *msr_config_tdp_l2,
+                               off_t *msr_config_tdp_nominal);
+
+void get_available_frequencies_skx(FILE *writedest,
+                                   off_t *msr_platform_info,
+                                   off_t *msr_turbo_ratio_limit,
+                                   off_t *msr_turbo_ratio_limit_cores,
+                                   off_t *msr_config_tdp_l1,
+                                   off_t *msr_config_tdp_l2,
+                                   off_t *msr_config_tdp_nominal);
+
 ///// @brief Print current p-state.
 /////
 ///// @param [in] writedest File stream where output will be written to.

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -10,6 +10,7 @@
 #include <config_architecture.h>
 #include <variorum_error.h>
 #include <SandyBridge_2A.h>
+#include <SandyBridge_2D.h>
 #include <IvyBridge_3E.h>
 #include <Broadwell_4F.h>
 #include <Haswell_3F.h>
@@ -49,6 +50,10 @@ int gpu_power_ratio_unimplemented(int long_ver)
     return 0;
 }
 
+/* 02/25/2019 SB
+ *    If implementation is identical, have function pointer use the same function.
+ *    If it is different, implement a new function.
+ */
 int set_intel_func_ptrs(void)
 {
     int err = 0;
@@ -74,7 +79,28 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_poll_power = fm_06_2a_poll_power;
         g_platform.variorum_monitoring = fm_06_2a_monitoring;
         //g_platform.variorum_cap_each_core_frequency =
-        //fm_06_2a_set_frequency;
+        //    fm_06_2a_set_frequency;
+        g_platform.variorum_print_available_frequencies =
+            fm_06_2a_get_frequencies;
+    }
+    else if (*g_platform.intel_arch == FM_06_2D)
+    {
+        g_platform.variorum_dump_power_limits = fm_06_2d_get_power_limits;
+        g_platform.variorum_set_each_socket_power_limit = fm_06_2d_set_power_limits;
+        g_platform.variorum_print_features = fm_06_2d_get_features;
+        g_platform.variorum_dump_thermals = fm_06_2d_get_thermals;
+        g_platform.variorum_dump_counters = fm_06_2d_get_counters;
+        g_platform.variorum_dump_clocks = fm_06_2d_get_clocks;
+        g_platform.variorum_dump_power = fm_06_2d_get_power;
+        g_platform.variorum_dump_turbo = fm_06_2d_get_turbo_status;
+        g_platform.variorum_enable_turbo = fm_06_2d_enable_turbo;
+        g_platform.variorum_disable_turbo = fm_06_2d_disable_turbo;
+        g_platform.variorum_poll_power = fm_06_2d_poll_power;
+        g_platform.variorum_monitoring = fm_06_2d_monitoring;
+        //g_platform.variorum_cap_each_core_frequency =
+        //    fm_06_2d_set_frequency;
+        g_platform.variorum_print_available_frequencies =
+            fm_06_2d_get_frequencies;
     }
     // Ivy Bridge 06_3E
     else if (*g_platform.intel_arch == FM_06_3E)
@@ -93,7 +119,9 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_poll_power = fm_06_3e_poll_power;
         g_platform.variorum_monitoring = fm_06_3e_monitoring;
         //g_platform.variorum_cap_each_core_frequency =
-        //fm_06_3e_set_frequency;
+        //    fm_06_3e_set_frequency;
+        g_platform.variorum_print_available_frequencies =
+            fm_06_3e_get_frequencies;
     }
     // Haswell 06_3F
     else if (*g_platform.intel_arch == FM_06_3F)
@@ -112,7 +140,9 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_poll_power = fm_06_3f_poll_power;
         g_platform.variorum_monitoring = fm_06_3f_monitoring;
         //g_platform.variorum_cap_each_core_frequency =
-        //fm_06_3f_set_frequency;
+        //    fm_06_3f_set_frequency;
+        g_platform.variorum_print_available_frequencies =
+            fm_06_3f_get_frequencies;
     }
     // Broadwell 06_4F
     else if (*g_platform.intel_arch == FM_06_4F)
@@ -131,11 +161,13 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_poll_power = fm_06_4f_poll_power;
         g_platform.variorum_monitoring = fm_06_4f_monitoring;
         //g_platform.variorum_cap_each_core_frequency =
-        //fm_06_4f_set_frequency;
+        //    fm_06_4f_set_frequency;
         g_platform.variorum_get_node_power_json =
             fm_06_4f_get_node_power_json;
         g_platform.variorum_set_best_effort_node_power_limit =
             fm_06_4f_set_best_effort_node_power_limit;
+        g_platform.variorum_print_available_frequencies =
+            fm_06_4f_get_frequencies;
     }
     // Skylake 06_55
     else if (*g_platform.intel_arch == FM_06_55)
@@ -154,6 +186,8 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_poll_power = fm_06_55_poll_power;
         g_platform.variorum_monitoring = fm_06_55_monitoring;
         g_platform.variorum_cap_each_core_frequency = fm_06_55_set_frequency;
+        g_platform.variorum_print_available_frequencies =
+            fm_06_55_get_frequencies;
     }
     // Kaby Lake 06_9E
     else if (*g_platform.intel_arch == FM_06_9E)
@@ -171,6 +205,8 @@ int set_intel_func_ptrs(void)
         //g_platform.variorum_disable_turbo = fm_06_9e_disable_turbo;
         g_platform.variorum_poll_power = fm_06_9e_poll_power;
         g_platform.variorum_monitoring = fm_06_9e_monitoring;
+        g_platform.variorum_print_available_frequencies =
+            fm_06_9e_get_frequencies;
     }
     else
     {

--- a/src/variorum/Intel/misc_features.h
+++ b/src/variorum/Intel/misc_features.h
@@ -14,7 +14,30 @@
 /// @param [in] msr_platform_info Unique MSR address for MSR_PLATFORM_INFO.
 ///
 /// @return Maximum non-turbo ratio in Hz.
-int get_max_non_turbo_ratio(off_t msr_platform_info);
+int get_max_non_turbo_ratio(off_t msr_platform_info,
+                            int *val);
+
+int get_max_efficiency_ratio(off_t msr_platform_info,
+                             int *val);
+
+int get_min_operating_ratio(off_t msr_platform_info,
+                            int *val);
+
+int get_turbo_ratio_limit(off_t msr_turbo_ratio_limit);
+
+int get_turbo_ratio_limits(off_t msr_turbo_ratio_limit,
+                           off_t msr_turbo_ratio_limit1);
+
+int get_turbo_ratio_limits_skx(off_t msr_turbo_ratio_limit,
+                               off_t msr_turbo_ratio_limit_cores);
+
+int get_avx_limits(off_t *msr_platform_info,
+                   off_t *msr_config_tdp_l1,
+                   off_t *msr_config_tdp_l2,
+                   off_t *msr_config_tdp_nominal);
+
+int config_tdp(int nlevels,
+               off_t msr_config_tdp_level);
 
 /// NOTE about Turbo bit -- Pulled from the Intel Vol. 4 2-154 Documentation
 /// When set to 1 on processors that support Intel Turbo Boost Technology,

--- a/src/variorum/Intel/msr_core.c
+++ b/src/variorum/Intel/msr_core.c
@@ -6,6 +6,8 @@
 // Necessary for pread & pwrite.
 #define _XOPEN_SOURCE 500
 
+#define USE_MSR_SAFE_BEFORE_1_5_0
+
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/ioctl.h>
@@ -207,10 +209,11 @@ static int do_batch_op(int batchnum, int type)
         {
             if (batch->ops[i].err)
             {
-                fprintf(stderr, "CPU %d, RDMSR 0x%x, ERR (%s)\n", batch->ops[i].cpu,
+                fprintf(stderr, "    CPU %3d, MSR 0x%x, ERR (%s)\n", batch->ops[i].cpu,
                         batch->ops[i].msr, strerror(batch->ops[i].err));
             }
         }
+        return res;
     }
 #ifdef BATCH_DEBUG
     int k;
@@ -636,7 +639,8 @@ int load_thread_batch(off_t msr, uint64_t **val, int batchnum)
 
 int read_batch(const int batchnum)
 {
-    return do_batch_op(batchnum, BATCH_READ);
+    int err = do_batch_op(batchnum, BATCH_READ);
+    return err;
 }
 
 int write_batch(const int batchnum)

--- a/src/variorum/Intel/msr_core.h
+++ b/src/variorum/Intel/msr_core.h
@@ -87,6 +87,13 @@ enum variorum_data_type_e
     /// @brief User-defined batch MSR data.
     USR_BATCH10 = 28,
     PLATFORM_INFO = 29,
+    MIN_OPERATING_RATIO = 30,
+    MAX_EFFICIENCY = 31,
+    TURBO_RATIO_LIMIT = 32,
+    TURBO_RATIO_LIMIT1 = 33,
+    TURBO_RATIO_LIMIT_CORES = 34,
+    TDP_DEFS = 35,
+    TDP_CONFIG = 36,
 };
 
 /// @brief Enum encompassing batch operations.

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -221,6 +221,7 @@ void variorum_init_func_ptrs()
     g_platform.variorum_cap_each_core_frequency = NULL;
     g_platform.variorum_monitoring = NULL;
     g_platform.variorum_get_node_power_json = NULL;
+    g_platform.variorum_print_available_frequencies = NULL;
 }
 
 int variorum_set_func_ptrs()

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -192,6 +192,11 @@ struct platform
     /// @return Error code.
     int (*variorum_get_node_power_json)(json_t *get_power_obj);
 
+    /// @brief Function pointer to get list of available frequencies.
+    ///
+    /// @return Error code.
+    int (*variorum_print_available_frequencies)(void);
+
     /******************************/
     /* Platform-Specific Topology */
     /******************************/

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -822,3 +822,30 @@ int variorum_get_node_power_json(json_t *get_power_obj)
     return err;
 }
 
+int variorum_print_available_frequencies(void)
+{
+    int err = 0;
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    if (g_platform.variorum_print_available_frequencies == NULL)
+    {
+        variorum_error_handler("Feature not yet implemented or is not supported",
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               __FUNCTION__, __LINE__);
+        return 0;
+    }
+    err = g_platform.variorum_print_available_frequencies();
+    if (err)
+    {
+        return -1;
+    }
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -163,6 +163,11 @@ int variorum_print_verbose_gpu_utilization(void);
 /// @return Error code.
 int variorum_print_gpu_utilization(void);
 
+/// @brief Print list of available frequencies from p-states, turbo, AVX, etc. ranges.
+///
+/// @return Error code.
+int variorum_print_available_frequencies(void);
+
 /***************************/
 /* Enable/Disable Features */
 /***************************/


### PR DESCRIPTION
Check this API across older generations of Intel architectures. Some will not have AVX calls.

- [x] Test on different Intel generations -- catalyst, quartz, thompson
- [x] Which generation did avx frequencies appear? MSRs needed to read these frequencies are not in our whitelists.
- [x] Confirm which frequency ranges are available on which platforms (skylake and beyond use a different nomenclature for defining the turbo frequencies)