### PR TITLE
Variorum JSON API.

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -34,7 +34,7 @@ set(BASIC_EXAMPLES
     variorum-set-gpu-power-ratio-example
     variorum-set-node-power-limit-example
     variorum-set-socket-power-limits-example
-    variorum-json-get-node-power-example
+    variorum-get-node-power-json-example
 )
 
 message(STATUS "Adding variorum examples")

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -34,6 +34,7 @@ set(BASIC_EXAMPLES
     variorum-set-gpu-power-ratio-example
     variorum-set-node-power-limit-example
     variorum-set-socket-power-limits-example
+    variorum-json-get-node-power-example
 )
 
 message(STATUS "Adding variorum examples")

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 
     my_power_obj =
         json_object(); // Create JSON object and pass to variorum API as reference.
-    ret = variorum_json_get_node_power(my_power_obj);
+    ret = variorum_get_node_power_json(my_power_obj);
     if (ret != 0)
     {
         printf("First run: JSON get node power failed!\n");
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
     {
         x += do_work(i);
     }
-    ret = variorum_json_get_node_power(my_power_obj);
+    ret = variorum_get_node_power_json(my_power_obj);
     if (ret != 0)
     {
         printf("Second run: JSON get node power failed!\n");

--- a/src/examples/variorum-json-get-node-power-example.c
+++ b/src/examples/variorum-json-get-node-power-example.c
@@ -1,0 +1,62 @@
+// Copyright 2019 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+
+#include <variorum.h>
+#include <jansson.h>
+
+#ifdef SECOND_RUN
+static inline double do_work(int input)
+{
+    int i;
+    double result = (double)input;
+
+    for (i = 0; i < 100000; i++)
+    {
+        result += i*result;
+    }
+
+    return result;
+}
+#endif
+
+int main(int argc, char **argv)
+{
+    int ret;
+    json_t *my_power_obj = NULL;
+    char *s = NULL; 
+#ifdef SECOND_RUN
+    int i;
+    int size = 1E4;
+    double x = 0.0;
+#endif
+
+    my_power_obj = json_object(); // Create JSON object and pass to variorum API as reference. 
+    ret = variorum_json_get_node_power(my_power_obj);
+    if (ret != 0)
+    {
+        printf("First run: JSON get node power failed!\n");
+    }
+    s = json_dumps(my_power_obj, 0);
+    puts(s);
+
+#ifdef SECOND_RUN
+    for (i = 0; i < size; i++)
+    {
+        x += do_work(i);
+    }
+    ret = variorum_json_get_node_power(my_power_obj);
+    if (ret != 0)
+    {
+        printf("Second run: JSON get node power failed!\n");
+    }
+#endif
+    
+    s = json_dumps(my_power_obj, 0);
+    puts(s);
+    json_decref(my_power_obj); 
+    return ret;
+}

--- a/src/examples/variorum-json-get-node-power-example.c
+++ b/src/examples/variorum-json-get-node-power-example.c
@@ -16,7 +16,7 @@ static inline double do_work(int input)
 
     for (i = 0; i < 100000; i++)
     {
-        result += i*result;
+        result += i * result;
     }
 
     return result;
@@ -27,14 +27,15 @@ int main(int argc, char **argv)
 {
     int ret;
     json_t *my_power_obj = NULL;
-    char *s = NULL; 
+    char *s = NULL;
 #ifdef SECOND_RUN
     int i;
     int size = 1E4;
     double x = 0.0;
 #endif
 
-    my_power_obj = json_object(); // Create JSON object and pass to variorum API as reference. 
+    my_power_obj =
+        json_object(); // Create JSON object and pass to variorum API as reference.
     ret = variorum_json_get_node_power(my_power_obj);
     if (ret != 0)
     {
@@ -54,9 +55,9 @@ int main(int argc, char **argv)
         printf("Second run: JSON get node power failed!\n");
     }
 #endif
-    
+
     s = json_dumps(my_power_obj, 0);
     puts(s);
-    json_decref(my_power_obj); 
+    json_decref(my_power_obj);
     return ret;
 }

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -374,3 +374,72 @@ int p9_set_socket_power_limit(int pcap_new)
 
     return 0;
 }
+
+int p9_json_get_node_power(json_t *get_power_obj)                               
+{                                                                               
+#ifdef VARIORUM_LOG                                                             
+    printf("Running %s\n", __FUNCTION__);                                       
+#endif                                                                          
+                                                                                
+    void *buf;                                                                  
+    int fd;                                                                     
+    int rc;                                                                     
+    int bytes;                                                                  
+    int initial_bytes;                                                          
+    int iter = 0;                                                               
+    int nsockets;                                                               
+    char hostname[1024];                                                        
+    struct timeval tv;                                                          
+    uint64_t ts;                                                                
+                                                                                
+    variorum_get_topology(&nsockets, NULL, NULL);                               
+    printf("nsock: %d\n", nsockets);                                            
+                                                                                
+    gethostname(hostname, 1024);                                                
+    gettimeofday(&tv, NULL);                                                    
+    ts = tv.tv_sec*(uint64_t)1000000+tv.tv_usec;                                
+    json_object_set_new(get_power_obj, "hostname", json_string(hostname));      
+    json_object_set_new(get_power_obj, "timestamp", json_integer(ts));          
+                                                                                
+    fd = open("/sys/firmware/opal/exports/occ_inband_sensors", O_RDONLY);       
+    if (fd < 0)                                                                 
+    {                                                                           
+        printf("Failed to open occ_inband_sensors file\n");                     
+        return -1;                                                              
+    }                                                                           
+                                                                                
+    for (iter = 0; iter < nsockets; iter++)                                     
+    {                                                                           
+        lseek(fd, iter * OCC_SENSOR_DATA_BLOCK_SIZE, SEEK_SET);                 
+                                                                                
+        buf = malloc(OCC_SENSOR_DATA_BLOCK_SIZE);                               
+                                                                                
+        if (!buf)                                                               
+        {                                                                       
+            printf("Failed to allocate\n");                                     
+            return -1;                                                          
+        }                                                                       
+                                                                                
+        for (rc = bytes = 0; bytes < OCC_SENSOR_DATA_BLOCK_SIZE; bytes += rc)   
+        {                                                                       
+            rc = read(fd, buf + bytes, OCC_SENSOR_DATA_BLOCK_SIZE - bytes);     
+                                                                                
+            if (!rc || rc < 0)                                                  
+            {                                                                   
+                break;                                                          
+            }                                                                   
+        }                                                                       
+                                                                                
+        if (bytes != OCC_SENSOR_DATA_BLOCK_SIZE)                                
+        {                                                                       
+            printf("Failed to read data\n");                                    
+            free(buf);                                                          
+            return -1;                                                          
+        }                                                                       
+                                                                                
+        json_get_power_sensors(iter, get_power_obj, buf);                       
+        free(buf);                                                              
+    }                                                                           
+    close(fd);                                                                  
+    return 0;                                                                   
+}                                                          

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -375,71 +375,70 @@ int p9_set_socket_power_limit(int pcap_new)
     return 0;
 }
 
