### PR TITLE
Node power cap support for Intel Broadwell

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -32,7 +32,7 @@ set(BASIC_EXAMPLES
     variorum-set-and-verify-node-power-limit-example
     variorum-cap-cpu-clock-speed-example
     variorum-set-gpu-power-ratio-example
-    variorum-set-node-power-limit-example
+    variorum-set-best-effort-node-power-limit-example
     variorum-set-socket-power-limits-example
     variorum-get-node-power-json-example
 )

--- a/src/examples/variorum-set-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-set-best-effort-node-power-limit-example.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
 
     if (argc == 1)
     {
-        printf("Please specify an input value in W for correctness.\n");
+        printf("Please specify an input value in Watts for correctness.\n");
         printf("Cannot set defaults due to architecture dependence.\n");
         return 0;
     }

--- a/src/examples/variorum-set-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-set-best-effort-node-power-limit-example.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
         printf("Setting node to %dW.\n", node_pow_lim_watts);
     }
 
-    ret = variorum_set_node_power_limit(node_pow_lim_watts);
+    ret = variorum_set_best_effort_node_power_limit(node_pow_lim_watts);
     if (ret != 0)
     {
         printf("Set node power limit failed!\n");

--- a/src/examples/variorum-set-node-power-limit-example.c
+++ b/src/examples/variorum-set-node-power-limit-example.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
     if (argc == 1)
     {
         printf("Please specify an input value in W for correctness.\n");
-        printf("Cannot set defaults as these can be architecture dependent.\n");
+        printf("Cannot set defaults due to architecture dependence.\n");
         return 0;
     }
     else if (argc == 2)

--- a/src/examples/variorum-set-node-power-limit-example.c
+++ b/src/examples/variorum-set-node-power-limit-example.c
@@ -15,9 +15,9 @@ int main(int argc, char **argv)
 
     if (argc == 1)
     {
-        printf("No power limit specified...using default limit of 500W.\n");
-        // 500W is based on minimum power on IBM Witherspoon
-        node_pow_lim_watts = 500;
+        printf("Please specify an input value in W for correctness.\n");
+        printf("Cannot set defaults as these can be architecture dependent.\n");
+        return 0;
     }
     else if (argc == 2)
     {

--- a/src/tests/variorum/CMakeLists.txt
+++ b/src/tests/variorum/CMakeLists.txt
@@ -6,7 +6,7 @@
 set(BASIC_TESTS
     t_variorum_gpu_power_ratio
     t_variorum_monitoring
-    t_variorum_node_power_limit
+    t_variorum_best_effort_node_power_limit
     t_variorum_poll_data
     t_variorum_query_clock_speed
     t_variorum_query_counters

--- a/src/tests/variorum/t_variorum_best_effort_node_power_limit.cpp
+++ b/src/tests/variorum/t_variorum_best_effort_node_power_limit.cpp
@@ -9,10 +9,10 @@ extern "C" {
 #include <variorum.h>
 }
 
-TEST(variorum_power_limit, test_set_node_power_limit)
+TEST(variorum_power_limit, test_set_best_effort_node_power_limit)
 {
-    int node_power_limit = 200;
-    EXPECT_EQ(0, variorum_set_node_power_limit(node_power_limit));
+    int node_pow_limit = 200;
+    EXPECT_EQ(0, variorum_set_best_effort_node_power_limit(node_pow_limit));
 }
 
 int main(int argc, char **argv)

--- a/src/variorum/IBM/config_ibm.c
+++ b/src/variorum/IBM/config_ibm.c
@@ -27,7 +27,8 @@ int set_ibm_func_ptrs(void)
     {
         g_platform.variorum_dump_power = p9_get_power;
         g_platform.variorum_dump_power_limits = p9_get_power_limits;
-        g_platform.variorum_set_node_power_limit = p9_set_node_power_limit;
+        g_platform.variorum_set_best_effort_node_power_limit =
+            p9_set_node_power_limit;
         g_platform.variorum_set_each_socket_power_limit =
             p9_set_socket_power_limit;
         g_platform.variorum_set_gpu_power_ratio = p9_set_gpu_power_ratio;

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -445,7 +445,7 @@ int fm_06_4f_set_best_effort_node_power_limit(int node_limit)
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     // Adding this for portability and rounding down.
-    // Ideally line 437 should be okay as it is integer division and we have
+    // Ideally line 451 should be okay as it is integer division and we have
     // two sockets only.
 
     int remainder = node_limit % nsockets;

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -142,7 +142,8 @@ int fm_06_4f_set_power_limits(int package_power_limit)
 
     for (socket = 0; socket < nsockets; socket++)
     {
-        set_package_power_limit(socket, package_power_limit, msrs.msr_pkg_power_limit,
+        set_package_power_limit(socket, package_power_limit,
+                                msrs.msr_pkg_power_limit,
                                 msrs.msr_rapl_power_unit);
     }
     return 0;
@@ -264,12 +265,14 @@ int fm_06_4f_get_thermals(int long_ver)
     if (long_ver == 0)
     {
         dump_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+                                msrs.ia32_package_therm_status,
+                                msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
         print_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+                                 msrs.ia32_package_therm_status,
+                                 msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -283,16 +286,22 @@ int fm_06_4f_get_counters(int long_ver)
     if (long_ver == 0)
     {
         dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
-                              msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                              msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+                              msrs.ia32_perf_global_ctrl,
+                              msrs.ia32_fixed_ctr_ctrl,
+                              msrs.ia32_perfevtsel_counters,
+                              msrs.ia32_perfmon_counters,
+                              msrs.msrs_pcu_pmon_evtsel,
+                              msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
         print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
-                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+                               msrs.ia32_perf_global_ctrl,
+                               msrs.ia32_fixed_ctr_ctrl,
+                               msrs.ia32_perfevtsel_counters,
+                               msrs.ia32_perfmon_counters,
+                               msrs.msrs_pcu_pmon_evtsel,
+                               msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -306,14 +315,14 @@ int fm_06_4f_get_clocks(int long_ver)
     if (long_ver == 0)
     {
         dump_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                         msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                         CORE);
+                         msrs.ia32_time_stamp_counter, msrs.ia32_perf_status,
+                         msrs.msr_platform_info, CORE);
     }
     else if (long_ver == 1)
     {
         print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                          CORE);
+                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status,
+                          msrs.msr_platform_info, CORE);
     }
     return 0;
 }
@@ -326,13 +335,15 @@ int fm_06_4f_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
-                        msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        dump_power_data(stdout, msrs.msr_pkg_power_limit,
+                        msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                        msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
-                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_pkg_power_limit,
+                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                         msrs.msr_dram_energy_status);
     }
     return 0;
 }
