### PR TITLE
Allow travis script to work with older msr-safe.

### DIFF
--- a/scripts/travis/load-msr-safe.sh
+++ b/scripts/travis/load-msr-safe.sh
@@ -30,24 +30,22 @@ ls -l /dev/cpu/*/msr_safe
 # The version information for msr-safe resides in /sys/module/msr_safe/version
 MSR_SAFE_VERSION=`cat /sys/module/msr_safe/version`
 
-# coreutils-7 and later have the -V option for sort.  Verify via sort --version.
-if [ `echo -e "${MSR_SAFE_VERSION}\n1.3" | sort -V | head -n1` = "1.4" ]; then 
-
-
-	# MSR_SAFE_VERSION is less than 1.4, so we need to deal with whitelists.
-	WL=$(printf 'wl_%.2x%x\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
-	echo -e "WL:" ${WL}
-
-	cat whitelists/${WL} > /dev/cpu/msr_whitelist
-	cat /dev/cpu/msr_whitelist | head
-
-else
-	# MSR_SAFE_VERSION is 1.4 or greater, so we need to deal with allowlists.
+# coreutils-7 and later have the -V option for sort.  Verify via sort --version,
+#  which puts the earlier version first.
+if [ `echo -e "${MSR_SAFE_VERSION}\n1.5" | sort -V | head -n1` = "1.5" ]; then 
+	# MSR_SAFE_VERSION is 1.5 or greater, so we need to deal with allowlists.
 	AL=$(printf 'al_%.2x%x\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
 	echo -e "AL:" ${AL}
 
 	cat allowlists/${WL} > /dev/cpu/msr_allowlist
 	cat /dev/cpu/msr_allowlist | head
+else
+	# MSR_SAFE_VERSION is less than 1.5, so we need to deal with whitelists.
+	WL=$(printf 'wl_%.2x%x\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
+	echo -e "WL:" ${WL}
+
+	cat whitelists/${WL} > /dev/cpu/msr_whitelist
+	cat /dev/cpu/msr_whitelist | head
 fi
 
 

--- a/scripts/travis/load-msr-safe.sh
+++ b/scripts/travis/load-msr-safe.sh
@@ -27,10 +27,28 @@ sleep 2
 ls -l /dev/cpu
 ls -l /dev/cpu/*/msr_safe
 