-int p9_json_get_node_power(json_t *get_power_obj)                               
-{                                                                               
-#ifdef VARIORUM_LOG                                                             
-    printf("Running %s\n", __FUNCTION__);                                       
-#endif                                                                          
-                                                                                
-    void *buf;                                                                  
-    int fd;                                                                     
-    int rc;                                                                     
-    int bytes;                                                                  
-    int initial_bytes;                                                          
-    int iter = 0;                                                               
-    int nsockets;                                                               
-    char hostname[1024];                                                        
-    struct timeval tv;                                                          
-    uint64_t ts;                                                                
-                                                                                
-    variorum_get_topology(&nsockets, NULL, NULL);                               
-    printf("nsock: %d\n", nsockets);                                            
-                                                                                
-    gethostname(hostname, 1024);                                                
-    gettimeofday(&tv, NULL);                                                    
-    ts = tv.tv_sec*(uint64_t)1000000+tv.tv_usec;                                
-    json_object_set_new(get_power_obj, "hostname", json_string(hostname));      
-    json_object_set_new(get_power_obj, "timestamp", json_integer(ts));          
-                                                                                
-    fd = open("/sys/firmware/opal/exports/occ_inband_sensors", O_RDONLY);       
-    if (fd < 0)                                                                 
-    {                                                                           
-        printf("Failed to open occ_inband_sensors file\n");                     
-        return -1;                                                              
-    }                                                                           
-                                                                                
-    for (iter = 0; iter < nsockets; iter++)                                     
-    {                                                                           
-        lseek(fd, iter * OCC_SENSOR_DATA_BLOCK_SIZE, SEEK_SET);                 
-                                                                                
-        buf = malloc(OCC_SENSOR_DATA_BLOCK_SIZE);                               
-                                                                                
-        if (!buf)                                                               
-        {                                                                       
-            printf("Failed to allocate\n");                                     
-            return -1;                                                          
-        }                                                                       
-                                                                                
-        for (rc = bytes = 0; bytes < OCC_SENSOR_DATA_BLOCK_SIZE; bytes += rc)   
-        {                                                                       
-            rc = read(fd, buf + bytes, OCC_SENSOR_DATA_BLOCK_SIZE - bytes);     
-                                                                                
-            if (!rc || rc < 0)                                                  
-            {                                                                   
-                break;                                                          
-            }                                                                   
-        }                                                                       
-                                                                                
-        if (bytes != OCC_SENSOR_DATA_BLOCK_SIZE)                                
-        {                                                                       
-            printf("Failed to read data\n");                                    
-            free(buf);                                                          
-            return -1;                                                          
-        }                                                                       
-                                                                                
-        json_get_power_sensors(iter, get_power_obj, buf);                       
-        free(buf);                                                              
-    }                                                                           
-    close(fd);                                                                  
-    return 0;                                                                   
-}                                                          
+int p9_json_get_node_power(json_t *get_power_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    void *buf;
+    int fd;
+    int rc;
+    int bytes;
+    int initial_bytes;
+    int iter = 0;
+    int nsockets;
+    char hostname[1024];
+    struct timeval tv;
+    uint64_t ts;
+
+    variorum_get_topology(&nsockets, NULL, NULL);
+
+    gethostname(hostname, 1024);
+    gettimeofday(&tv, NULL);
+    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
+    json_object_set_new(get_power_obj, "hostname", json_string(hostname));
+    json_object_set_new(get_power_obj, "timestamp", json_integer(ts));
+
+    fd = open("/sys/firmware/opal/exports/occ_inband_sensors", O_RDONLY);
+    if (fd < 0)
+    {
+        printf("Failed to open occ_inband_sensors file\n");
+        return -1;
+    }
+
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        lseek(fd, iter * OCC_SENSOR_DATA_BLOCK_SIZE, SEEK_SET);
+
+        buf = malloc(OCC_SENSOR_DATA_BLOCK_SIZE);
+
+        if (!buf)
+        {
+            printf("Failed to allocate\n");
+            return -1;
+        }
+
+        for (rc = bytes = 0; bytes < OCC_SENSOR_DATA_BLOCK_SIZE; bytes += rc)
+        {
+            rc = read(fd, buf + bytes, OCC_SENSOR_DATA_BLOCK_SIZE - bytes);
+
+            if (!rc || rc < 0)
+            {
+                break;
+            }
+        }
+
+        if (bytes != OCC_SENSOR_DATA_BLOCK_SIZE)
+        {
+            printf("Failed to read data\n");
+            free(buf);
+            return -1;
+        }
+
+        json_get_power_sensors(iter, get_power_obj, buf);
+        free(buf);
+    }
+    close(fd);
+    return 0;
+}

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -375,7 +375,7 @@ int p9_set_socket_power_limit(int pcap_new)
     return 0;
 }
 
-int p9_json_get_node_power(json_t *get_power_obj)
+int p9_get_node_power_json(json_t *get_power_obj)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/IBM/Power9.h
+++ b/src/variorum/IBM/Power9.h
@@ -6,6 +6,8 @@
 #ifndef POWER9_H_INCLUDE
 #define POWER9_H_INCLUDE
 
+#include <jansson.h>
+
 int p9_get_power(int long_ver);
 
 int p9_get_power_limits(int long_ver);
@@ -19,5 +21,7 @@ int p9_set_and_verify_node_power_limit(int pcap_new);
 int p9_set_gpu_power_ratio(int gpu_power_ratio);
 
 int p9_monitoring(FILE *output);
+
+int p9_json_get_node_power(json_t *get_power_obj);    
 
 #endif

--- a/src/variorum/IBM/Power9.h
+++ b/src/variorum/IBM/Power9.h
@@ -22,6 +22,6 @@ int p9_set_gpu_power_ratio(int gpu_power_ratio);
 
 int p9_monitoring(FILE *output);
 
-int p9_json_get_node_power(json_t *get_power_obj);    
+int p9_json_get_node_power(json_t *get_power_obj);
 
 #endif

--- a/src/variorum/IBM/Power9.h
+++ b/src/variorum/IBM/Power9.h
@@ -22,6 +22,6 @@ int p9_set_gpu_power_ratio(int gpu_power_ratio);
 
 int p9_monitoring(FILE *output);
 
-int p9_json_get_node_power(json_t *get_power_obj);
+int p9_get_node_power_json(json_t *get_power_obj);
 
 #endif