@@ -379,9 +390,9 @@ int fm_06_4f_poll_power(FILE *output)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    get_all_power_data(output, msrs.msr_pkg_power_limit, msrs.msr_dram_power_limit,
-                       msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
-                       msrs.msr_dram_energy_status);
+    get_all_power_data(output, msrs.msr_pkg_power_limit,
+                       msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit,
+                       msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     return 0;
 }
 
@@ -392,9 +403,13 @@ int fm_06_4f_monitoring(FILE *output)
 #endif
 
     get_all_power_data_fixed(output, msrs.msr_pkg_power_limit,
-                             msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
-                             msrs.msr_dram_energy_status, msrs.ia32_fixed_counters,
-                             msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl, msrs.ia32_aperf,
+                             msrs.msr_dram_power_limit,
+                             msrs.msr_rapl_power_unit,
+                             msrs.msr_pkg_energy_status,
+                             msrs.msr_dram_energy_status,
+                             msrs.ia32_fixed_counters,
+                             msrs.ia32_perf_global_ctrl,
+                             msrs.ia32_fixed_ctr_ctrl, msrs.ia32_aperf,
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
     return 0;
 }
@@ -412,33 +427,33 @@ int fm_06_4f_get_node_power_json(json_t *get_power_obj)
     return 0;
 }
 
-int fm_06_4f_set_node_power_limit(int node_limit)
+int fm_06_4f_set_best_effort_node_power_limit(int node_limit)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    /* We make an assumption here to uniformly distribute the specified 
+    /* We make an assumption here to uniformly distribute the specified
      * power to both sockets as socket-level power caps. We are not accounting
      * for memory power or uncore power at the moment. We will develop a model
-     * for this in the future. 
-     * When an odd number value is provided, we want this to result in 
-     * the floor of the value being taken. So while we will be off by 1W total, 
+     * for this in the future.
+     * When an odd number value is provided, we want this to result in
+     * the floor of the value being taken. So while we will be off by 1W total,
      * we will guarantee that we stay under the specified cap. */
 
     int nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
-    // Adding this for portability and rounding down. 
+    // Adding this for portability and rounding down.
     // Ideally line 437 should be okay as it is integer division and we have
-    // two sockets only. 
+    // two sockets only.
 
-    int remainder = node_limit % nsockets; 
+    int remainder = node_limit % nsockets;
     node_limit = (remainder == 0) ? node_limit : (node_limit - remainder);
 
