### PR TITLE
WIP: Front-facing APIs for MSR access for GEOPM integration.

### DIFF
--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
 #include <Broadwell_4F.h>
 #include <clocks_features.h>
 #include <config_architecture.h>
@@ -398,3 +397,51 @@ int fm_06_4f_monitoring(FILE *output)
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
     return 0;
 }
+
+int fm_06_4f_init_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    init_msr();
+    return 0;
+}
+
+int fm_06_4f_finalize_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    finalize_msr();
+    return 0;
+}
+
+int fm_06_4f_read_msr(int cpuid, unsigned long offset, unsigned long *value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    int err = read_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+int fm_06_4f_write_msr(int cpuid, unsigned long offset, unsigned long value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+    int err = write_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}
+

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -100,4 +100,12 @@ int fm_06_4f_get_turbo_status(void);
 int fm_06_4f_poll_power(FILE *output);
 
 int fm_06_4f_monitoring(FILE *output);
+
+int fm_06_4f_init_msr(void);
+
+int fm_06_4f_finalize_msr(void);
+
+int fm_06_4f_read_msr(int cpuid, unsigned long offset, unsigned long *value);
+
+int fm_06_4f_write_msr(int cpuid, unsigned long offset, unsigned long value);
 #endif

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -383,3 +383,50 @@ int fm_06_3f_monitoring(FILE *output)
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
     return 0;
 }
+
+int fm_06_3f_init_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    init_msr();
+    return 0;
+}
+
+int fm_06_3f_finalize_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    finalize_msr();
+    return 0;
+}
+
+int fm_06_3f_read_msr(int cpuid, unsigned long offset, unsigned long *value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    int err = read_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+int fm_06_3f_write_msr(int cpuid, unsigned long offset, unsigned long value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+    int err = write_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}

--- a/src/variorum/Intel/Haswell_3F.h
+++ b/src/variorum/Intel/Haswell_3F.h
@@ -100,4 +100,12 @@ int fm_06_3f_get_turbo_status(void);
 int fm_06_3f_poll_power(FILE *output);
 
 int fm_06_3f_monitoring(FILE *output);
+
+int fm_06_3f_init_msr(void);
+
+int fm_06_3f_finalize_msr(void);
+
+int fm_06_3f_read_msr(int cpuid, unsigned long offset, unsigned long *value);
+
+int fm_06_3f_write_msr(int cpuid, unsigned long offset, unsigned long value);
 #endif

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -398,3 +398,50 @@ int fm_06_3e_monitoring(FILE *output)
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
     return 0;
 }
+
+int fm_06_3e_init_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    init_msr();
+    return 0;
+}
+
+int fm_06_3e_finalize_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    finalize_msr();
+    return 0;
+}
+
+int fm_06_3e_read_msr(int cpuid, unsigned long offset, unsigned long *value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    int err = read_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+int fm_06_3e_write_msr(int cpuid, unsigned long offset, unsigned long value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+    int err = write_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}

--- a/src/variorum/Intel/IvyBridge_3E.h
+++ b/src/variorum/Intel/IvyBridge_3E.h
@@ -101,4 +101,11 @@ int fm_06_3e_poll_power(FILE *output);
 
 int fm_06_3e_monitoring(FILE *output);
 
+int fm_06_3e_init_msr(void);
+
+int fm_06_3e_finalize_msr(void);
+
+int fm_06_3e_read_msr(int cpuid, unsigned long offset, unsigned long *value);
+
+int fm_06_3e_write_msr(int cpuid, unsigned long offset, unsigned long value);
 #endif

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -335,3 +335,50 @@ int fm_06_9e_monitoring(FILE *output)
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
     return 0;
 }
+
+int fm_06_9e_init_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    init_msr();
+    return 0;
+}
+
+int fm_06_9e_finalize_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    finalize_msr();
+    return 0;
+}
+
+int fm_06_9e_read_msr(int cpuid, unsigned long offset, unsigned long *value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    int err = read_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+int fm_06_9e_write_msr(int cpuid, unsigned long offset, unsigned long value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+    int err = write_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}

--- a/src/variorum/Intel/KabyLake_9E.h
+++ b/src/variorum/Intel/KabyLake_9E.h
@@ -95,4 +95,11 @@ int fm_06_9e_poll_power(FILE *output);
 
 int fm_06_9e_monitoring(FILE *output);
 
+int fm_06_9e_init_msr(void);
+
+int fm_06_9e_finalize_msr(void);
+
+int fm_06_9e_read_msr(int cpuid, unsigned long offset, unsigned long *value);
+
+int fm_06_9e_write_msr(int cpuid, unsigned long offset, unsigned long value);
 #endif

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -366,3 +366,50 @@ int fm_06_2a_monitoring(FILE *output)
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
     return 0;
 }