--- a/src/variorum/IBM/config_ibm.c
+++ b/src/variorum/IBM/config_ibm.c
@@ -28,7 +28,8 @@ int set_ibm_func_ptrs(void)
         g_platform.variorum_dump_power = p9_get_power;
         g_platform.variorum_dump_power_limits = p9_get_power_limits;
         g_platform.variorum_set_node_power_limit = p9_set_node_power_limit;
-        g_platform.variorum_set_each_socket_power_limit = p9_set_socket_power_limit;
+        g_platform.variorum_set_each_socket_power_limit =
+            p9_set_socket_power_limit;
         g_platform.variorum_set_gpu_power_ratio = p9_set_gpu_power_ratio;
         g_platform.variorum_set_and_verify_node_power_limit =
             p9_set_and_verify_node_power_limit;

--- a/src/variorum/IBM/config_ibm.c
+++ b/src/variorum/IBM/config_ibm.c
@@ -34,7 +34,7 @@ int set_ibm_func_ptrs(void)
         g_platform.variorum_set_and_verify_node_power_limit =
             p9_set_and_verify_node_power_limit;
         g_platform.variorum_monitoring = p9_monitoring;
-        g_platform.variorum_json_get_node_power = p9_json_get_node_power;
+        g_platform.variorum_get_node_power_json = p9_get_node_power_json;
     }
     else
     {

--- a/src/variorum/IBM/config_ibm.c
+++ b/src/variorum/IBM/config_ibm.c
@@ -33,6 +33,7 @@ int set_ibm_func_ptrs(void)
         g_platform.variorum_set_and_verify_node_power_limit =
             p9_set_and_verify_node_power_limit;
         g_platform.variorum_monitoring = p9_monitoring;
+        g_platform.variorum_json_get_node_power = p9_json_get_node_power;
     }
     else
     {

--- a/src/variorum/IBM/ibm_sensors.c
+++ b/src/variorum/IBM/ibm_sensors.c
@@ -300,77 +300,77 @@ void print_all_sensors(int chipid, FILE *output, const void *buf)
     fprintf(output, "\n"); // Add end of line.
 }
 
-void json_get_power_sensors(int chipid, json_t* get_power_obj, const void* buf) 
-{                                                                                  
-    struct occ_sensor_data_header *hb;                                             
-    struct occ_sensor_name *md;                                                    
-    int i = 0;                                                                     
-    static int init = 0;                                                           
-    // Power in watts.                                                             
-    uint64_t pwrsys = 0;                                                           
-    uint64_t pwrproc = 0;                                                          
-    uint64_t pwrmem = 0;                                                           
-    uint64_t pwrgpu = 0;                                                           
-    char sockID[4];                                                                
-                                                                                   
-    char cpu_str[24] = "power_cpu_socket_";                                        
-    char mem_str[24] = "power_mem_socket_";                                        
-    char gpu_str[24] = "power_gpu_socket_";                                        
-                                                                                   
-    sprintf(sockID, "%d", chipid);                                                 
-    strcat(cpu_str, sockID);                                                       
-    strcat(mem_str, sockID);                                                       
-    strcat(gpu_str, sockID);                                                       
-                                                                                   
-    hb = (struct occ_sensor_data_header *)(uint64_t)buf;                           
-    md = (struct occ_sensor_name *)((uint64_t)hb + be32toh(hb->names_offset));  
-                                                                                   
-    for (i = 0; i < be16toh(hb->nr_sensors); i++)                                  
-    {                                                                              
-        uint32_t offset = be32toh(md[i].reading_offset);                           
-        uint32_t scale = be32toh(md[i].scale_factor);                              
-        uint64_t sample;                                                           
-                                                                                   
+void json_get_power_sensors(int chipid, json_t *get_power_obj, const void *buf)
+{
+    struct occ_sensor_data_header *hb;
+    struct occ_sensor_name *md;
+    int i = 0;
+    static int init = 0;
+    // Power in watts.
+    uint64_t pwrsys = 0;
+    uint64_t pwrproc = 0;
+    uint64_t pwrmem = 0;
+    uint64_t pwrgpu = 0;
+    char sockID[4];
+
+    char cpu_str[24] = "power_cpu_socket_";
+    char mem_str[24] = "power_mem_socket_";
+    char gpu_str[24] = "power_gpu_socket_";
+
+    sprintf(sockID, "%d", chipid);
+    strcat(cpu_str, sockID);
+    strcat(mem_str, sockID);
+    strcat(gpu_str, sockID);
+
+    hb = (struct occ_sensor_data_header *)(uint64_t)buf;
+    md = (struct occ_sensor_name *)((uint64_t)hb + be32toh(hb->names_offset));
+
+    for (i = 0; i < be16toh(hb->nr_sensors); i++)
+    {
+        uint32_t offset = be32toh(md[i].reading_offset);
+        uint32_t scale = be32toh(md[i].scale_factor);
+        uint64_t sample;
+
         // We are not reading counters here because power data doesn't need counter.
-        if (md[i].structure_type == OCC_SENSOR_READING_FULL)                       
-        {                                                                          
-            sample = read_sensor(hb, offset, SENSOR_SAMPLE);                       
-        }                                                                          
-                                                                                   
-        /* Ideally, we don't want to use strcmp and use offsets instead.           
-         * But this was not clear to us at the time of the implementation.         
-         * OCC_DATA_BLOCK contents are different because of master-slave design 
-         * across different processor sockets. So the same offset can refer to  
-         * a different sensor depending on the socket.                             
-         *                                                                         
-         * Note that we're not capturing timestamp here, the common timestamp   
-         * printed is the one from the end of the loop, where all 336 sensors   
-         * have been scanned on P9.                                                
-         * */                                                                      
-                                                                                   
-        if (strcmp(md[i].name, "PWRSYS") == 0)                                     
-        {                                                                          
-            pwrsys = (uint64_t)(sample * TO_FP(scale));                            
-        }                                                                          
-        if (strcmp(md[i].name, "PWRPROC") == 0)                                    
-        {                                                                          
-            pwrproc = (uint64_t)(sample * TO_FP(scale));                           
-        }                                                                          
-        if (strcmp(md[i].name, "PWRMEM") == 0)                                     
-        {                                                                          
-            pwrmem = (uint64_t)(sample * TO_FP(scale));                            
-        }                                                                          
-        if (strcmp(md[i].name, "PWRGPU") == 0)                                     
-        {                                                                          
-            pwrgpu = (uint64_t)(sample * TO_FP(scale));                            
-        }                                                                          
-    }                                                                              
-                                                                                   
-    if (chipid == 0)                                                               
-        json_object_set_new(get_power_obj, "power_node", json_real(pwrsys));        
-                                                                                   
-    json_object_set_new(get_power_obj, cpu_str, json_real(pwrproc));               
-    json_object_set_new(get_power_obj, mem_str, json_real(pwrmem));                
-    json_object_set_new(get_power_obj, gpu_str, json_real(pwrgpu));                
-                                                                                   
-}                                                                         
+        if (md[i].structure_type == OCC_SENSOR_READING_FULL)
+        {
+            sample = read_sensor(hb, offset, SENSOR_SAMPLE);
+        }
+
+        /* Ideally, we don't want to use strcmp and use offsets instead.
+         * But this was not clear to us at the time of the implementation.
+         * OCC_DATA_BLOCK contents are different because of master-slave design
+         * across different processor sockets. So the same offset can refer to
+         * a different sensor depending on the socket.
+         *
+         * Note that we're not capturing timestamp here, the common timestamp
+         * printed is the one from the end of the loop, where all 336 sensors
+         * have been scanned on P9.
+         * */
+
+        if (strcmp(md[i].name, "PWRSYS") == 0)
+        {
+            pwrsys = (uint64_t)(sample * TO_FP(scale));
+        }
+        if (strcmp(md[i].name, "PWRPROC") == 0)
+        {
+            pwrproc = (uint64_t)(sample * TO_FP(scale));
+        }
+        if (strcmp(md[i].name, "PWRMEM") == 0)
+        {
+            pwrmem = (uint64_t)(sample * TO_FP(scale));
+        }
+        if (strcmp(md[i].name, "PWRGPU") == 0)
+        {
+            pwrgpu = (uint64_t)(sample * TO_FP(scale));
+        }
+    }
+
+    if (chipid == 0)
+        json_object_set_new(get_power_obj, "power_node", json_real(pwrsys));
+
+    json_object_set_new(get_power_obj, cpu_str, json_real(pwrproc));
+    json_object_set_new(get_power_obj, mem_str, json_real(pwrmem));
+    json_object_set_new(get_power_obj, gpu_str, json_real(pwrgpu));
+
+}