-WL=$(printf 'wl_%.2x%x\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
-echo -e "WL:" ${WL}
+# The version information for msr-safe resides in /sys/module/msr_safe/version
+MSR_SAFE_VERSION=`cat /sys/module/msr_safe/version`
 
-cat whitelists/${WL} > /dev/cpu/msr_whitelist
-cat /dev/cpu/msr_whitelist | head
+# coreutils-7 and later have the -V option for sort.  Verify via sort --version.
+if [ `echo -e "${MSR_SAFE_VERSION}\n1.3" | sort -V | head -n1` = "1.4" ]; then 
+
+
+	# MSR_SAFE_VERSION is less than 1.4, so we need to deal with whitelists.
+	WL=$(printf 'wl_%.2x%x\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
+	echo -e "WL:" ${WL}
+
+	cat whitelists/${WL} > /dev/cpu/msr_whitelist
+	cat /dev/cpu/msr_whitelist | head
+
+else
+	# MSR_SAFE_VERSION is 1.4 or greater, so we need to deal with allowlists.
+	AL=$(printf 'al_%.2x%x\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
+	echo -e "AL:" ${AL}
+
+	cat allowlists/${WL} > /dev/cpu/msr_allowlist
+	cat /dev/cpu/msr_allowlist | head
+fi
+
 
 #

--- a/src/docs/sphinx/QuickStart.rst
+++ b/src/docs/sphinx/QuickStart.rst
@@ -29,7 +29,7 @@ Accessing Low-Level Registers
 
 To use Variorum on Intel platforms, the `msr-safe
 <https://github.com/llnl/msr-safe>`_ kernel driver must be loaded to enable
-user-level read and write of whitelisted MSRs.
+user-level read and write of allowed MSRs.
 
 Alternately, you can use Variorum as root with the stock MSR kernel driver
 loaded.

--- a/src/docs/sphinx/Utilities.rst
+++ b/src/docs/sphinx/Utilities.rst
@@ -73,7 +73,7 @@ From the top-level Variorum directory:
 
 .. code:: bash
 
-   brink2@quartz5:~]$ python ./src/utilities/verify_msr_kernel.py -v
+   brink2@quartz5:~]$ python3 ./src/utilities/verify_msr_kernel.py -v
    ######################
    # x86 CPU MSR Access #
    ######################
@@ -86,7 +86,7 @@ From the top-level Variorum directory:
    -- Check if msr_safe kernel files are character devices: /dev/cpu/3/msr_safe -- yes
    ...
    -- Check if msr_safe kernel files are character devices: /dev/cpu/71/msr_safe -- yes
-   -- Check if msr_safe kernel files are character devices: /dev/cpu/msr_whitelist -- yes
+   -- Check if msr_safe kernel files are character devices: /dev/cpu/msr_allowlist -- yes
    -- Check if msr_safe kernel files are character devices: /dev/cpu/msr_batch -- yes
    -- Check if msr_safe kernel files are accessible by user
    -- Check if msr_safe kernel files are accessible by user: /dev/cpu/0/msr_safe -- yes
@@ -95,7 +95,7 @@ From the top-level Variorum directory:
    -- Check if msr_safe kernel files are accessible by user: /dev/cpu/3/msr_safe -- yes
    ...
    -- Check if msr_safe kernel files are accessible by user: /dev/cpu/71/msr_safe -- yes
-   -- Check if msr_safe kernel files are accessible by user: /dev/cpu/msr_whitelist -- yes
+   -- Check if msr_safe kernel files are accessible by user: /dev/cpu/msr_allowlist -- yes
    -- Check if msr_safe kernel files are accessible by user: /dev/cpu/msr_batch -- yes
    -- Valid kernel loaded: msr-safe
 

--- a/src/tests/system-env/intel/CMakeLists.txt
+++ b/src/tests/system-env/intel/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 set(BASIC_TESTS
   t_system_env_intel_msr_safe_driver
-  t_system_env_intel_msr_safe_whitelist
+  t_system_env_intel_msr_safe_allowlist
 )
 
 set(UNIT_TEST_BASE_LIBS gtest_main gtest)

--- a/src/tests/system-env/intel/t_system_env_intel_msr_safe_allowlist.cpp
+++ b/src/tests/system-env/intel/t_system_env_intel_msr_safe_allowlist.cpp
@@ -72,7 +72,7 @@ TEST(MsrAllowlist, Exists)
 {
     char *filename;
 
-#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
     asprintf(&filename, "/dev/cpu/msr_whitelist");
 #else
     asprintf(&filename, "/dev/cpu/msr_allowlist");
@@ -85,7 +85,7 @@ TEST(MsrAllowlist, Perms)
 {
     char *filename;
 
-#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
     asprintf(&filename, "/dev/cpu/msr_whitelist");
 #else
     asprintf(&filename, "/dev/cpu/msr_allowlist");
@@ -98,7 +98,7 @@ TEST(MsrAllowlist, Size)
 {
     char *filename;
 
-#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
     asprintf(&filename, "/dev/cpu/msr_whitelist");
 #else
     asprintf(&filename, "/dev/cpu/msr_allowlist");

--- a/src/tests/system-env/intel/t_system_env_intel_msr_safe_allowlist.cpp
+++ b/src/tests/system-env/intel/t_system_env_intel_msr_safe_allowlist.cpp
@@ -45,11 +45,11 @@ int check_other_permissions(const char *file)
     return EXIT_SUCCESS;
 }
 
-int whitelist_size(const char *file)
+int allowlist_size(const char *file)
 {
     std::ifstream infile(file);
     std::string line;
-    std::string tmp = "tmp_whitelist";
+    std::string tmp = "tmp_allowlist";
     std::ofstream outfile;
 
     outfile.open(tmp.c_str());
@@ -68,31 +68,43 @@ int whitelist_size(const char *file)
     return statbuf.st_size;
 }
 
-TEST(MsrWhitelist, Exists)
+TEST(MsrAllowlist, Exists)
 {
     char *filename;
 
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
     asprintf(&filename, "/dev/cpu/msr_whitelist");
+#else
+    asprintf(&filename, "/dev/cpu/msr_allowlist");
+#endif
     EXPECT_EQ(0, is_file_exist(filename));
     free(filename);
 }
 
-TEST(MsrWhitelist, Perms)
+TEST(MsrAllowlist, Perms)
 {
     char *filename;
 
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
     asprintf(&filename, "/dev/cpu/msr_whitelist");
+#else
+    asprintf(&filename, "/dev/cpu/msr_allowlist");
+#endif
     EXPECT_EQ(1, check_other_permissions(filename));
     free(filename);
 }
 
-TEST(MsrWhitelist, Size)
+TEST(MsrAllowlist, Size)
 {
     char *filename;
 
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
     asprintf(&filename, "/dev/cpu/msr_whitelist");
-    /* Valid whitelist should not be empty */
-    EXPECT_NE(0, whitelist_size(filename));
+#else
+    asprintf(&filename, "/dev/cpu/msr_allowlist");
+#endif
+    /* Valid list should not be empty */
+    EXPECT_NE(0, allowlist_size(filename));
     free(filename);
 }
 

--- a/src/utilities/verify_msr_kernel.py
+++ b/src/utilities/verify_msr_kernel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
 # Variorum Project Developers. See the top-level LICENSE file for details.
@@ -6,13 +6,12 @@
 # SPDX-License-Identifier: MIT
 
 from __future__ import print_function
-
+from packaging import version
 import os
 import sys
 
 import pathlib
 import getopt
-
 
 # check msr_safe kernel is loaded
 def check_msr_safe_kernel_loaded(verbose):
@@ -62,7 +61,12 @@ def check_msr_safe_files_character_devices(verbose):
                 )
             ret = 1
 
-    wl_file = "/dev/cpu/msr_whitelist"
+    msr_safe_version = open("/sys/module/msr_safe/version").readline().strip()
+    if( version.parse( msr_safe_version ) < version.parse( "1.4" )):
+        wl_file = "/dev/cpu/msr_whitelist"
+    else:
+        wl_file = "/dev/cpu/msr_allowlist"
+
     p = pathlib.Path(wl_file)
     if p.is_char_device():
         if verbose:
@@ -130,7 +134,12 @@ def check_msr_safe_files_access(verbose):
                 )
             ret = 1
 
-    wl_file = "/dev/cpu/msr_whitelist"
+    msr_safe_version = open("/sys/module/msr_safe/version").readline().strip()
+    if( version.parse( msr_safe_version ) < version.parse( "1.4" )):
+        wl_file = "/dev/cpu/msr_whitelist"
+    else:
+        wl_file = "/dev/cpu/msr_allowlist"
+
     if os.access(wl_file, os.R_OK):
         if verbose:
             print(

--- a/src/utilities/verify_msr_kernel.py
+++ b/src/utilities/verify_msr_kernel.py
@@ -13,6 +13,7 @@ import sys
 import pathlib
 import getopt
 
+
 # check msr_safe kernel is loaded
 def check_msr_safe_kernel_loaded(verbose):
     if verbose:
@@ -62,7 +63,7 @@ def check_msr_safe_files_character_devices(verbose):
             ret = 1
 
     msr_safe_version = open("/sys/module/msr_safe/version").readline().strip()
-    if( version.parse( msr_safe_version ) < version.parse( "1.4" )):
+    if version.parse(msr_safe_version) < version.parse("1.4"):
         wl_file = "/dev/cpu/msr_whitelist"
     else:
         wl_file = "/dev/cpu/msr_allowlist"
@@ -135,7 +136,7 @@ def check_msr_safe_files_access(verbose):
             ret = 1
 
     msr_safe_version = open("/sys/module/msr_safe/version").readline().strip()
-    if( version.parse( msr_safe_version ) < version.parse( "1.4" )):
+    if version.parse(msr_safe_version) < version.parse("1.4"):
         wl_file = "/dev/cpu/msr_whitelist"
     else:
         wl_file = "/dev/cpu/msr_allowlist"

--- a/src/utilities/verify_msr_kernel.py
+++ b/src/utilities/verify_msr_kernel.py
@@ -7,9 +7,9 @@
 
 from __future__ import print_function
 from packaging import version
+
 import os
 import sys
-
 import pathlib
 import getopt
 

--- a/src/variorum/Intel/msr_core.c
+++ b/src/variorum/Intel/msr_core.c
@@ -23,6 +23,7 @@
 #include <config_architecture.h>
 #include <variorum_error.h>
 
+
 static uint64_t devidx(int socket, int core, int thread)
 {
     int nsockets, ncores, nthreads;
@@ -300,7 +301,11 @@ int stat_module(char *filename, int *kerneltype, int *dev_idx)
         if (!(statbuf.st_mode & S_IRUSR) || !(statbuf.st_mode & S_IWUSR))
         {
             fprintf(stderr,
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
                     "Warning: <variorum> Incorrect permissions on msr_whitelist: stat_module(): %s:%s::%d\n",
+#else
+                    "Warning: <variorum> Incorrect permissions on msr_allowlist: stat_module(): %s:%s::%d\n",
+#endif
                     getenv("HOSTNAME"), __FILE__, __LINE__);
             *kerneltype = 1;
             free(variorum_error_msg);
@@ -313,7 +318,11 @@ int stat_module(char *filename, int *kerneltype, int *dev_idx)
     if (stat(filename, &statbuf))
     {
         fprintf(stderr,
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
                 "Warning: <variorum> Incorrect permissions on msr_whitelist: stat_module(): %s:%s::%d\n",
+#else
+                "Warning: <variorum> Incorrect permissions on msr_allowlist: stat_module(): %s:%s::%d\n",
+#endif
                 getenv("HOSTNAME"), __FILE__, __LINE__);
         if (*kerneltype)
         {
@@ -402,7 +411,11 @@ int init_msr(void)
     int nsockets, ncores, nthreads;
 
     variorum_get_topology(&nsockets, &ncores, &nthreads);
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
     snprintf(filename, FILENAME_SIZE, "/dev/cpu/msr_whitelist");
+#else
+    snprintf(filename, FILENAME_SIZE, "/dev/cpu/msr_allowlist");
+#endif
     stat_module(filename, &kerneltype, 0);
     /* Open the file descriptor for each device's msr interface. */
     for (dev_idx = 0; dev_idx < nthreads; dev_idx++)

--- a/src/variorum/Intel/msr_core.c
+++ b/src/variorum/Intel/msr_core.c
@@ -23,7 +23,6 @@
 #include <config_architecture.h>
 #include <variorum_error.h>
 
-
 static uint64_t devidx(int socket, int core, int thread)
 {
     int nsockets, ncores, nthreads;


### PR DESCRIPTION
load-msr-safe.sh had not yet been convered to use the allowlist
terminology present in msr-safe 1.4 and greater.  This PR pulls
the current msr-safe version out of /sys/module/msr_safe/version
to determine if whitelist or allowlist should be used.

This PR introduces a dependence on coreutils 7 or greater as that
is the verison where sort -V was introduced.

Fixes #136 
Fixes #138 