-    int pkg_limit = node_limit/nsockets; 
+    int pkg_limit = node_limit / nsockets;
 
-    fm_06_4f_set_power_limits(pkg_limit); 
+    fm_06_4f_set_power_limits(pkg_limit);
 
     return 0;
 }

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -103,4 +103,6 @@ int fm_06_4f_poll_power(FILE *output);
 int fm_06_4f_monitoring(FILE *output);
 
 int fm_06_4f_get_node_power_json(json_t *get_power_obj);
+
+int fm_06_4f_set_node_power_limit(int node_power_limit); 
 #endif

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -104,5 +104,5 @@ int fm_06_4f_monitoring(FILE *output);
 
 int fm_06_4f_get_node_power_json(json_t *get_power_obj);
 
-int fm_06_4f_set_node_power_limit(int node_power_limit); 
+int fm_06_4f_set_best_effort_node_power_limit(int node_power_limit);
 #endif

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -128,6 +128,8 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_monitoring = fm_06_4f_monitoring;
         //g_platform.variorum_cap_each_core_frequency = fm_06_4f_set_frequency;
         g_platform.variorum_get_node_power_json = fm_06_4f_get_node_power_json;
+        g_platform.variorum_set_node_power_limit = 
+            fm_06_4f_set_node_power_limit;
     }
     // Skylake 06_55
     else if (*g_platform.intel_arch == FM_06_55)

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -42,8 +42,9 @@ int gpu_power_ratio_unimplemented(int long_ver)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    variorum_error_handler("GPU power ratio is not available on Intel platforms",
-                           VARIORUM_ERROR_FEATURE_NOT_AVAILABLE, getenv("HOSTNAME"), __FILE__,
+    variorum_error_handler("GPU power ratio is unavailable on Intel platforms",
+                           VARIORUM_ERROR_FEATURE_NOT_AVAILABLE,
+                           getenv("HOSTNAME"), __FILE__,
                            __FUNCTION__, __LINE__);
     return 0;
 }
@@ -72,7 +73,8 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_disable_turbo = fm_06_2a_disable_turbo;
         g_platform.variorum_poll_power = fm_06_2a_poll_power;
         g_platform.variorum_monitoring = fm_06_2a_monitoring;
-        //g_platform.variorum_cap_each_core_frequency = fm_06_2a_set_frequency;
+        //g_platform.variorum_cap_each_core_frequency =
+        //fm_06_2a_set_frequency;
     }
     // Ivy Bridge 06_3E
     else if (*g_platform.intel_arch == FM_06_3E)
@@ -90,7 +92,8 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_disable_turbo = fm_06_3e_disable_turbo;
         g_platform.variorum_poll_power = fm_06_3e_poll_power;
         g_platform.variorum_monitoring = fm_06_3e_monitoring;
-        //g_platform.cap_each_core_frequency = fm_06_3e_set_frequency;
+        //g_platform.variorum_cap_each_core_frequency =
+        //fm_06_3e_set_frequency;
     }
     // Haswell 06_3F
     else if (*g_platform.intel_arch == FM_06_3F)
@@ -108,7 +111,8 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_disable_turbo = fm_06_3f_disable_turbo;
         g_platform.variorum_poll_power = fm_06_3f_poll_power;
         g_platform.variorum_monitoring = fm_06_3f_monitoring;
-        //g_platform.cap_each_core_frequency = fm_06_3f_set_frequency;
+        //g_platform.variorum_cap_each_core_frequency =
+        //fm_06_3f_set_frequency;
     }
     // Broadwell 06_4F
     else if (*g_platform.intel_arch == FM_06_4F)
@@ -126,10 +130,12 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_disable_turbo = fm_06_4f_disable_turbo;
         g_platform.variorum_poll_power = fm_06_4f_poll_power;
         g_platform.variorum_monitoring = fm_06_4f_monitoring;