--- a/src/variorum/IBM/ibm_sensors.c
+++ b/src/variorum/IBM/ibm_sensors.c
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <ibm_sensors.h>
 
@@ -298,3 +299,78 @@ void print_all_sensors(int chipid, FILE *output, const void *buf)
     }
     fprintf(output, "\n"); // Add end of line.
 }
+
+void json_get_power_sensors(int chipid, json_t* get_power_obj, const void* buf) 
+{                                                                                  
+    struct occ_sensor_data_header *hb;                                             
+    struct occ_sensor_name *md;                                                    
+    int i = 0;                                                                     
+    static int init = 0;                                                           
+    // Power in watts.                                                             
+    uint64_t pwrsys = 0;                                                           
+    uint64_t pwrproc = 0;                                                          
+    uint64_t pwrmem = 0;                                                           
+    uint64_t pwrgpu = 0;                                                           
+    char sockID[4];                                                                
+                                                                                   
+    char cpu_str[24] = "power_cpu_socket_";                                        
+    char mem_str[24] = "power_mem_socket_";                                        
+    char gpu_str[24] = "power_gpu_socket_";                                        
+                                                                                   
+    sprintf(sockID, "%d", chipid);                                                 
+    strcat(cpu_str, sockID);                                                       
+    strcat(mem_str, sockID);                                                       
+    strcat(gpu_str, sockID);                                                       
+                                                                                   
+    hb = (struct occ_sensor_data_header *)(uint64_t)buf;                           
+    md = (struct occ_sensor_name *)((uint64_t)hb + be32toh(hb->names_offset));  
+                                                                                   
+    for (i = 0; i < be16toh(hb->nr_sensors); i++)                                  
+    {                                                                              
+        uint32_t offset = be32toh(md[i].reading_offset);                           
+        uint32_t scale = be32toh(md[i].scale_factor);                              
+        uint64_t sample;                                                           
+                                                                                   
+        // We are not reading counters here because power data doesn't need counter.
+        if (md[i].structure_type == OCC_SENSOR_READING_FULL)                       
+        {                                                                          
+            sample = read_sensor(hb, offset, SENSOR_SAMPLE);                       
+        }                                                                          
+                                                                                   
+        /* Ideally, we don't want to use strcmp and use offsets instead.           
+         * But this was not clear to us at the time of the implementation.         
+         * OCC_DATA_BLOCK contents are different because of master-slave design 
+         * across different processor sockets. So the same offset can refer to  
+         * a different sensor depending on the socket.                             
+         *                                                                         
+         * Note that we're not capturing timestamp here, the common timestamp   
+         * printed is the one from the end of the loop, where all 336 sensors   
+         * have been scanned on P9.                                                
+         * */                                                                      
+                                                                                   
+        if (strcmp(md[i].name, "PWRSYS") == 0)                                     
+        {                                                                          
+            pwrsys = (uint64_t)(sample * TO_FP(scale));                            
+        }                                                                          
+        if (strcmp(md[i].name, "PWRPROC") == 0)                                    
+        {                                                                          
+            pwrproc = (uint64_t)(sample * TO_FP(scale));                           
+        }                                                                          
+        if (strcmp(md[i].name, "PWRMEM") == 0)                                     
+        {                                                                          
+            pwrmem = (uint64_t)(sample * TO_FP(scale));                            
+        }                                                                          
+        if (strcmp(md[i].name, "PWRGPU") == 0)                                     
+        {                                                                          
+            pwrgpu = (uint64_t)(sample * TO_FP(scale));                            
+        }                                                                          
+    }                                                                              
+                                                                                   
+    if (chipid == 0)                                                               
+        json_object_set_new(get_power_obj, "power_node", json_real(pwrsys));        
+                                                                                   
+    json_object_set_new(get_power_obj, cpu_str, json_real(pwrproc));               
+    json_object_set_new(get_power_obj, mem_str, json_real(pwrmem));                
+    json_object_set_new(get_power_obj, gpu_str, json_real(pwrgpu));                
+                                                                                   
+}                                                                         

