### PR TITLE
Dev force python version

### DIFF
--- a/src/thirdparty_builtin/googletest/scripts/fuse_gtest_files.py
+++ b/src/thirdparty_builtin/googletest/scripts/fuse_gtest_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/scripts/gen_gtest_pred_impl.py
+++ b/src/thirdparty_builtin/googletest/scripts/gen_gtest_pred_impl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2006, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/scripts/pump.py
+++ b/src/thirdparty_builtin/googletest/scripts/pump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2008, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/scripts/release_docs.py
+++ b/src/thirdparty_builtin/googletest/scripts/release_docs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2013 Google Inc. All Rights Reserved.
 #

--- a/src/thirdparty_builtin/googletest/scripts/upload.py
+++ b/src/thirdparty_builtin/googletest/scripts/upload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2007 Google Inc.
 #

--- a/src/thirdparty_builtin/googletest/scripts/upload_gtest.py
+++ b/src/thirdparty_builtin/googletest/scripts/upload_gtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_break_on_failure_unittest.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_break_on_failure_unittest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2006, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_catch_exceptions_test.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_catch_exceptions_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2010 Google Inc.  All Rights Reserved.
 #

--- a/src/thirdparty_builtin/googletest/test/gtest_color_test.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_color_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2008, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_env_var_test.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_env_var_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2008, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_filter_unittest.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_filter_unittest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2005 Google Inc. All Rights Reserved.
 #

--- a/src/thirdparty_builtin/googletest/test/gtest_help_test.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_help_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_list_tests_unittest.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_list_tests_unittest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2006, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_output_test.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_output_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2008, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_shuffle_test.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_shuffle_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009 Google Inc. All Rights Reserved.
 #

--- a/src/thirdparty_builtin/googletest/test/gtest_test_utils.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_test_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2006, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_throw_on_failure_test.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_throw_on_failure_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_uninitialized_test.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_uninitialized_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2008, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_xml_outfiles_test.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_xml_outfiles_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2008, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_xml_output_unittest.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_xml_output_unittest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2006, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/test/gtest_xml_test_utils.py
+++ b/src/thirdparty_builtin/googletest/test/gtest_xml_test_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2006, Google Inc.
 # All rights reserved.

--- a/src/thirdparty_builtin/googletest/xcode/Scripts/versiongenerate.py
+++ b/src/thirdparty_builtin/googletest/xcode/Scripts/versiongenerate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2008, Google Inc.
 # All rights reserved.

--- a/src/utilities/verify_msr_kernel.py
+++ b/src/utilities/verify_msr_kernel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
 # Variorum Project Developers. See the top-level LICENSE file for details.

--- a/src/utilities/verify_opal.py
+++ b/src/utilities/verify_opal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
 # Variorum Project Developers. See the top-level LICENSE file for details.


### PR DESCRIPTION
Changes "python" to "python3".  Required to work under Ubuntu.  Not yet tested across all scripts.

Fixes #139 