+
+int fm_06_2a_init_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    init_msr();
+    return 0;
+}
+
+int fm_06_2a_finalize_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    finalize_msr();
+    return 0;
+}
+
+int fm_06_2a_read_msr(int cpuid, unsigned long offset, unsigned long *value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    int err = read_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+int fm_06_2a_write_msr(int cpuid, unsigned long offset, unsigned long value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+    int err = write_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}

--- a/src/variorum/Intel/SandyBridge_2A.h
+++ b/src/variorum/Intel/SandyBridge_2A.h
@@ -101,4 +101,11 @@ int fm_06_2a_poll_power(FILE *output);
 
 int fm_06_2a_monitoring(FILE *output);
 
+int fm_06_2a_init_msr(void);
+
+int fm_06_2a_finalize_msr(void);
+
+int fm_06_2a_read_msr(int cpuid, unsigned long offset, unsigned long *value);
+
+int fm_06_2a_write_msr(int cpuid, unsigned long offset, unsigned long value);
 #endif

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -349,3 +349,50 @@ int fm_06_55_set_frequency(int core_freq_mhz)
     set_p_state(core_freq_mhz, CORE, msrs.ia32_perf_status, msrs.ia32_perf_ctl);
     return 0;
 }
+
+int fm_06_55_init_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    init_msr();
+    return 0;
+}
+
+int fm_06_55_finalize_msr(void)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    finalize_msr();
+    return 0;
+}
+
+int fm_06_55_read_msr(int cpuid, unsigned long offset, unsigned long *value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    int err = read_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+int fm_06_55_write_msr(int cpuid, unsigned long offset, unsigned long value)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+    int err = write_msr_by_coord(cpuid, 0, 0, offset, value);
+    if (err < 0)
+    {
+        return -1;
+    }
+    return 0;
+}

--- a/src/variorum/Intel/Skylake_55.h
+++ b/src/variorum/Intel/Skylake_55.h
@@ -99,4 +99,11 @@ int fm_06_55_monitoring(FILE *output);
 
 int fm_06_55_set_frequency(int core_freq_mhz);
 
+int fm_06_55_init_msr(void);
+
+int fm_06_55_finalize_msr(void);
+
+int fm_06_55_read_msr(int cpuid, unsigned long offset, unsigned long *value);
+
+int fm_06_55_write_msr(int cpuid, unsigned long offset, unsigned long value);
 #endif

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -71,6 +71,10 @@ int set_intel_func_ptrs(void)
         g_platform.disable_turbo = fm_06_2a_disable_turbo;
         g_platform.poll_power = fm_06_2a_poll_power;
         g_platform.monitoring = fm_06_2a_monitoring;
+        g_platform.init_msr = fm_06_2a_init_msr;
+        g_platform.finalize_msr = fm_06_2a_finalize_msr;
+        g_platform.read_msr = fm_06_2a_read_msr;
+        g_platform.write_msr = fm_06_2a_write_msr;
         //g_platform.set_each_core_frequency = fm_06_2a_set_frequency;
     }
     // Ivy Bridge 06_3E
@@ -88,6 +92,10 @@ int set_intel_func_ptrs(void)
         g_platform.disable_turbo = fm_06_3e_disable_turbo;
         g_platform.poll_power = fm_06_3e_poll_power;
         g_platform.monitoring = fm_06_3e_monitoring;
+        g_platform.init_msr = fm_06_3e_init_msr;
+        g_platform.finalize_msr = fm_06_3e_finalize_msr;
+        g_platform.read_msr = fm_06_3e_read_msr;
+        g_platform.write_msr = fm_06_3e_write_msr;
         //g_platform.set_each_core_frequency = fm_06_3e_set_frequency;
     }
     // Haswell 06_3F
@@ -105,6 +113,10 @@ int set_intel_func_ptrs(void)
         g_platform.disable_turbo = fm_06_3f_disable_turbo;
         g_platform.poll_power = fm_06_3f_poll_power;
         g_platform.monitoring = fm_06_3f_monitoring;
+        g_platform.init_msr = fm_06_3f_init_msr;
+        g_platform.finalize_msr = fm_06_3f_finalize_msr;
+        g_platform.read_msr = fm_06_3f_read_msr;
+        g_platform.write_msr = fm_06_3f_write_msr;
         //g_platform.set_each_core_frequency = fm_06_3f_set_frequency;
     }
     // Broadwell 06_4F
@@ -122,6 +134,10 @@ int set_intel_func_ptrs(void)
         g_platform.disable_turbo = fm_06_4f_disable_turbo;
         g_platform.poll_power = fm_06_4f_poll_power;
         g_platform.monitoring = fm_06_4f_monitoring;
+        g_platform.init_msr = fm_06_4f_init_msr;
+        g_platform.finalize_msr = fm_06_4f_finalize_msr;
+        g_platform.read_msr = fm_06_4f_read_msr;
+        g_platform.write_msr = fm_06_4f_write_msr;
         //g_platform.set_each_core_frequency = fm_06_4f_set_frequency;
     }
     // Skylake 06_55
@@ -140,6 +156,10 @@ int set_intel_func_ptrs(void)
         g_platform.poll_power = fm_06_55_poll_power;
         g_platform.monitoring = fm_06_55_monitoring;
         g_platform.set_each_core_frequency = fm_06_55_set_frequency;