--- a/src/variorum/IBM/ibm_sensors.h
+++ b/src/variorum/IBM/ibm_sensors.h
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <math.h>
+#include <jansson.h>
 
 /* Documentation for the OCC Sensors and the structures in this header file
  * is available in README_IBM_OCC.
@@ -148,5 +149,9 @@ unsigned long read_counter(const struct occ_sensor_data_header *hb,
 unsigned long read_sensor(const struct occ_sensor_data_header *hb,
                           uint32_t offset,
                           int attr);
+
+void json_get_power_sensors(int chipid,                                            
+                            json_t *get_power_obj,                                    
+                            const void *buf);     
 
 #endif

--- a/src/variorum/IBM/ibm_sensors.h
+++ b/src/variorum/IBM/ibm_sensors.h
@@ -150,8 +150,8 @@ unsigned long read_sensor(const struct occ_sensor_data_header *hb,
                           uint32_t offset,
                           int attr);
 
-void json_get_power_sensors(int chipid,                                            
-                            json_t *get_power_obj,                                    
-                            const void *buf);     
+void json_get_power_sensors(int chipid,
+                            json_t *get_power_obj,
+                            const void *buf);
 
 #endif

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -399,15 +399,15 @@ int fm_06_4f_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_4f_json_get_node_power(json_t *get_power_obj)                            
-{                                                                                  
-#ifdef VARIORUM_LOG                                                                
-    printf("Running %s\n", __FUNCTION__);                                          
-#endif                                                                             
-                                                                                   
-    json_dump_power_data(get_power_obj, msrs.msr_pkg_power_limit, 
-                        msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, 
-                        msrs.msr_dram_energy_status);
-                                                                                   
-  return 0;                                                                        
-} 
+int fm_06_4f_json_get_node_power(json_t *get_power_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_dump_power_data(get_power_obj, msrs.msr_pkg_power_limit,
+                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                         msrs.msr_dram_energy_status);
+
+    return 0;
+}

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -398,3 +398,16 @@ int fm_06_4f_monitoring(FILE *output)
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
     return 0;
 }
+
+int fm_06_4f_json_get_node_power(json_t *get_power_obj)                            
+{                                                                                  
+#ifdef VARIORUM_LOG                                                                
+    printf("Running %s\n", __FUNCTION__);                                          
+#endif                                                                             
+                                                                                   
+    json_dump_power_data(get_power_obj, msrs.msr_pkg_power_limit, 
+                        msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, 
+                        msrs.msr_dram_energy_status);
+                                                                                   
+  return 0;                                                                        
+} 

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -399,7 +399,7 @@ int fm_06_4f_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_4f_json_get_node_power(json_t *get_power_obj)
+int fm_06_4f_get_node_power_json(json_t *get_power_obj)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -102,5 +102,5 @@ int fm_06_4f_poll_power(FILE *output);
 
 int fm_06_4f_monitoring(FILE *output);
 
-int fm_06_4f_json_get_node_power(json_t *get_power_obj); 
+int fm_06_4f_json_get_node_power(json_t *get_power_obj);
 #endif

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -7,6 +7,7 @@
 #define BROADWELL_4F_H_INCLUDE
 
 #include <sys/types.h>
+#include <jansson.h>
 
 /// @brief List of unique addresses for Broadwell Family/Model 4FH.
 struct broadwell_4f_offsets
@@ -100,4 +101,6 @@ int fm_06_4f_get_turbo_status(void);
 int fm_06_4f_poll_power(FILE *output);
 
 int fm_06_4f_monitoring(FILE *output);
+
+int fm_06_4f_json_get_node_power(json_t *get_power_obj); 
 #endif

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -102,5 +102,5 @@ int fm_06_4f_poll_power(FILE *output);
 
 int fm_06_4f_monitoring(FILE *output);
 
-int fm_06_4f_json_get_node_power(json_t *get_power_obj);
+int fm_06_4f_get_node_power_json(json_t *get_power_obj);
 #endif

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -127,7 +127,7 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_poll_power = fm_06_4f_poll_power;
         g_platform.variorum_monitoring = fm_06_4f_monitoring;
         //g_platform.variorum_cap_each_core_frequency = fm_06_4f_set_frequency;
-        g_platform.variorum_json_get_node_power = fm_06_4f_json_get_node_power;
+        g_platform.variorum_get_node_power_json = fm_06_4f_get_node_power_json;
     }
     // Skylake 06_55
     else if (*g_platform.intel_arch == FM_06_55)

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -123,6 +123,7 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_poll_power = fm_06_4f_poll_power;
         g_platform.variorum_monitoring = fm_06_4f_monitoring;
         //g_platform.variorum_cap_each_core_frequency = fm_06_4f_set_frequency;
+        g_platform.variorum_json_get_node_power = fm_06_4f_json_get_node_power;
     }
     // Skylake 06_55
     else if (*g_platform.intel_arch == FM_06_55)

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -60,7 +60,8 @@ int set_intel_func_ptrs(void)
     if (*g_platform.intel_arch == FM_06_2A)
     {
         g_platform.variorum_dump_power_limits = fm_06_2a_get_power_limits;
-        g_platform.variorum_set_each_socket_power_limit = fm_06_2a_set_power_limits;
+        g_platform.variorum_set_each_socket_power_limit =
+            fm_06_2a_set_power_limits;
         g_platform.variorum_print_features = fm_06_2a_get_features;
         g_platform.variorum_dump_thermals = fm_06_2a_get_thermals;
         g_platform.variorum_dump_counters = fm_06_2a_get_counters;
@@ -77,7 +78,8 @@ int set_intel_func_ptrs(void)
     else if (*g_platform.intel_arch == FM_06_3E)
     {
         g_platform.variorum_dump_power_limits = fm_06_3e_get_power_limits;
-        g_platform.variorum_set_each_socket_power_limit = fm_06_3e_set_power_limits;
+        g_platform.variorum_set_each_socket_power_limit =
+            fm_06_3e_set_power_limits;
         g_platform.variorum_print_features = fm_06_3e_get_features;
         g_platform.variorum_dump_thermals = fm_06_3e_get_thermals;
         g_platform.variorum_dump_counters = fm_06_3e_get_counters;
@@ -94,7 +96,8 @@ int set_intel_func_ptrs(void)
     else if (*g_platform.intel_arch == FM_06_3F)
     {
         g_platform.variorum_dump_power_limits = fm_06_3f_get_power_limits;
-        g_platform.variorum_set_each_socket_power_limit = fm_06_3f_set_power_limits;
+        g_platform.variorum_set_each_socket_power_limit =
+            fm_06_3f_set_power_limits;
         g_platform.variorum_print_features = fm_06_3f_get_features;
         g_platform.variorum_dump_thermals = fm_06_3f_get_thermals;
         g_platform.variorum_dump_counters = fm_06_3f_get_counters;
@@ -111,7 +114,8 @@ int set_intel_func_ptrs(void)
     else if (*g_platform.intel_arch == FM_06_4F)
     {
         g_platform.variorum_dump_power_limits = fm_06_4f_get_power_limits;
-        g_platform.variorum_set_each_socket_power_limit = fm_06_4f_set_power_limits;
+        g_platform.variorum_set_each_socket_power_limit =
+            fm_06_4f_set_power_limits;
         g_platform.variorum_print_features = fm_06_4f_get_features;
         g_platform.variorum_dump_thermals = fm_06_4f_get_thermals;
         g_platform.variorum_dump_counters = fm_06_4f_get_counters;
@@ -129,7 +133,8 @@ int set_intel_func_ptrs(void)
     else if (*g_platform.intel_arch == FM_06_55)
     {
         g_platform.variorum_dump_power_limits = fm_06_55_get_power_limits;
-        g_platform.variorum_set_each_socket_power_limit = fm_06_55_set_power_limits;
+        g_platform.variorum_set_each_socket_power_limit =
+            fm_06_55_set_power_limits;
         g_platform.variorum_print_features = fm_06_55_get_features;
         g_platform.variorum_dump_thermals = fm_06_55_get_thermals;
         g_platform.variorum_dump_counters = fm_06_55_get_counters;
@@ -146,7 +151,8 @@ int set_intel_func_ptrs(void)
     else if (*g_platform.intel_arch == FM_06_9E)
     {
         g_platform.variorum_dump_power_limits = fm_06_9e_get_power_limits;
-        g_platform.variorum_set_each_socket_power_limit = fm_06_9e_set_power_limits;
+        g_platform.variorum_set_each_socket_power_limit =
+            fm_06_9e_set_power_limits;
         g_platform.variorum_print_features = fm_06_9e_get_features;
         g_platform.variorum_dump_thermals = fm_06_9e_get_thermals;
         g_platform.variorum_dump_counters = fm_06_9e_get_counters;

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -936,10 +936,6 @@ void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit,
     char sockID[4];                                                                 
     int i;
     double node_power = 0.0;                                                                         
-                                                                                    
-    char cpu_str[24] = "power_cpu_socket_";                                     
-    char mem_str[24] = "power_mem_socket_";
-    char gpu_str[24] = "power_gpu_socket_";      
                                  
     gethostname(hostname, 1024);                                                    
     variorum_get_topology(&nsockets, NULL, NULL);                                   
@@ -957,7 +953,13 @@ void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit,
     json_object_set_new(get_power_obj, "timestamp", json_integer(ts));              
                                                                                     
     for (i = 0; i < nsockets; i++)                                                  
-    {                                                                               
+    {  
+        /* Defined here so as to reset the string for each socket 
+         * and append correctly */                                                                            
+        char cpu_str[24] = "power_cpu_socket_";                                     
+        char mem_str[24] = "power_mem_socket_";
+        char gpu_str[24] = "power_gpu_socket_";      
+ 
         sprintf(sockID, "%d", i);                                                   
         strcat(cpu_str, sockID);                                                    
         strcat(mem_str, sockID);                                                    

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -922,79 +922,79 @@ void dump_power_data(FILE *writedest, off_t msr_power_limit,
     }
 }
 
