### PR TITLE
Renamed frequency-set function to frequency-cap.

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -30,7 +30,7 @@ set(BASIC_EXAMPLES
     variorum-print-verbose-thermals-example
     variorum-print-verbose-gpu-utilization-example
     variorum-set-and-verify-node-power-limit-example
-    variorum-set-cpu-clock-speed-example
+    variorum-cap-cpu-clock-speed-example
     variorum-set-gpu-power-ratio-example
     variorum-set-node-power-limit-example
     variorum-set-socket-power-limits-example

--- a/src/examples/variorum-cap-cpu-clock-speed-example.c
+++ b/src/examples/variorum-cap-cpu-clock-speed-example.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
     cpu_freq_mhz = atoi(argv[1]);
     printf("Setting each CPU to %d MHz.\n", cpu_freq_mhz);
 
-    ret = variorum_set_each_core_frequency(cpu_freq_mhz);
+    ret = variorum_cap_each_core_frequency(cpu_freq_mhz);
     if (ret != 0)
     {
         printf("Set each core frequency failed!\n");

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -71,7 +71,7 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_disable_turbo = fm_06_2a_disable_turbo;
         g_platform.variorum_poll_power = fm_06_2a_poll_power;
         g_platform.variorum_monitoring = fm_06_2a_monitoring;
-        //g_platform.variorum_set_each_core_frequency = fm_06_2a_set_frequency;
+        //g_platform.variorum_cap_each_core_frequency = fm_06_2a_set_frequency;
     }
     // Ivy Bridge 06_3E
     else if (*g_platform.intel_arch == FM_06_3E)
@@ -88,7 +88,7 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_disable_turbo = fm_06_3e_disable_turbo;
         g_platform.variorum_poll_power = fm_06_3e_poll_power;
         g_platform.variorum_monitoring = fm_06_3e_monitoring;
-        //g_platform.set_each_core_frequency = fm_06_3e_set_frequency;
+        //g_platform.cap_each_core_frequency = fm_06_3e_set_frequency;
     }
     // Haswell 06_3F
     else if (*g_platform.intel_arch == FM_06_3F)
@@ -105,7 +105,7 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_disable_turbo = fm_06_3f_disable_turbo;
         g_platform.variorum_poll_power = fm_06_3f_poll_power;
         g_platform.variorum_monitoring = fm_06_3f_monitoring;
-        //g_platform.set_each_core_frequency = fm_06_3f_set_frequency;
+        //g_platform.cap_each_core_frequency = fm_06_3f_set_frequency;
     }
     // Broadwell 06_4F
     else if (*g_platform.intel_arch == FM_06_4F)
@@ -122,7 +122,7 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_disable_turbo = fm_06_4f_disable_turbo;
         g_platform.variorum_poll_power = fm_06_4f_poll_power;
         g_platform.variorum_monitoring = fm_06_4f_monitoring;
-        //g_platform.variorum_set_each_core_frequency = fm_06_4f_set_frequency;
+        //g_platform.variorum_cap_each_core_frequency = fm_06_4f_set_frequency;
     }
     // Skylake 06_55
     else if (*g_platform.intel_arch == FM_06_55)
@@ -139,7 +139,7 @@ int set_intel_func_ptrs(void)
         //g_platform.variorum_disable_turbo = fm_06_55_disable_turbo;
         g_platform.variorum_poll_power = fm_06_55_poll_power;
         g_platform.variorum_monitoring = fm_06_55_monitoring;
-        g_platform.variorum_set_each_core_frequency = fm_06_55_set_frequency;
+        g_platform.variorum_cap_each_core_frequency = fm_06_55_set_frequency;
     }
     // Kaby Lake 06_9E
     else if (*g_platform.intel_arch == FM_06_9E)

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -215,7 +215,7 @@ void variorum_init_func_ptrs()
     g_platform.variorum_dump_turbo = NULL;
     g_platform.variorum_poll_power = NULL;
     g_platform.variorum_dump_gpu_utilization = NULL;
-    g_platform.variorum_set_each_core_frequency = NULL;
+    g_platform.variorum_cap_each_core_frequency = NULL;
     g_platform.variorum_monitoring = NULL;
 }
 

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -123,7 +123,7 @@ struct platform
     /// @return Error code.
     int (*variorum_set_each_socket_power_limit)(int socket_power_limit);
 
-    int (*variorum_set_each_core_frequency)(int core_freq_mhz);
+    int (*variorum_cap_each_core_frequency)(int core_freq_mhz);
 
     /// @brief Function pointer to print the feature set.
     ///

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -322,7 +322,7 @@ int variorum_set_each_socket_power_limit(int socket_power_limit)
     return err;
 }
 
-int variorum_set_each_core_frequency(int core_freq_mhz)
+int variorum_cap_each_core_frequency(int core_freq_mhz)
 {
     int err = 0;
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
@@ -330,14 +330,14 @@ int variorum_set_each_core_frequency(int core_freq_mhz)
     {
         return -1;
     }
-    if (g_platform.variorum_set_each_core_frequency == NULL)
+    if (g_platform.variorum_cap_each_core_frequency == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_set_each_core_frequency(core_freq_mhz);
+    err = g_platform.variorum_cap_each_core_frequency(core_freq_mhz);
     if (err)
     {
         return -1;

--- a/src/variorum/variorum.f90
+++ b/src/variorum/variorum.f90
@@ -70,12 +70,12 @@ module variorum
 
     !-------------------------------------------------------------------------
     integer(kind=c_int) &
-            function variorum_set_each_core_frequency(cpu_freq_mhz) &
+            function variorum_cap_each_core_frequency(cpu_freq_mhz) &
             bind(C)
         import
         implicit none
         integer(kind=c_int), value, intent(in) ::cpu_freq_mhz
-    end function variorum_set_each_core_frequency
+    end function variorum_cap_each_core_frequency
 
     !-------------------------------------------------------------------------
     integer(kind=c_int) &

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -62,7 +62,7 @@ int variorum_set_gpu_power_ratio(int gpu_power_ratio);
 /// @param [in] cpu_freq_mhz Desired CPU frequency for each core in MHz.
 ///
 /// @return Error code.
-int variorum_set_each_core_frequency(int cpu_freq_mhz);
+int variorum_cap_each_core_frequency(int cpu_freq_mhz);
 
 ///// @brief Set a power limit to the gpu domain.
 /////


### PR DESCRIPTION
variorum_set_each_core_frequency() is now
variorum_cap_each_core_frequency().

Also changed the name of an example file.

Fixes #128.