+        g_platform.init_msr = fm_06_55_init_msr;
+        g_platform.finalize_msr = fm_06_55_finalize_msr;
+        g_platform.read_msr = fm_06_55_read_msr;
+        g_platform.write_msr = fm_06_55_write_msr;
     }
     // Kaby Lake 06_9E
     else if (*g_platform.intel_arch == FM_06_9E)
@@ -156,6 +176,10 @@ int set_intel_func_ptrs(void)
         //g_platform.disable_turbo = fm_06_9e_disable_turbo;
         g_platform.poll_power = fm_06_9e_poll_power;
         g_platform.monitoring = fm_06_9e_monitoring;
+        g_platform.init_msr = fm_06_9e_init_msr;
+        g_platform.finalize_msr = fm_06_9e_finalize_msr;
+        g_platform.read_msr = fm_06_9e_read_msr;
+        g_platform.write_msr = fm_06_9e_write_msr;
     }
     else
     {

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -217,6 +217,10 @@ void variorum_init_func_ptrs()
     g_platform.dump_gpu_utilization = NULL;
     g_platform.set_each_core_frequency = NULL;
     g_platform.monitoring = NULL;
+    g_platform.init_msr = NULL;
+    g_platform.finalize_msr = NULL;
+    g_platform.read_msr = NULL;
+    g_platform.write_msr = NULL;
 }
 
 int variorum_set_func_ptrs()

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -182,6 +182,26 @@ struct platform
     /// @return Error code.
     int (*dump_gpu_utilization)(int long_ver);
 
+    /// @brief Function pointer to initialize the MSR interface.
+    ///
+    /// @return Error code.
+    int (*init_msr)(void);
+
+    /// @brief Function pointer to finalize the MSR interface.
+    ///
+    /// @return Error code.
+    int (*finalize_msr)(void);
+
+    /// @brief Function pointer to print GPU utilization.
+    ///
+    /// @return Error code.
+    int (*read_msr)(int cpuid, unsigned long offset, unsigned long *value);
+
+    /// @brief Function pointer to print GPU utilization.
+    ///
+    /// @return Error code.
+    int (*write_msr)(int cpuid, unsigned long offset, unsigned long value);
+
     /******************************/
     /* Platform-Specific Topology */
     /******************************/

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -769,3 +769,51 @@ int variorum_disable_turbo(void)
     }
     return err;
 }
+
+int variorum_init_msr(void)
+{
+    int err = 0;
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
+
+int variorum_finalize_msr(void)
+{
+    int err = 0;
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
+
+int variorum_read_msr(int cpuid, unsigned long offset, unsigned long *value)
+{
+    //!@todo: Verify that MSR interface has been initialized before proceeding
+    int err = 0;
+    err = g_platform.read_msr(cpuid, offset, value);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
+
+int variorum_write_msr(int cpuid, unsigned long offset, unsigned long value)
+{
+
+    //!@todo: Verify that MSR interface has been initialized before proceeding
+    int err = 0;
+    err = g_platform.write_msr(cpuid, offset, value);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
+

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -176,6 +176,38 @@ int variorum_disable_turbo(void);
 /// @brief Test for memory leaks.
 int variorum_tester(void);
 
+/// @brief Initialize MSR interface.
+//
+//  @return Error code.
+int variorum_init_msr(void);
+
+/// @brief Finalize MSR interface.
+//
+//  @return Error code.
+int variorum_finalize_msr(void);
+
+/// @brief read MSR offset on the specified CPU.
+//
+//  @param [in] cpuid. ID of the CPU on which the MSR will be read.
+//
+//  @param [in] offset. MSR offset to be read on the CPU.
+//
+//  @return Value read from the MSR offset on the CPU.
+int variorum_read_msr(int cpuid, unsigned long offset, unsigned long *value);
+
+/// @brief write value to MSR offset on the specified CPU.
+//
+//  @param [in] cpuid. ID of the CPU on which the MSR will be read.
+//
+//  @param [in] offset. MSR offset to be read on the CPU.
+//
+//  @param [in] raw_value. Value to be written to the MSR on the CPU.
+//
+//  @param [in] write_mask. Bit write mask for the MSR.
+//
+//  @return Value read from the MSR offset on the CPU.
+int variorum_write_msr(int cpuid, unsigned long offset, unsigned long value);
+//
 ///* Do we need these? */
 //int print_cap_package_frequency(void);
 //int print_available_frequencies(void);


### PR DESCRIPTION
This is a WIP PR for changes to Variorum to support integration with GEOPM. These changes will enable using Variorum instead of PlatformIO for platform-specific control and sampling operations. These changes are limited to the Intel-related functionality of Variorum.

This PR adds four front-facing APIs to Variorum for basic MSR access: 

int variorum_init_msr(void);
int variorum_finalize_msr(void);
int variorum_read_msr(int cpuid, unsigned long offset, unsigned long *value);
int variorum_write_msr(int cpuid, unsigned long offset, unsigned long value);

These are used by the Variorum PlatformIO component of our GEOPM port to interface with Variorum. 