-void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit, 
-                          off_t msr_rapl_unit, off_t msr_pkg_energy_status, 
+void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit,
+                          off_t msr_rapl_unit, off_t msr_pkg_energy_status,
                           off_t msr_dram_energy_status)
-{                                                                                   
-    static int init = 0;                                                            
-    static struct rapl_data *rapl = NULL;                                           
-    struct rapl_limit l1, l2;                                                       
-    int nsockets = 0;                                                               
-    char hostname[1024];                                                            
-    struct timeval tv;                                                              
-    uint64_t ts; 
-    char sockID[4];                                                                 
+{
+    static int init = 0;
+    static struct rapl_data *rapl = NULL;
+    struct rapl_limit l1, l2;
+    int nsockets = 0;
+    char hostname[1024];
+    struct timeval tv;
+    uint64_t ts;
+    char sockID[4];
     int i;
-    double node_power = 0.0;                                                                         
-                                 
-    gethostname(hostname, 1024);                                                    
-    variorum_get_topology(&nsockets, NULL, NULL);                                   
-                                                                                    
-    gettimeofday(&tv, NULL);                                                        
-    ts = tv.tv_sec*(uint64_t)1000000+tv.tv_usec;                           
+    double node_power = 0.0;
 
-    get_power(msr_rapl_unit, msr_pkg_energy_status, msr_dram_energy_status);    
-    if (!init)                                                                      
-    {                                                                               
-        rapl_storage(&rapl);                                                        
-    }                                                                               
-                                                                                    
-    json_object_set_new(get_power_obj, "hostname", json_string(hostname));          
-    json_object_set_new(get_power_obj, "timestamp", json_integer(ts));              
-                                                                                    
-    for (i = 0; i < nsockets; i++)                                                  
-    {  
-        /* Defined here so as to reset the string for each socket 
-         * and append correctly */                                                                            
-        char cpu_str[24] = "power_cpu_socket_";                                     
+    gethostname(hostname, 1024);
+    variorum_get_topology(&nsockets, NULL, NULL);
+
+    gettimeofday(&tv, NULL);
+    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
+
+    get_power(msr_rapl_unit, msr_pkg_energy_status, msr_dram_energy_status);
+    if (!init)
+    {
+        rapl_storage(&rapl);
+    }
+
+    json_object_set_new(get_power_obj, "hostname", json_string(hostname));
+    json_object_set_new(get_power_obj, "timestamp", json_integer(ts));
+
+    for (i = 0; i < nsockets; i++)
+    {
+        /* Defined here so as to reset the string for each socket
+         * and append correctly */
+        char cpu_str[24] = "power_cpu_socket_";
         char mem_str[24] = "power_mem_socket_";
-        char gpu_str[24] = "power_gpu_socket_";      
- 
-        sprintf(sockID, "%d", i);                                                   
-        strcat(cpu_str, sockID);                                                    
-        strcat(mem_str, sockID);                                                    
-        strcat(gpu_str, sockID);                                                    
-                                                                                    
-        get_package_rapl_limit(i, &l1, &l2, msr_power_limit, msr_rapl_unit);    
-                                                                                    
+        char gpu_str[24] = "power_gpu_socket_";
+
+        sprintf(sockID, "%d", i);
+        strcat(cpu_str, sockID);
+        strcat(mem_str, sockID);
+        strcat(gpu_str, sockID);
+
+        get_package_rapl_limit(i, &l1, &l2, msr_power_limit, msr_rapl_unit);
+
         json_object_set_new(get_power_obj, cpu_str, json_real(rapl->pkg_watts[i]));
         json_object_set_new(get_power_obj, mem_str, json_real(rapl->dram_watts[i]));
 
-        /* To ensure vendor-neutrality of the JSON power object across various 
+        /* To ensure vendor-neutrality of the JSON power object across various
            platforms, such as IBM, we set gpu_power to -1.0 here as MSRs do not
            report it. The negative -1.0 value indicates that the JSON object does
-           not contain the data for the associated key due to architecture 
-           limitations.  
+           not contain the data for the associated key due to architecture
+           limitations.
            TODO is to populate this through the NVIDIA NVML GPU power values
            when variorum is built with NVIDIA on Intel architectures. */
-        
+
         json_object_set_new(get_power_obj, gpu_str, json_real(-1.0));
 
-        
-        /* To ensure vendor-neutrality of the JSON power object across various 
-           platforms, such as IBM, we set power_sys as the sum of CPU and DRAM 
+
+        /* To ensure vendor-neutrality of the JSON power object across various
+           platforms, such as IBM, we set power_sys as the sum of CPU and DRAM
            power values. This is estimated node power, and is not total power on
-           the node. Intel platforms currently do not report total node power 
-           like the IBM platforms. We hope this changes in the future, and we 
+           the node. Intel platforms currently do not report total node power
+           like the IBM platforms. We hope this changes in the future, and we
            have an acutal measurement for node power instead, so the following
-           can be updated accordingly. */ 
-    
+           can be updated accordingly. */
+
         node_power += rapl->pkg_watts[i] + rapl->dram_watts[i];
-    }          
-                                                                     
-     // Set the node power key with pwrnode value.                                                                                  
-      json_object_set_new(get_power_obj, "power_node", json_real(node_power)); 
-}                                         
+    }
+
+    // Set the node power key with pwrnode value.
+    json_object_set_new(get_power_obj, "power_node", json_real(node_power));
+}
 
 
 //int dump_rapl_data(FILE *writedest)

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <sys/time.h>
 #include <unistd.h>