-        //g_platform.variorum_cap_each_core_frequency = fm_06_4f_set_frequency;
-        g_platform.variorum_get_node_power_json = fm_06_4f_get_node_power_json;
-        g_platform.variorum_set_node_power_limit = 
-            fm_06_4f_set_node_power_limit;
+        //g_platform.variorum_cap_each_core_frequency =
+        //fm_06_4f_set_frequency;
+        g_platform.variorum_get_node_power_json =
+            fm_06_4f_get_node_power_json;
+        g_platform.variorum_set_best_effort_node_power_limit =
+            fm_06_4f_set_best_effort_node_power_limit;
     }
     // Skylake 06_55
     else if (*g_platform.intel_arch == FM_06_55)

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -41,15 +41,17 @@ int variorum_enter(const char *filename, const char *func_name, int line_num)
     err = variorum_detect_arch();
     if (err)
     {
-        variorum_error_handler("Cannot detect architecture", err, getenv("HOSTNAME"),
-                               __FILE__, __FUNCTION__, __LINE__);
+        variorum_error_handler("Cannot detect architecture", err,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                               __LINE__);
         return err;
     }
     err = variorum_set_func_ptrs();
     if (err)
     {
-        variorum_error_handler("Cannot set function pointers", err, getenv("HOSTNAME"),
-                               __FILE__, __FUNCTION__, __LINE__);
+        variorum_error_handler("Cannot set function pointers", err,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                               __LINE__);
         return err;
     }
     return err;
@@ -114,7 +116,8 @@ int variorum_detect_arch(void)
         g_platform.nvidia_arch  == NULL)
     {
         variorum_error_handler("No architectures detected", VARIORUM_ERROR_RUNTIME,
-                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                               __LINE__);
         return VARIORUM_ERROR_UNSUPPORTED_ARCH;
     }
 
@@ -201,7 +204,7 @@ void variorum_get_topology(int *nsockets, int *ncores, int *nthreads)
 void variorum_init_func_ptrs()
 {
     g_platform.variorum_dump_power_limits = NULL;
-    g_platform.variorum_set_node_power_limit = NULL;
+    g_platform.variorum_set_best_effort_node_power_limit = NULL;
     g_platform.variorum_set_and_verify_node_power_limit = NULL;
     g_platform.variorum_set_gpu_power_ratio = NULL;
     g_platform.variorum_set_each_socket_power_limit = NULL;

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -33,8 +33,9 @@ enum ctl_domains_e
     SOCKET,
     NODE,
     TILE,
-    UNIQUE, // Each processor core has a separate MSR, or a bit field in an MSR governs only a core independently.
-    SHARED // MSR or bit field in an MSR governs the operation of both processor cores.
+    UNIQUE, // Each processor core has a separate MSR,
+    // or a bit field in an MSR governs only a core independently.
+    SHARED // MSR or bit field that governs the operation of both processor cores.
 };
 
 /// @brief List of Intel family and models.
@@ -99,20 +100,23 @@ struct platform
     /// @param [in] node_power_limit Desired node power limit in Watts.
     ///
     /// @return Error code.
-    int (*variorum_set_node_power_limit)(int node_power_limit);
+    int (*variorum_set_best_effort_node_power_limit)(int node_power_limit);
 
-    /// @brief Function pointer to set a power limit to each node and then verify that the cap was set correctly.
+    /// @brief Function pointer to set a power limit to each node and then
+    //  verify that the cap was set correctly.
     ///
     /// @param [in] node_power_limit Desired node power limit in Watts.
     ///
     /// @return Error code.
     int (*variorum_set_and_verify_node_power_limit)(int node_power_limit);
 
-    /// @brief Set the power shifting ratio to the GPU (uniform on both sockets).
+    /// @brief Set the GPU power shifting ratio (uniform across sockets).
     ///
-    /// @param [in] gpu_power_ratio Desired power ratio (percentage) for the processor and GPU.
+    /// @param [in] gpu_power_ratio Desired power ratio (percent) for the
+    //  processor and GPU.
     ///