+#include <string.h>
 
 #include <power_features.h>
 #include <config_architecture.h>
@@ -920,6 +921,79 @@ void dump_power_data(FILE *writedest, off_t msr_power_limit,
                 now.tv_sec - start.tv_sec + (now.tv_usec - start.tv_usec) / 1000000.0);
     }
 }
+
+void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit, 
+                          off_t msr_rapl_unit, off_t msr_pkg_energy_status, 
+                          off_t msr_dram_energy_status)
+{                                                                                   
+    static int init = 0;                                                            
+    static struct rapl_data *rapl = NULL;                                           
+    struct rapl_limit l1, l2;                                                       
+    int nsockets = 0;                                                               
+    char hostname[1024];                                                            
+    struct timeval tv;                                                              
+    uint64_t ts; 
+    char sockID[4];                                                                 
+    int i;
+    double node_power = 0.0;                                                                         
+                                                                                    
+    char cpu_str[24] = "power_cpu_socket_";                                     
+    char mem_str[24] = "power_mem_socket_";
+    char gpu_str[24] = "power_gpu_socket_";      
+                                 
+    gethostname(hostname, 1024);                                                    
+    variorum_get_topology(&nsockets, NULL, NULL);                                   
+                                                                                    
+    gettimeofday(&tv, NULL);                                                        
+    ts = tv.tv_sec*(uint64_t)1000000+tv.tv_usec;                           
+
+    get_power(msr_rapl_unit, msr_pkg_energy_status, msr_dram_energy_status);    
+    if (!init)                                                                      
+    {                                                                               
+        rapl_storage(&rapl);                                                        
+    }                                                                               
+                                                                                    
+    json_object_set_new(get_power_obj, "hostname", json_string(hostname));          
+    json_object_set_new(get_power_obj, "timestamp", json_integer(ts));              
+                                                                                    
+    for (i = 0; i < nsockets; i++)                                                  
+    {                                                                               
+        sprintf(sockID, "%d", i);                                                   
+        strcat(cpu_str, sockID);                                                    
+        strcat(mem_str, sockID);                                                    
+        strcat(gpu_str, sockID);                                                    
+                                                                                    
+        get_package_rapl_limit(i, &l1, &l2, msr_power_limit, msr_rapl_unit);    
+                                                                                    
+        json_object_set_new(get_power_obj, cpu_str, json_real(rapl->pkg_watts[i]));
+        json_object_set_new(get_power_obj, mem_str, json_real(rapl->dram_watts[i]));
+
+        /* To ensure vendor-neutrality of the JSON power object across various 
+           platforms, such as IBM, we set gpu_power to -1.0 here as MSRs do not
+           report it. The negative -1.0 value indicates that the JSON object does
+           not contain the data for the associated key due to architecture 
+           limitations.  
+           TODO is to populate this through the NVIDIA NVML GPU power values
+           when variorum is built with NVIDIA on Intel architectures. */
+        
+        json_object_set_new(get_power_obj, gpu_str, json_real(-1.0));
+
+        
+        /* To ensure vendor-neutrality of the JSON power object across various 
+           platforms, such as IBM, we set power_sys as the sum of CPU and DRAM 
+           power values. This is estimated node power, and is not total power on
+           the node. Intel platforms currently do not report total node power 
+           like the IBM platforms. We hope this changes in the future, and we 
+           have an acutal measurement for node power instead, so the following
+           can be updated accordingly. */ 
+    
+        node_power += rapl->pkg_watts[i] + rapl->dram_watts[i];
+    }          
+                                                                     
+     // Set the node power key with pwrnode value.                                                                                  
+      json_object_set_new(get_power_obj, "power_node", json_real(node_power)); 
+}                                         
+
 
 //int dump_rapl_data(FILE *writedest)
 //{

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/types.h>
+#include <jansson.h>
 
 #define UINT_MAX 4294967295U // taken from limits.h
 #define STD_ENERGY_UNIT 65536.0
@@ -218,6 +219,13 @@ void print_power_data(FILE *writedest,
                       off_t msr_rapl_unit,
                       off_t msr_pkg_energy_status,
                       off_t msr_dram_energy_status);
+
+                                                                                   
+void json_dump_power_data(json_t *get_power_obj,                                   
+                          off_t msr_power_limit,                                   
+                          off_t msr_rapl_unit,                                     
+                          off_t msr_pkg_energy_status,                             
+                          off_t msr_dram_energy_status);    
 
 /// @brief Store the RAPL data on the heap.
 ///

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -220,12 +220,12 @@ void print_power_data(FILE *writedest,
                       off_t msr_pkg_energy_status,
                       off_t msr_dram_energy_status);
 
-                                                                                   
-void json_dump_power_data(json_t *get_power_obj,                                   
-                          off_t msr_power_limit,                                   
-                          off_t msr_rapl_unit,                                     
-                          off_t msr_pkg_energy_status,                             
-                          off_t msr_dram_energy_status);    
+
+void json_dump_power_data(json_t *get_power_obj,
+                          off_t msr_power_limit,
+                          off_t msr_rapl_unit,
+                          off_t msr_pkg_energy_status,
+                          off_t msr_dram_energy_status);
 
 /// @brief Store the RAPL data on the heap.
 ///

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -217,7 +217,7 @@ void variorum_init_func_ptrs()
     g_platform.variorum_dump_gpu_utilization = NULL;
     g_platform.variorum_cap_each_core_frequency = NULL;
     g_platform.variorum_monitoring = NULL;
-    g_platform.variorum_json_get_node_power= NULL;
+    g_platform.variorum_json_get_node_power = NULL;
 }
 
 int variorum_set_func_ptrs()

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -217,7 +217,7 @@ void variorum_init_func_ptrs()
     g_platform.variorum_dump_gpu_utilization = NULL;
     g_platform.variorum_cap_each_core_frequency = NULL;
     g_platform.variorum_monitoring = NULL;
-    g_platform.variorum_json_get_node_power = NULL;
+    g_platform.variorum_get_node_power_json = NULL;
 }
 
 int variorum_set_func_ptrs()

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -217,6 +217,7 @@ void variorum_init_func_ptrs()
     g_platform.variorum_dump_gpu_utilization = NULL;
     g_platform.variorum_cap_each_core_frequency = NULL;
     g_platform.variorum_monitoring = NULL;
+    g_platform.variorum_json_get_node_power= NULL;
 }
 
 int variorum_set_func_ptrs()

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -186,7 +186,7 @@ struct platform
     /// @brief Function pointer to get JSON object for node power data.
     ///
     /// @return Error code.
-    int (*variorum_json_get_node_power)(json_t *get_power_obj);
+    int (*variorum_get_node_power_json)(json_t *get_power_obj);
 
     /******************************/
     /* Platform-Specific Topology */

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -7,7 +7,7 @@
 #define CONFIG_ARCHIECTURE_H_INCLUDE
 
 #include <stdint.h>
-#include <jansson.h>  
+#include <jansson.h>
 
 #include <variorum_config.h>
 
@@ -183,11 +183,11 @@ struct platform
     /// @return Error code.
     int (*variorum_dump_gpu_utilization)(int long_ver);
 
-    /// @brief Function pointer to get JSON object for node power data.            
-    ///                                                                            
-    /// @return Error code.                                                        
-    int (*variorum_json_get_node_power)(json_t *get_power_obj);                    
-                                                                      
+    /// @brief Function pointer to get JSON object for node power data.
+    ///
+    /// @return Error code.
+    int (*variorum_json_get_node_power)(json_t *get_power_obj);
+
     /******************************/
     /* Platform-Specific Topology */
     /******************************/

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -7,6 +7,7 @@
 #define CONFIG_ARCHIECTURE_H_INCLUDE
 
 #include <stdint.h>
+#include <jansson.h>  
 
 #include <variorum_config.h>
 
@@ -182,6 +183,11 @@ struct platform
     /// @return Error code.
     int (*variorum_dump_gpu_utilization)(int long_ver);
 
+    /// @brief Function pointer to get JSON object for node power data.            
+    ///                                                                            
+    /// @return Error code.                                                        
+    int (*variorum_json_get_node_power)(json_t *get_power_obj);                    
+                                                                      
     /******************************/
     /* Platform-Specific Topology */
     /******************************/

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -769,3 +769,32 @@ int variorum_disable_turbo(void)
     }
     return err;
 }
+
+int variorum_json_get_node_power(json_t *get_power_obj)
+{
+    int err = 0;
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    if (g_platform.variorum_json_get_node_power == NULL)
+    {
+        variorum_error_handler("Feature not yet implemented or is not supported",
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               __FUNCTION__, __LINE__);
+        return 0;
+    }
+    err = g_platform.variorum_json_get_node_power(get_power_obj);
+    if (err)
+    {
+        return -1;
+    }
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
+

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -770,7 +770,7 @@ int variorum_disable_turbo(void)
     return err;
 }
 
-int variorum_json_get_node_power(json_t *get_power_obj)
+int variorum_get_node_power_json(json_t *get_power_obj)
 {
     int err = 0;
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
@@ -778,14 +778,14 @@ int variorum_json_get_node_power(json_t *get_power_obj)
     {
         return -1;
     }
-    if (g_platform.variorum_json_get_node_power == NULL)
+    if (g_platform.variorum_get_node_power_json == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_json_get_node_power(get_power_obj);
+    err = g_platform.variorum_get_node_power_json(get_power_obj);
     if (err)
     {
         return -1;

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -180,7 +180,7 @@ int variorum_disable_turbo(void);
 /// @brief Populate json_t object parameter with total node power.
 /////
 ///// @return Error code.
-int variorum_json_get_node_power(json_t *get_power_obj);
+int variorum_get_node_power_json(json_t *get_power_obj);
 
 /***************************/
 /* Testing */

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -7,6 +7,7 @@
 #define VARIORUM_H_INCLUDE
 
 #include <stdio.h>
+#include <jansson.h>
 
 /// @brief Collect power limits and energy usage for both the package and DRAM
 /// domains.
@@ -173,6 +174,17 @@ int variorum_enable_turbo(void);
 /// @return Error code.
 int variorum_disable_turbo(void);
 
+/***************************/
+/* JSON Support */
+/***************************/
+/// @brief Populate json_t object parameter with total node power.
+/////
+///// @return Error code.
+int variorum_json_get_node_power(json_t *get_power_obj);
+
+/***************************/
+/* Testing */
+/***************************/
 /// @brief Test for memory leaks.
 int variorum_tester(void);
 


### PR DESCRIPTION
Please see the commits for detailed information on the source code. 

Note that on IBM P9 platform, only the first socket (Chip-0) has the PWRSYS sensor, which reports total node power so this has to be handled as a separate if statement in the code. On Intel Broadwell, node power is not reported, and is estimated by adding CPU and DRAM power on both sockets. For GPU power, IBM P9 reports a single value which is the sum of power consumed by all the GPUs on a particular socket, which is why we have a "power_gpu_socket_*" interface. On Intel, this is set to -1.0 to indicate that the GPU power value cannot be measured directly through MSRs. This has been done to ensure that the JSON object in itself is vendor neutral from a tools perspective, that is, the tool that uses the API does not have to know what architecture it is on, necessarily, it can process a "-1.0" value as an unavailable power value, and can assume that for node power a reasonable estimate or best guess is made. We can always change this in the future. 

Currently the JSON object has the following fields:

- power_node
- power_cpu_socket_*
- power_mem_socket_*
- power_gpu_socket_*

The per-socket fields are implemented in a way that more than 2 sockets on the node can be handled, but in practice, all our systems have only 2 sockets. 

Sphinx documentation to follow as a separate PR that explains how to use the API correctly, describes the assumptions made from a vendor-neutrality point of view, and expected output. 