-    /// @note Only valid on IBM P9 systems for now. Same ratio will be set on both sockets.
+    /// @note Only valid on IBM P9 systems for now.
+    //  Same ratio will be set on both sockets.
     ///
     /// @return Error code.
     int (*variorum_set_gpu_power_ratio)(int gpu_power_ratio);

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -65,7 +65,8 @@ int variorum_poll_power(FILE *output)
     if (g_platform.variorum_poll_power == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -93,7 +94,8 @@ int variorum_monitoring(FILE *output)
     if (g_platform.variorum_monitoring == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -121,7 +123,8 @@ int variorum_print_power_limits(void)
     if (g_platform.variorum_dump_power_limits == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -149,7 +152,8 @@ int variorum_print_verbose_power_limits(void)
     if (g_platform.variorum_dump_power_limits == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -208,7 +212,7 @@ void variorum_print_topology(void)
     return;
 }
 
-int variorum_set_node_power_limit(int node_power_limit)
+int variorum_set_best_effort_node_power_limit(int node_power_limit)
 {
     int err = 0;
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
@@ -216,14 +220,15 @@ int variorum_set_node_power_limit(int node_power_limit)
     {
         return -1;
     }
-    if (g_platform.variorum_set_node_power_limit == NULL)
+    if (g_platform.variorum_set_best_effort_node_power_limit == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_set_node_power_limit(node_power_limit);
+    err = g_platform.variorum_set_best_effort_node_power_limit(node_power_limit);
     if (err)
     {
         return -1;
@@ -248,7 +253,8 @@ int variorum_set_and_verify_node_power_limit(int node_power_limit)
     if (g_platform.variorum_set_and_verify_node_power_limit == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -277,7 +283,8 @@ int variorum_set_gpu_power_ratio(int gpu_power_ratio)
     if (g_platform.variorum_set_gpu_power_ratio == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -305,7 +312,8 @@ int variorum_set_each_socket_power_limit(int socket_power_limit)
     if (g_platform.variorum_set_each_socket_power_limit == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -333,7 +341,8 @@ int variorum_cap_each_core_frequency(int core_freq_mhz)
     if (g_platform.variorum_cap_each_core_frequency == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -361,7 +370,8 @@ int variorum_print_features(void)
     if (g_platform.variorum_print_features == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -389,7 +399,8 @@ int variorum_print_thermals(void)
     if (g_platform.variorum_dump_thermals == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -417,7 +428,8 @@ int variorum_print_verbose_thermals(void)
     if (g_platform.variorum_dump_thermals == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -445,7 +457,8 @@ int variorum_print_counters(void)
     if (g_platform.variorum_dump_counters == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -473,7 +486,8 @@ int variorum_print_verbose_counters(void)
     if (g_platform.variorum_dump_counters == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -501,7 +515,8 @@ int variorum_print_clock_speed(void)
     if (g_platform.variorum_dump_clocks == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -529,7 +544,8 @@ int variorum_print_verbose_clock_speed(void)
     if (g_platform.variorum_dump_clocks == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -557,7 +573,8 @@ int variorum_print_power(void)
     if (g_platform.variorum_dump_power == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -585,7 +602,8 @@ int variorum_print_verbose_power(void)
     if (g_platform.variorum_dump_power == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -640,7 +658,8 @@ int variorum_print_turbo(void)
     if (g_platform.variorum_dump_turbo == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -669,7 +688,8 @@ int variorum_print_gpu_utilization(void)
     if (g_platform.variorum_dump_gpu_utilization == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -697,7 +717,8 @@ int variorum_print_verbose_gpu_utilization(void)
     if (g_platform.variorum_dump_gpu_utilization == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -725,7 +746,8 @@ int variorum_enable_turbo(void)
     if (g_platform.variorum_enable_turbo == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -753,7 +775,8 @@ int variorum_disable_turbo(void)
     if (g_platform.variorum_disable_turbo == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }
@@ -781,7 +804,8 @@ int variorum_get_node_power_json(json_t *get_power_obj)
     if (g_platform.variorum_get_node_power_json == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
     }

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -35,7 +35,8 @@ int variorum_monitoring(FILE *output);
 /// @return Error code.
 int variorum_set_each_socket_power_limit(int socket_power_limit);
 
-/// @brief Set a power limit to the node and verify if it was set correctly (10ms delay).
+/// @brief Set a power limit to the node and verify if it was set correctly
+//  (10ms delay).
 ///
 /// @param [in] node_power_limit Desired power limit for the node.
 ///
@@ -47,13 +48,14 @@ int variorum_set_and_verify_node_power_limit(int node_power_limit);
 /// @param [in] node_power_limit Desired power limit for the node.
 ///
 /// @return Error code.
-int variorum_set_node_power_limit(int node_power_limit);
+int variorum_set_best_effort_node_power_limit(int node_power_limit);
 
 /// @brief Set the power shifting ratio to the GPU (uniform on both sockets).
 ///
-/// @param [in] gpu_power_ratio Desired power ratio (percentage) for the processor and GPU.
+/// @param [in] gpu_power_ratio Desired power ratio (percentage).
+//  for the processor and GPU.
 ///
-/// @note Only valid on IBM P9 systems for now. Same ratio will be set on both sockets.
+/// @note Only valid on IBM P9 systems for now. Same ratio on both sockets.
 /////
 ///// @return Error code.
 int variorum_set_gpu_power_ratio(int gpu_power_ratio);


### PR DESCRIPTION
Add support for power capping a node on Intel Broadwell. As discussed, we take the input value and divide it by number of sockets, and set this as the uniform power cap on each socket. We will develop a model later that accomodates for memory, uncore and other components. This is a first cut to add support for Flux on Quartz.