### PR TITLE
Cleanup warnings

### DIFF
--- a/src/examples/variorum-disable-turbo-example.c
+++ b/src/examples/variorum-disable-turbo-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-enable-turbo-example.c
+++ b/src/examples/variorum-enable-turbo-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -23,7 +23,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
     json_t *my_power_obj = NULL;

--- a/src/examples/variorum-monitoring-to-file-example.c
+++ b/src/examples/variorum-monitoring-to-file-example.c
@@ -39,6 +39,12 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
+    if (argc > 1)
+    {
+        printf("Fatal Error: No argument needed.\n");
+        return 1;
+    }
+
     gethostname(hostname, 1024);
     ret = asprintf(&fname, "%s.powmon.dat", hostname);
     if (ret < 0)

--- a/src/examples/variorum-poll-power-to-file-example.c
+++ b/src/examples/variorum-poll-power-to-file-example.c
@@ -39,6 +39,12 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
+    if (argc > 1)
+    {
+        printf("Fatal Error: No argument needed.\n");
+        return 1;
+    }
+
     gethostname(hostname, 1024);
     ret = asprintf(&fname, "%s.powmon.dat", hostname);
     if (ret < 0)

--- a/src/examples/variorum-poll-power-to-stdout-example.c
+++ b/src/examples/variorum-poll-power-to-stdout-example.c
@@ -22,7 +22,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 #ifdef SECOND_RUN

--- a/src/examples/variorum-print-available-frequencies-example.c
+++ b/src/examples/variorum-print-available-frequencies-example.c
@@ -2,7 +2,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-clock-speed-example.c
+++ b/src/examples/variorum-print-clock-speed-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-counters-example.c
+++ b/src/examples/variorum-print-counters-example.c
@@ -22,7 +22,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 #ifdef SECOND_RUN

--- a/src/examples/variorum-print-features-example.c
+++ b/src/examples/variorum-print-features-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-gpu-utilization-example.c
+++ b/src/examples/variorum-print-gpu-utilization-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-hyperthreading-example.c
+++ b/src/examples/variorum-print-hyperthreading-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-power-example.c
+++ b/src/examples/variorum-print-power-example.c
@@ -22,7 +22,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 #ifdef SECOND_RUN

--- a/src/examples/variorum-print-power-limits-example.c
+++ b/src/examples/variorum-print-power-limits-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-thermals-example.c
+++ b/src/examples/variorum-print-thermals-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-topology-example.c
+++ b/src/examples/variorum-print-topology-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     variorum_print_topology();
     return 0;

--- a/src/examples/variorum-print-turbo-example.c
+++ b/src/examples/variorum-print-turbo-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-verbose-clock-speed-example.c
+++ b/src/examples/variorum-print-verbose-clock-speed-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-verbose-counters-example.c
+++ b/src/examples/variorum-print-verbose-counters-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-verbose-gpu-utilization-example.c
+++ b/src/examples/variorum-print-verbose-gpu-utilization-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-verbose-power-example.c
+++ b/src/examples/variorum-print-verbose-power-example.c
@@ -22,7 +22,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 #ifdef SECOND_RUN

--- a/src/examples/variorum-print-verbose-power-limits-example.c
+++ b/src/examples/variorum-print-verbose-power-limits-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-print-verbose-thermals-example.c
+++ b/src/examples/variorum-print-verbose-thermals-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     int ret;
 

--- a/src/examples/variorum-set-and-verify-node-power-limit-example.c
+++ b/src/examples/variorum-set-and-verify-node-power-limit-example.c
@@ -11,12 +11,12 @@
 int main(int argc, char **argv)
 {
     int ret;
-    int node_pow_lim_watts;
+    /* 500 W is based on minimum power on IBM Witherspoon */
+    int node_pow_lim_watts = 500;
 
     if (argc == 1)
     {
         printf("No power limit specified...using default limit of 500W.\n");
-        /* 500 W is based on minimum power on IBM Witherspoon */
         node_pow_lim_watts = 500;
     }
     else if (argc == 2)

--- a/src/examples/variorum-set-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-set-best-effort-node-power-limit-example.c
@@ -11,7 +11,8 @@
 int main(int argc, char **argv)
 {
     int ret;
-    int node_pow_lim_watts;
+    // 500W is based on minimum power on IBM Witherspoon
+    int node_pow_lim_watts = 500;
 
     if (argc == 1)
     {

--- a/src/examples/variorum-set-gpu-power-ratio-example.c
+++ b/src/examples/variorum-set-gpu-power-ratio-example.c
@@ -12,7 +12,7 @@ int main(int argc, char **argv)
 {
     int ret;
     /*100 % is based on IBM Witherspoon default */
-    int gpu_power_ratio_pct=100;
+    int gpu_power_ratio_pct = 100;
 
     if (argc == 1)
     {

--- a/src/examples/variorum-set-gpu-power-ratio-example.c
+++ b/src/examples/variorum-set-gpu-power-ratio-example.c
@@ -11,12 +11,12 @@
 int main(int argc, char **argv)
 {
     int ret;
-    int gpu_power_ratio_pct;
+    /*100 % is based on IBM Witherspoon default */
+    int gpu_power_ratio_pct=100;
 
     if (argc == 1)
     {
         printf("No GPU power ratio specified...using default ratio of 100 percent.\n");
-        gpu_power_ratio_pct = 100; /*100 % is based on IBM Witherspoon default */
     }
     else if (argc == 2)
     {

--- a/src/examples/variorum-set-socket-power-limits-example.c
+++ b/src/examples/variorum-set-socket-power-limits-example.c
@@ -24,8 +24,8 @@ int main(int argc, char **argv)
     }
     else
     {
-	printf("Usage: set_socket_power_limit [limit in watts]\n");
-	exit(0);
+        printf("Usage: set_socket_power_limit [limit in watts]\n");
+        exit(0);
     }
 
     ret = variorum_set_each_socket_power_limit(pkg_pow_lim_watts);

--- a/src/examples/variorum-set-socket-power-limits-example.c
+++ b/src/examples/variorum-set-socket-power-limits-example.c
@@ -11,17 +11,21 @@
 int main(int argc, char **argv)
 {
     int ret;
-    int pkg_pow_lim_watts;
+    int pkg_pow_lim_watts = 100;
 
     if (argc == 1)
     {
         printf("No power limit specified...using default limit of 100W.\n");
-        pkg_pow_lim_watts = 100;
     }
     else if (argc == 2)
     {
         pkg_pow_lim_watts = atoi(argv[1]);
         printf("Setting each socket to %dW.\n", pkg_pow_lim_watts);
+    }
+    else
+    {
+	printf("Usage: set_socket_power_limit [limit in watts]\n");
+	exit(0);
     }
 
     ret = variorum_set_each_socket_power_limit(pkg_pow_lim_watts);

--- a/src/powmon/power_wrapper_dynamic.c
+++ b/src/powmon/power_wrapper_dynamic.c
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
 #endif
 
     char *fname_dat = NULL;
-    int rc=0;
+    int rc = 0;
     char *fname_summary;
     if (highlander())
     {
@@ -197,12 +197,13 @@ int main(int argc, char **argv)
         gethostname(hostname, 64);
 
         rc = asprintf(&fname_dat, "%s.powmon.dat", hostname);
-	if( -1 == rc ){
-		fprintf(stderr, 
-			"%s:%d asprintf failed, perhaps out of memory.  Exiting.\n",
-			__FILE__, __LINE__);
-		exit(-1);
-	}
+        if (rc == -1)
+        {
+            fprintf(stderr,
+                    "%s:%d asprintf failed, perhaps out of memory.  Exiting.\n",
+                    __FILE__, __LINE__);
+            exit(-1);
+        }
 
         logfd = open(fname_dat, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
                      S_IRUSR | S_IWUSR);
@@ -211,7 +212,7 @@ int main(int argc, char **argv)
             fprintf(stderr,
                     "Fatal Error: %s on %s cannot open the appropriate fd for %s -- %s.\n", argv[0],
                     hostname, fname_dat, strerror(errno));
-	    free(fname_dat);
+            free(fname_dat);
             return 1;
         }
         logfile = fdopen(logfd, "w");
@@ -219,7 +220,7 @@ int main(int argc, char **argv)
         {
             fprintf(stderr, "Fatal Error: %s on %s fdopen failed for %s -- %s.\n", argv[0],
                     hostname, fname_dat, strerror(errno));
-	    free(fname_dat);
+            free(fname_dat);
             return 1;
         }
 
@@ -267,12 +268,13 @@ int main(int argc, char **argv)
 
         /* Output summary data. */
         rc = asprintf(&fname_summary, "%s.power.summary", hostname);
-	if( -1 == rc ){
-		fprintf(stderr, 
-			"%s:%d asprintf failed, perhaps out of memory.  Exiting.\n",
-			__FILE__, __LINE__);
-		exit(-1);
-	}
+        if (rc == -1)
+        {
+            fprintf(stderr,
+                    "%s:%d asprintf failed, perhaps out of memory.  Exiting.\n",
+                    __FILE__, __LINE__);
+            exit(-1);
+        }
 
         logfd = open(fname_summary, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
                      S_IRUSR | S_IWUSR);
@@ -281,7 +283,7 @@ int main(int argc, char **argv)
             fprintf(stderr,
                     "Fatal Error: %s on %s cannot open the appropriate fd for %s -- %s.\n", argv[0],
                     hostname, fname_summary, strerror(errno));
-	    free(fname_summary);
+            free(fname_summary);
             return 1;
         }
         summaryfile = fdopen(logfd, "w");
@@ -289,23 +291,25 @@ int main(int argc, char **argv)
         {
             fprintf(stderr, "Fatal Error: %s on %s fdopen failed for %s -- %s.\n", argv[0],
                     hostname, fname_summary, strerror(errno));
-	    free(fname_summary);
+            free(fname_summary);
             return 1;
         }
 
         char *msg;
         //rc = asprintf(&msg, "host: %s\npid: %d\ntotal: %lf\nallocated: %lf\nmax_watts: %lf\nmin_watts: %lf\nruntime ms: %lu\n,start: %lu\nend: %lu\n", hostname, app_pid, total_joules, limit_joules, max_watts, min_watts, end-start, start, end);
-        rc = asprintf(&msg, "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
-                 hostname, app_pid, end - start, start, end);
-	if( -1 == rc ){
-		fprintf(stderr, 
-			"%s:%d asprintf failed, perhaps out of memory.  Exiting.\n",
-			__FILE__, __LINE__);
-		exit(-1);
-	}
+        rc = asprintf(&msg,
+                      "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
+                      hostname, app_pid, end - start, start, end);
+        if (rc == -1)
+        {
+            fprintf(stderr,
+                    "%s:%d asprintf failed, perhaps out of memory.  Exiting.\n",
+                    __FILE__, __LINE__);
+            exit(-1);
+        }
 
         fprintf(summaryfile, "%s", msg);
-	free(msg);
+        free(msg);
         fclose(summaryfile);
         close(logfd);
 

--- a/src/powmon/power_wrapper_dynamic.c
+++ b/src/powmon/power_wrapper_dynamic.c
@@ -186,7 +186,8 @@ int main(int argc, char **argv)
     }
 #endif
 
-    char *fname_dat;
+    char *fname_dat = NULL;
+    int rc=0;
     char *fname_summary;
     if (highlander())
     {
@@ -195,7 +196,13 @@ int main(int argc, char **argv)
         char hostname[64];
         gethostname(hostname, 64);
 
-        asprintf(&fname_dat, "%s.powmon.dat", hostname);
+        rc = asprintf(&fname_dat, "%s.powmon.dat", hostname);
+	if( -1 == rc ){
+		fprintf(stderr, 
+			"%s:%d asprintf failed, perhaps out of memory.  Exiting.\n",
+			__FILE__, __LINE__);
+		exit(-1);
+	}
 
         logfd = open(fname_dat, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
                      S_IRUSR | S_IWUSR);
@@ -204,6 +211,7 @@ int main(int argc, char **argv)
             fprintf(stderr,
                     "Fatal Error: %s on %s cannot open the appropriate fd for %s -- %s.\n", argv[0],
                     hostname, fname_dat, strerror(errno));
+	    free(fname_dat);
             return 1;
         }
         logfile = fdopen(logfd, "w");
@@ -211,6 +219,7 @@ int main(int argc, char **argv)
         {
             fprintf(stderr, "Fatal Error: %s on %s fdopen failed for %s -- %s.\n", argv[0],
                     hostname, fname_dat, strerror(errno));
+	    free(fname_dat);
             return 1;
         }
 
@@ -257,7 +266,13 @@ int main(int argc, char **argv)
         end = now_ms();
 
         /* Output summary data. */
-        asprintf(&fname_summary, "%s.power.summary", hostname);
+        rc = asprintf(&fname_summary, "%s.power.summary", hostname);
+	if( -1 == rc ){
+		fprintf(stderr, 
+			"%s:%d asprintf failed, perhaps out of memory.  Exiting.\n",
+			__FILE__, __LINE__);
+		exit(-1);
+	}
 
         logfd = open(fname_summary, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
                      S_IRUSR | S_IWUSR);
@@ -266,6 +281,7 @@ int main(int argc, char **argv)
             fprintf(stderr,
                     "Fatal Error: %s on %s cannot open the appropriate fd for %s -- %s.\n", argv[0],
                     hostname, fname_summary, strerror(errno));
+	    free(fname_summary);
             return 1;
         }
         summaryfile = fdopen(logfd, "w");
@@ -273,15 +289,23 @@ int main(int argc, char **argv)
         {
             fprintf(stderr, "Fatal Error: %s on %s fdopen failed for %s -- %s.\n", argv[0],
                     hostname, fname_summary, strerror(errno));
+	    free(fname_summary);
             return 1;
         }
 
         char *msg;
-        //asprintf(&msg, "host: %s\npid: %d\ntotal: %lf\nallocated: %lf\nmax_watts: %lf\nmin_watts: %lf\nruntime ms: %lu\n,start: %lu\nend: %lu\n", hostname, app_pid, total_joules, limit_joules, max_watts, min_watts, end-start, start, end);
-        asprintf(&msg, "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
+        //rc = asprintf(&msg, "host: %s\npid: %d\ntotal: %lf\nallocated: %lf\nmax_watts: %lf\nmin_watts: %lf\nruntime ms: %lu\n,start: %lu\nend: %lu\n", hostname, app_pid, total_joules, limit_joules, max_watts, min_watts, end-start, start, end);
+        rc = asprintf(&msg, "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
                  hostname, app_pid, end - start, start, end);
+	if( -1 == rc ){
+		fprintf(stderr, 
+			"%s:%d asprintf failed, perhaps out of memory.  Exiting.\n",
+			__FILE__, __LINE__);
+		exit(-1);
+	}
 
         fprintf(summaryfile, "%s", msg);
+	free(msg);
         fclose(summaryfile);
         close(logfd);
 
@@ -289,6 +313,7 @@ int main(int argc, char **argv)
         shmdt(shmseg);
 
         pthread_attr_destroy(&mattr);
+        free(fname_summary);
     }
     else
     {
@@ -310,6 +335,8 @@ int main(int argc, char **argv)
     printf("Output Files\n"
            "  %s\n"
            "  %s\n\n", fname_dat, fname_summary);
+
+    free(fname_dat);
     highlander_clean();
     return 0;
 }

--- a/src/powmon/power_wrapper_static.c
+++ b/src/powmon/power_wrapper_static.c
@@ -154,11 +154,12 @@ int main(int argc, char **argv)
         gethostname(hostname, 64);
 
         rc = asprintf(&fname_dat, "%s.powmon.dat", hostname);
-	if( -1 == rc ){
-		fprintf(stderr, 
-			"%s:%d asprintf failed, perhaps out of memory.\n",
-			__FILE__, __LINE__);
-	}
+        if (rc == -1)
+        {
+            fprintf(stderr,
+                    "%s:%d asprintf failed, perhaps out of memory.\n",
+                    __FILE__, __LINE__);
+        }
 
         logfd = open(fname_dat, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
                      S_IRUSR | S_IWUSR);
@@ -167,7 +168,7 @@ int main(int argc, char **argv)
             fprintf(stderr,
                     "Fatal Error: %s on %s cannot open the appropriate fd for %s -- %s.\n", argv[0],
                     hostname, fname_dat, strerror(errno));
-	    free(fname_dat);
+            free(fname_dat);
             return 1;
         }
         logfile = fdopen(logfd, "w");
@@ -175,7 +176,7 @@ int main(int argc, char **argv)
         {
             fprintf(stderr, "Fatal Error: %s on %s fdopen failed for %s -- %s.\n", argv[0],
                     hostname, fname_dat, strerror(errno));
-	    free(fname_dat);
+            free(fname_dat);
             return 1;
         }
 
@@ -223,11 +224,12 @@ int main(int argc, char **argv)
 
         /* Output summary data. */
         rc = asprintf(&fname_summary, "%s.power.summary", hostname);
-	if( -1 == rc ){
-		fprintf(stderr, 
-			"%s:%d asprintf failed, perhaps out of memory.\n",
-			__FILE__, __LINE__);
-	}
+        if (rc == -1)
+        {
+            fprintf(stderr,
+                    "%s:%d asprintf failed, perhaps out of memory.\n",
+                    __FILE__, __LINE__);
+        }
 
         logfd = open(fname_summary, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
                      S_IRUSR | S_IWUSR);
@@ -236,7 +238,7 @@ int main(int argc, char **argv)
             fprintf(stderr,
                     "Fatal Error: %s on %s cannot open the appropriate fd for %s -- %s.\n", argv[0],
                     hostname, fname_summary, strerror(errno));
-	    free(fname_summary);
+            free(fname_summary);
             return 1;
         }
         summaryfile = fdopen(logfd, "w");
@@ -244,22 +246,24 @@ int main(int argc, char **argv)
         {
             fprintf(stderr, "Fatal Error: %s on %s fdopen failed for %s -- %s.\n", argv[0],
                     hostname, fname_summary, strerror(errno));
-	    free(fname_summary);
+            free(fname_summary);
             return 1;
         }
 
         char *msg;
-        //asprintf(&msg, "host: %s\npid: %d\ntotal: %lf\nallocated: %lf\nmax_watts: %lf\nmin_watts: %lf\nruntime ms: %lu\n,start: %lu\nend: %lu\n", hostname, app_pid, total_joules, limit_joules, max_watts, min_watts, end-start, start, end);
-        rc = asprintf(&msg, "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
-                 hostname, app_pid, end - start, start, end);
-	if( -1 == rc ){
-		fprintf(stderr, 
-			"%s:%d asprintf failed, perhaps out of memory.\n",
-			__FILE__, __LINE__);
-	}
+        //rc = asprintf(&msg, "host: %s\npid: %d\ntotal: %lf\nallocated: %lf\nmax_watts: %lf\nmin_watts: %lf\nruntime ms: %lu\n,start: %lu\nend: %lu\n", hostname, app_pid, total_joules, limit_joules, max_watts, min_watts, end-start, start, end);
+        rc = asprintf(&msg,
+                      "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
+                      hostname, app_pid, end - start, start, end);
+        if (rc == -1)
+        {
+            fprintf(stderr,
+                    "%s:%d asprintf failed, perhaps out of memory.\n",
+                    __FILE__, __LINE__);
+        }
 
         fprintf(summaryfile, "%s", msg);
-	free(msg);
+        free(msg);
         fclose(summaryfile);
         close(logfd);
 

--- a/src/powmon/power_wrapper_static.c
+++ b/src/powmon/power_wrapper_static.c
@@ -145,6 +145,7 @@ int main(int argc, char **argv)
 
     char *fname_dat;
     char *fname_summary;
+    int rc;
     if (highlander())
     {
         /* Start the log file. */
@@ -152,7 +153,12 @@ int main(int argc, char **argv)
         char hostname[64];
         gethostname(hostname, 64);
 
-        asprintf(&fname_dat, "%s.powmon.dat", hostname);
+        rc = asprintf(&fname_dat, "%s.powmon.dat", hostname);
+	if( -1 == rc ){
+		fprintf(stderr, 
+			"%s:%d asprintf failed, perhaps out of memory.\n",
+			__FILE__, __LINE__);
+	}
 
         logfd = open(fname_dat, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
                      S_IRUSR | S_IWUSR);
@@ -161,6 +167,7 @@ int main(int argc, char **argv)
             fprintf(stderr,
                     "Fatal Error: %s on %s cannot open the appropriate fd for %s -- %s.\n", argv[0],
                     hostname, fname_dat, strerror(errno));
+	    free(fname_dat);
             return 1;
         }
         logfile = fdopen(logfd, "w");
@@ -168,6 +175,7 @@ int main(int argc, char **argv)
         {
             fprintf(stderr, "Fatal Error: %s on %s fdopen failed for %s -- %s.\n", argv[0],
                     hostname, fname_dat, strerror(errno));
+	    free(fname_dat);
             return 1;
         }
 
@@ -214,7 +222,12 @@ int main(int argc, char **argv)
         end = now_ms();
 
         /* Output summary data. */
-        asprintf(&fname_summary, "%s.power.summary", hostname);
+        rc = asprintf(&fname_summary, "%s.power.summary", hostname);
+	if( -1 == rc ){
+		fprintf(stderr, 
+			"%s:%d asprintf failed, perhaps out of memory.\n",
+			__FILE__, __LINE__);
+	}
 
         logfd = open(fname_summary, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
                      S_IRUSR | S_IWUSR);
@@ -223,6 +236,7 @@ int main(int argc, char **argv)
             fprintf(stderr,
                     "Fatal Error: %s on %s cannot open the appropriate fd for %s -- %s.\n", argv[0],
                     hostname, fname_summary, strerror(errno));
+	    free(fname_summary);
             return 1;
         }
         summaryfile = fdopen(logfd, "w");
@@ -230,15 +244,22 @@ int main(int argc, char **argv)
         {
             fprintf(stderr, "Fatal Error: %s on %s fdopen failed for %s -- %s.\n", argv[0],
                     hostname, fname_summary, strerror(errno));
+	    free(fname_summary);
             return 1;
         }
 
         char *msg;
         //asprintf(&msg, "host: %s\npid: %d\ntotal: %lf\nallocated: %lf\nmax_watts: %lf\nmin_watts: %lf\nruntime ms: %lu\n,start: %lu\nend: %lu\n", hostname, app_pid, total_joules, limit_joules, max_watts, min_watts, end-start, start, end);
-        asprintf(&msg, "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
+        rc = asprintf(&msg, "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
                  hostname, app_pid, end - start, start, end);
+	if( -1 == rc ){
+		fprintf(stderr, 
+			"%s:%d asprintf failed, perhaps out of memory.\n",
+			__FILE__, __LINE__);
+	}
 
         fprintf(summaryfile, "%s", msg);
+	free(msg);
         fclose(summaryfile);
         close(logfd);
 
@@ -268,5 +289,6 @@ int main(int argc, char **argv)
            "  %s\n"
            "  %s\n\n", fname_dat, fname_summary);
     highlander_clean();
+    free(fname_dat);
     return 0;
 }

--- a/src/powmon/powmon.c
+++ b/src/powmon/powmon.c
@@ -170,8 +170,9 @@ int main(int argc, char **argv)
     }
 #endif
 
-    char *fname_dat;
-    char *fname_summary;
+    char *fname_dat = NULL;
+    char *fname_summary = NULL;
+    int rc;
     if (highlander())
     {
         /* Start the log file. */
@@ -182,12 +183,22 @@ int main(int argc, char **argv)
         if (logpath)
         {
             /* Output trace data into the specified location. */
-            asprintf(&fname_dat, "%s/%s.powmon.dat", logpath, hostname);
+            rc = asprintf(&fname_dat, "%s/%s.powmon.dat", logpath, hostname);
+	    if( -1 == rc ){
+		    fprintf( stderr, 
+			"%s:%d asprintf failed, perhaps out of memory.\n",
+			__FILE__, __LINE__);
+	    }
         }
         else
         {
             /* Output trace data into the default location. */
-            asprintf(&fname_dat, "%s.powmon.dat", hostname);
+            rc = asprintf(&fname_dat, "%s.powmon.dat", hostname);
+	    if( -1 == rc ){
+		    fprintf( stderr, 
+			"%s:%d asprintf failed, perhaps out of memory.\n",
+			__FILE__, __LINE__);
+	    }
         }
 
         logfd = open(fname_dat, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
@@ -254,12 +265,22 @@ int main(int argc, char **argv)
         if (logpath)
         {
             /* Output summary data into the specified location. */
-            asprintf(&fname_summary, "%s/%s.powmon.summary", logpath, hostname);
+            rc = asprintf(&fname_summary, "%s/%s.powmon.summary", logpath, hostname);
+	    if( -1 == rc ){
+		    fprintf( stderr, 
+			"%s:%d asprintf failed, perhaps out of memory.\n",
+			__FILE__, __LINE__);
+	    }
         }
         else
         {
             /* Output summary data into the default location. */
-            asprintf(&fname_summary, "%s.powmon.summary", hostname);
+            rc = asprintf(&fname_summary, "%s.powmon.summary", hostname);
+	    if( -1 == rc ){
+		    fprintf( stderr, 
+			"%s:%d asprintf failed, perhaps out of memory.\n",
+			__FILE__, __LINE__);
+	    }
         }
 
         logfd = open(fname_summary, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
@@ -280,10 +301,16 @@ int main(int argc, char **argv)
         }
 
         char *msg;
-        asprintf(&msg, "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
+        rc = asprintf(&msg, "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
                  hostname, app_pid, end - start, start, end);
+	if( -1 == rc ){
+	    fprintf( stderr, 
+		"%s:%d asprintf failed, perhaps out of memory.\n",
+		__FILE__, __LINE__);
+	}
 
         fprintf(summaryfile, "%s", msg);
+	free(msg);
         fclose(summaryfile);
         close(logfd);
 
@@ -313,5 +340,7 @@ int main(int argc, char **argv)
            "  %s\n"
            "  %s\n\n", fname_dat, fname_summary);
     highlander_clean();
+    free(fname_dat);
+    free(fname_summary);
     return 0;
 }

--- a/src/powmon/powmon.c
+++ b/src/powmon/powmon.c
@@ -184,21 +184,23 @@ int main(int argc, char **argv)
         {
             /* Output trace data into the specified location. */
             rc = asprintf(&fname_dat, "%s/%s.powmon.dat", logpath, hostname);
-	    if( -1 == rc ){
-		    fprintf( stderr, 
-			"%s:%d asprintf failed, perhaps out of memory.\n",
-			__FILE__, __LINE__);
-	    }
+            if (rc == -1)
+            {
+                fprintf(stderr,
+                        "%s:%d asprintf failed, perhaps out of memory.\n",
+                        __FILE__, __LINE__);
+            }
         }
         else
         {
             /* Output trace data into the default location. */
             rc = asprintf(&fname_dat, "%s.powmon.dat", hostname);
-	    if( -1 == rc ){
-		    fprintf( stderr, 
-			"%s:%d asprintf failed, perhaps out of memory.\n",
-			__FILE__, __LINE__);
-	    }
+            if (rc == -1)
+            {
+                fprintf(stderr,
+                        "%s:%d asprintf failed, perhaps out of memory.\n",
+                        __FILE__, __LINE__);
+            }
         }
 
         logfd = open(fname_dat, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
@@ -266,21 +268,23 @@ int main(int argc, char **argv)
         {
             /* Output summary data into the specified location. */
             rc = asprintf(&fname_summary, "%s/%s.powmon.summary", logpath, hostname);
-	    if( -1 == rc ){
-		    fprintf( stderr, 
-			"%s:%d asprintf failed, perhaps out of memory.\n",
-			__FILE__, __LINE__);
-	    }
+            if (rc == -1)
+            {
+                fprintf(stderr,
+                        "%s:%d asprintf failed, perhaps out of memory.\n",
+                        __FILE__, __LINE__);
+            }
         }
         else
         {
             /* Output summary data into the default location. */
             rc = asprintf(&fname_summary, "%s.powmon.summary", hostname);
-	    if( -1 == rc ){
-		    fprintf( stderr, 
-			"%s:%d asprintf failed, perhaps out of memory.\n",
-			__FILE__, __LINE__);
-	    }
+            if (rc == -1)
+            {
+                fprintf(stderr,
+                        "%s:%d asprintf failed, perhaps out of memory.\n",
+                        __FILE__, __LINE__);
+            }
         }
 
         logfd = open(fname_summary, O_WRONLY | O_CREAT | O_EXCL | O_NOATIME | O_NDELAY,
@@ -301,16 +305,18 @@ int main(int argc, char **argv)
         }
 
         char *msg;
-        rc = asprintf(&msg, "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
-                 hostname, app_pid, end - start, start, end);
-	if( -1 == rc ){
-	    fprintf( stderr, 
-		"%s:%d asprintf failed, perhaps out of memory.\n",
-		__FILE__, __LINE__);
-	}
+        rc = asprintf(&msg,
+                      "host: %s\npid: %d\nruntime ms: %lu\nstart: %lu\nend: %lu\n",
+                      hostname, app_pid, end - start, start, end);
+        if (-1 == rc)
+        {
+            fprintf(stderr,
+                    "%s:%d asprintf failed, perhaps out of memory.\n",
+                    __FILE__, __LINE__);
+        }
 
         fprintf(summaryfile, "%s", msg);
-	free(msg);
+        free(msg);
         fclose(summaryfile);
         close(logfd);
 

--- a/src/tests/system-env/intel/t_system_env_intel_msr_safe_allowlist.cpp
+++ b/src/tests/system-env/intel/t_system_env_intel_msr_safe_allowlist.cpp
@@ -70,30 +70,30 @@ int allowlist_size(const char *file)
 
 TEST(MsrAllowlist, Exists)
 {
-#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
-    const char * const filename = "/dev/cpu/msr_whitelist";
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
+    const char *const filename = "/dev/cpu/msr_whitelist";
 #else
-    const char * const filename = "/dev/cpu/msr_allowlist";
+    const char *const filename = "/dev/cpu/msr_allowlist";
 #endif
     EXPECT_EQ(0, is_file_exist(filename));
 }
 
 TEST(MsrAllowlist, Perms)
 {
-#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
-    const char * const filename = "/dev/cpu/msr_whitelist";
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
+    const char *const filename = "/dev/cpu/msr_whitelist";
 #else
-    const char * const filename = "/dev/cpu/msr_allowlist";
+    const char *const filename = "/dev/cpu/msr_allowlist";
 #endif
     EXPECT_EQ(1, check_other_permissions(filename));
 }
 
 TEST(MsrAllowlist, Size)
 {
-#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
-    const char * const filename = "/dev/cpu/msr_whitelist";
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
+    const char *const filename = "/dev/cpu/msr_whitelist";
 #else
-    const char * const filename = "/dev/cpu/msr_allowlist";
+    const char *const filename = "/dev/cpu/msr_allowlist";
 #endif
     /* Valid list should not be empty */
     EXPECT_NE(0, allowlist_size(filename));

--- a/src/tests/system-env/intel/t_system_env_intel_msr_safe_allowlist.cpp
+++ b/src/tests/system-env/intel/t_system_env_intel_msr_safe_allowlist.cpp
@@ -70,41 +70,32 @@ int allowlist_size(const char *file)
 
 TEST(MsrAllowlist, Exists)
 {
-    char *filename;
-
-#ifdef USE_MSR_SAFE_BEFORE_1_5_0
-    asprintf(&filename, "/dev/cpu/msr_whitelist");
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
+    const char * const filename = "/dev/cpu/msr_whitelist";
 #else
-    asprintf(&filename, "/dev/cpu/msr_allowlist");
+    const char * const filename = "/dev/cpu/msr_allowlist";
 #endif
     EXPECT_EQ(0, is_file_exist(filename));
-    free(filename);
 }
 
 TEST(MsrAllowlist, Perms)
 {
-    char *filename;
-
-#ifdef USE_MSR_SAFE_BEFORE_1_5_0
-    asprintf(&filename, "/dev/cpu/msr_whitelist");
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
+    const char * const filename = "/dev/cpu/msr_whitelist";
 #else
-    asprintf(&filename, "/dev/cpu/msr_allowlist");
+    const char * const filename = "/dev/cpu/msr_allowlist";
 #endif
     EXPECT_EQ(1, check_other_permissions(filename));
-    free(filename);
 }
 
 TEST(MsrAllowlist, Size)
 {
-    char *filename;
-
-#ifdef USE_MSR_SAFE_BEFORE_1_5_0
-    asprintf(&filename, "/dev/cpu/msr_whitelist");
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0 
+    const char * const filename = "/dev/cpu/msr_whitelist";
 #else
-    asprintf(&filename, "/dev/cpu/msr_allowlist");
+    const char * const filename = "/dev/cpu/msr_allowlist";
 #endif
     /* Valid list should not be empty */
     EXPECT_NE(0, allowlist_size(filename));
-    free(filename);
 }
 

--- a/src/tests/system-env/intel/t_system_env_intel_msr_safe_driver.cpp
+++ b/src/tests/system-env/intel/t_system_env_intel_msr_safe_driver.cpp
@@ -62,8 +62,8 @@ TEST_P(MsrDriverTest, Exists)
 {
     int testparam = GetParam();
     char *filename;
-
-    asprintf(&filename, "/dev/cpu/%d/msr_safe", testparam);
+    int rc = asprintf(&filename, "/dev/cpu/%d/msr_safe", testparam);
+    EXPECT_NE(-1, rc);
     EXPECT_EQ(0, is_file_exist(filename));
     free(filename);
 }
@@ -72,9 +72,10 @@ TEST_P(MsrDriverTest, GroupID)
 {
     int testparam = GetParam();
     char *filename;
+    int rc = asprintf(&filename, "/dev/cpu/%d/msr_safe", testparam);
 
-    asprintf(&filename, "/dev/cpu/%d/msr_safe", testparam);
     /* Check if group owner is not root */
+    EXPECT_NE(-1, rc);
     EXPECT_NE(0, check_group_id(filename));
     free(filename);
 }
@@ -84,8 +85,9 @@ TEST_P(MsrDriverTest, GroupPerms)
     int testparam = GetParam();
     char *filename;
 
-    asprintf(&filename, "/dev/cpu/%d/msr_safe", testparam);
+    int rc = asprintf(&filename, "/dev/cpu/%d/msr_safe", testparam);
     /* Check if group owner is not root */
+    EXPECT_NE(-1, rc);
     EXPECT_EQ(1, check_group_permissions(filename));
     free(filename);
 }

--- a/src/variorum/IBM/Power9.h
+++ b/src/variorum/IBM/Power9.h
@@ -12,7 +12,7 @@ int p9_get_power(int long_ver);
 
 int p9_get_power_limits(int long_ver);
 
-int p9_set_socket_power_limit(int pcap_new);
+int p9_set_socket_power_limit(int long_ver);
 
 int p9_set_node_power_limit(int pcap_new);
 

--- a/src/variorum/IBM/ibm_sensors.c
+++ b/src/variorum/IBM/ibm_sensors.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
 
 #include <ibm_sensors.h>
 
@@ -146,7 +147,7 @@ void print_power_sensors(int chipid, int long_ver, FILE *output,
     {
         uint32_t offset = be32toh(md[i].reading_offset);
         uint32_t scale = be32toh(md[i].scale_factor);
-        uint64_t sample;
+        uint64_t sample = 0;
 
         // We are not reading counters here because power data doesn't need counter.
         if (md[i].structure_type == OCC_SENSOR_READING_FULL)
@@ -204,8 +205,6 @@ void print_all_sensors_header(int chipid, FILE *output, const void *buf)
     struct occ_sensor_data_header *hb;
     struct occ_sensor_name *md;
     int i = 0;
-    static struct timeval start;
-    struct timeval now;
 
     hb = (struct occ_sensor_data_header *)(uint64_t)buf;
     md = (struct occ_sensor_name *)((uint64_t)hb + be32toh(hb->names_offset));
@@ -214,8 +213,6 @@ void print_all_sensors_header(int chipid, FILE *output, const void *buf)
 
     for (i = 0; i < be16toh(hb->nr_sensors); i++)
     {
-        uint32_t offset = be32toh(md[i].reading_offset);
-
         if (be16toh(md[i].type) == OCC_SENSOR_TYPE_POWER)
         {
             fprintf(output, " %s_Scale_%s %s_Energy_J", md[i].name, md[i].units,
@@ -305,7 +302,6 @@ void json_get_power_sensors(int chipid, json_t *get_power_obj, const void *buf)
     struct occ_sensor_data_header *hb;
     struct occ_sensor_name *md;
     int i = 0;
-    static int init = 0;
     // Power in watts.
     uint64_t pwrsys = 0;
     uint64_t pwrproc = 0;
@@ -329,7 +325,7 @@ void json_get_power_sensors(int chipid, json_t *get_power_obj, const void *buf)
     {
         uint32_t offset = be32toh(md[i].reading_offset);
         uint32_t scale = be32toh(md[i].scale_factor);
-        uint64_t sample;
+        uint64_t sample = 0;
 
         // We are not reading counters here because power data doesn't need counter.
         if (md[i].structure_type == OCC_SENSOR_READING_FULL)

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -73,8 +73,8 @@ static struct broadwell_4f_offsets msrs =
 
 int fm_06_4f_get_power_limits(int long_ver)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -135,8 +135,8 @@ int fm_06_4f_get_power_limits(int long_ver)
 
 int fm_06_4f_set_power_limits(int package_power_limit)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -289,8 +289,6 @@ int fm_06_4f_get_counters(int long_ver)
     if (long_ver == 0)
     {
         dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perf_global_ctrl,
-                              msrs.ia32_fixed_ctr_ctrl,
                               msrs.ia32_perfevtsel_counters,
                               msrs.ia32_perfmon_counters,
                               msrs.msrs_pcu_pmon_evtsel,
@@ -299,8 +297,6 @@ int fm_06_4f_get_counters(int long_ver)
     else if (long_ver == 1)
     {
         print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perf_global_ctrl,
-                               msrs.ia32_fixed_ctr_ctrl,
                                msrs.ia32_perfevtsel_counters,
                                msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel,
@@ -338,13 +334,13 @@ int fm_06_4f_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_pkg_power_limit,
+        dump_power_data(stdout, 
                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                         msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_pkg_power_limit,
+        print_power_data(stdout, 
                          msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                          msrs.msr_dram_energy_status);
     }
@@ -444,7 +440,7 @@ int fm_06_4f_set_best_effort_node_power_limit(int node_limit)
      * the floor of the value being taken. So while we will be off by 1W total,
      * we will guarantee that we stay under the specified cap. */
 
-    int nsockets, ncores, nthreads;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
     // Adding this for portability and rounding down.
@@ -469,7 +465,6 @@ int fm_06_4f_get_frequencies(void)
 
     get_available_frequencies(stdout, &msrs.msr_platform_info,
                               &msrs.msr_turbo_ratio_limit, &msrs.msr_turbo_ratio_limit1,
-                              &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2,
-                              &msrs.msr_config_tdp_nominal);
+                              &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2);
     return 0;
 }

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -334,13 +334,13 @@ int fm_06_4f_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, 
+        dump_power_data(stdout,
                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                         msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, 
+        print_power_data(stdout,
                          msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                          msrs.msr_dram_energy_status);
     }

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -68,8 +68,8 @@ static struct haswell_3f_offsets msrs =
 
 int fm_06_3f_get_power_limits(int long_ver)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -130,8 +130,8 @@ int fm_06_3f_get_power_limits(int long_ver)
 
 int fm_06_3f_set_power_limits(int package_power_limit)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -272,14 +272,12 @@ int fm_06_3f_get_counters(int long_ver)
     if (long_ver == 0)
     {
         dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
         print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                                msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
@@ -315,12 +313,12 @@ int fm_06_3f_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        dump_power_data(stdout, msrs.msr_rapl_power_unit,
                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        print_power_data(stdout, msrs.msr_rapl_power_unit,
                          msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
@@ -395,7 +393,6 @@ int fm_06_3f_get_frequencies(void)
 
     get_available_frequencies(stdout, &msrs.msr_platform_info,
                               &msrs.msr_turbo_ratio_limit, &msrs.msr_turbo_ratio_limit1,
-                              &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2,
-                              &msrs.msr_config_tdp_nominal);
+                              &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2);
     return 0;
 }

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -72,8 +72,8 @@ static struct ivybridge_3e_offsets msrs =
 
 int fm_06_3e_get_power_limits(int long_ver)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -134,8 +134,8 @@ int fm_06_3e_get_power_limits(int long_ver)
 
 int fm_06_3e_set_power_limits(int package_power_limit)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -285,14 +285,12 @@ int fm_06_3e_get_counters(int long_ver)
     if (long_ver == 0)
     {
         dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
         print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                                msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
@@ -328,12 +326,12 @@ int fm_06_3e_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        dump_power_data(stdout, msrs.msr_rapl_power_unit,
                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        print_power_data(stdout, msrs.msr_rapl_power_unit,
                          msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
@@ -409,7 +407,7 @@ int fm_06_3e_get_frequencies(void)
 
     get_available_frequencies(stdout, &msrs.msr_platform_info,
                               &msrs.msr_turbo_ratio_limit, &msrs.msr_turbo_ratio_limit1,
-                              NULL, NULL, NULL);
+                              NULL, NULL);
     //    /* Turbo Range
     //     * Default ratio for 1C Max Turbo == P01
     //     * All core turbo == P0n

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -68,8 +68,8 @@ static struct kabylake_9e_offsets msrs =
 
 int fm_06_9e_get_power_limits(int long_ver)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -116,8 +116,8 @@ int fm_06_9e_get_power_limits(int long_ver)
 
 int fm_06_9e_set_power_limits(int package_power_limit)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -259,14 +259,12 @@ int fm_06_9e_get_counters(int long_ver)
     if (long_ver == 0)
     {
         dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
         print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                                msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
@@ -302,12 +300,12 @@ int fm_06_9e_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        dump_power_data(stdout, msrs.msr_rapl_power_unit,
                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        print_power_data(stdout, msrs.msr_rapl_power_unit,
                          msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
@@ -347,7 +345,6 @@ int fm_06_9e_get_frequencies(void)
 
     get_available_frequencies_skx(stdout, &msrs.msr_platform_info,
                                   &msrs.msr_turbo_ratio_limit, &msrs.msr_turbo_ratio_limit_cores,
-                                  &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2,
-                                  &msrs.msr_config_tdp_nominal);
+                                  &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2);
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -61,8 +61,8 @@ static struct sandybridge_2a_offsets msrs =
 
 int fm_06_2a_get_power_limits(int long_ver)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -123,8 +123,8 @@ int fm_06_2a_get_power_limits(int long_ver)
 
 int fm_06_2a_set_power_limits(int package_power_limit)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -253,14 +253,12 @@ int fm_06_2a_get_counters(int long_ver)
     if (long_ver == 0)
     {
         dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
         print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                                msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
@@ -296,12 +294,12 @@ int fm_06_2a_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        dump_power_data(stdout, msrs.msr_rapl_power_unit,
                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        print_power_data(stdout, msrs.msr_rapl_power_unit,
                          msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
@@ -377,7 +375,7 @@ int fm_06_2a_get_frequencies(void)
 
     get_available_frequencies(stdout, &msrs.msr_platform_info,
                               &msrs.msr_turbo_ratio_limit, NULL,
-                              NULL, NULL, NULL);
+                              NULL, NULL);
     //    /* Turbo Range
     //     * Default ratio for 1C Max Turbo == P01
     //     * All core turbo == P0n

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -62,8 +62,8 @@ static struct sandybridge_2d_offsets msrs =
 
 int fm_06_2d_get_power_limits(int long_ver)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -124,8 +124,8 @@ int fm_06_2d_get_power_limits(int long_ver)
 
 int fm_06_2d_set_power_limits(int package_power_limit)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -256,14 +256,12 @@ int fm_06_2d_get_counters(int long_ver)
     if (long_ver == 0)
     {
         dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
         print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                                msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
@@ -299,12 +297,12 @@ int fm_06_2d_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        dump_power_data(stdout, msrs.msr_rapl_power_unit,
                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        print_power_data(stdout, msrs.msr_rapl_power_unit,
                          msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
@@ -380,7 +378,7 @@ int fm_06_2d_get_frequencies(void)
 
     get_available_frequencies(stdout, &msrs.msr_platform_info,
                               &msrs.msr_turbo_ratio_limit, NULL,
-                              NULL, NULL, NULL);
+                              NULL, NULL);
 
     //    /* Turbo Range
     //     * Default ratio for 1C Max Turbo == P01

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -67,8 +67,8 @@ static struct skylake_55_offsets msrs =
 
 int fm_06_55_get_power_limits(int long_ver)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -115,8 +115,8 @@ int fm_06_55_get_power_limits(int long_ver)
 
 int fm_06_55_set_power_limits(int package_power_limit)
 {
-    int socket;
-    int nsockets, ncores, nthreads;
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
@@ -257,14 +257,12 @@ int fm_06_55_get_counters(int long_ver)
     if (long_ver == 0)
     {
         dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
         print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl,
                                msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
@@ -300,12 +298,12 @@ int fm_06_55_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        dump_power_data(stdout, msrs.msr_rapl_power_unit,
                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit,
+        print_power_data(stdout, msrs.msr_rapl_power_unit,
                          msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
@@ -339,14 +337,14 @@ int fm_06_55_monitoring(FILE *output)
 
 int fm_06_55_set_frequency(int core_freq_mhz)
 {
-    int nsockets, ncores, nthreads;
+    unsigned nsockets, ncores, nthreads;
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    set_p_state(core_freq_mhz, CORE, msrs.ia32_perf_status, msrs.ia32_perf_ctl);
+    set_p_state(core_freq_mhz, CORE, msrs.ia32_perf_status);
     return 0;
 }
 
@@ -358,7 +356,6 @@ int fm_06_55_get_frequencies(void)
 
     get_available_frequencies_skx(stdout, &msrs.msr_platform_info,
                                   &msrs.msr_turbo_ratio_limit, &msrs.msr_turbo_ratio_limit_cores,
-                                  &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2,
-                                  &msrs.msr_config_tdp_nominal);
+                                  &msrs.msr_config_tdp_level1, &msrs.msr_config_tdp_level2);
     return 0;
 }

--- a/src/variorum/Intel/clocks_features.c
+++ b/src/variorum/Intel/clocks_features.c
@@ -20,7 +20,7 @@ void clocks_storage(struct clocks_data **cd, off_t msr_aperf, off_t msr_mperf,
 {
     static int init = 0;
     static struct clocks_data d;
-    static int nthreads = 0;
+    static unsigned nthreads = 0;
 
     if (!init)
     {
@@ -40,12 +40,12 @@ void clocks_storage(struct clocks_data **cd, off_t msr_aperf, off_t msr_mperf,
     }
 }
 
-void perf_storage_temp(struct perf_data **pd, off_t msr_perf_status,
-                       off_t msr_perf_ctl, enum ctl_domains_e control_domains)
+void perf_storage_temp(struct perf_data **pd, off_t msr_perf_ctl,
+                       enum ctl_domains_e control_domains)
 {
     static int init = 0;
     static struct perf_data d;
-    int nsockets, ncores, nthreads;
+    unsigned nsockets, ncores, nthreads;
 
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
@@ -77,7 +77,7 @@ void perf_storage_temp(struct perf_data **pd, off_t msr_perf_status,
 void perf_storage(struct perf_data **pd, off_t msr_perf_status)
 {
     static struct perf_data d;
-    static int nsockets = 0;
+    static unsigned nsockets = 0;
 
     if (!nsockets)
     {
@@ -95,19 +95,28 @@ void perf_storage(struct perf_data **pd, off_t msr_perf_status)
     }
 }
 
-void dump_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
+int dump_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
                       off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info,
                       enum ctl_domains_e control_domains)
 {
-#if 0
     static struct clocks_data *cd;
     static struct perf_data *pd;
     static int init = 0;
-    int i, j, k;
-    int nsockets, ncores, nthreads;
+    unsigned i, j, k;
+    unsigned nsockets, ncores, nthreads;
     int idx;
     char hostname[1024];
-    //    int max_non_turbo_ratio = get_max_non_turbo_ratio(msr_platform_info);
+    int max_non_turbo_ratio;
+    int err;
+
+    err = get_max_non_turbo_ratio(msr_platform_info, &max_non_turbo_ratio);
+    if (err)
+    {
+        variorum_error_handler("Error retrieving max non-turbo ratio",
+                               VARIORUM_ERROR_FUNCTION, getenv("HOSTNAME"),
+                               __FILE__, __FUNCTION__, __LINE__);
+        return -1;
+    }
 
     variorum_get_topology(&nsockets, &ncores, &nthreads);
     gethostname(hostname, 1024);
@@ -168,24 +177,30 @@ void dump_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
             fprintf(stderr, "Not a valid control domain.\n");
             break;
     }
-#endif
+    return 0;
 }
 
-void print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
+int print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
                        off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info,
                        enum ctl_domains_e control_domains)
 {
     static struct clocks_data *cd;
     static struct perf_data *pd;
-    int i, j, k;
+    unsigned i, j, k;
     int idx;
-    int nsockets, ncores, nthreads;
+    unsigned nsockets, ncores, nthreads;
     char hostname[1024];
     int max_non_turbo_ratio;
     int err;
 
-
     err = get_max_non_turbo_ratio(msr_platform_info, &max_non_turbo_ratio);
+    if (err)
+    {
+        variorum_error_handler("Error retrieving max non-turbo ratio",
+                               VARIORUM_ERROR_FUNCTION, getenv("HOSTNAME"),
+                               __FILE__, __FUNCTION__, __LINE__);
+        return -1;
+    }
 
     variorum_get_topology(&nsockets, &ncores, &nthreads);
     gethostname(hostname, 1024);
@@ -235,6 +250,7 @@ void print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
             fprintf(stderr, "Not a valid control domain.\n");
             break;
     }
+    return 0;
 }
 
 //void print_clocks_data_socket(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info)
@@ -300,10 +316,10 @@ void print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
 //}
 
 void set_p_state(int cpu_freq_mhz, enum ctl_domains_e domain,
-                 off_t msr_perf_status, off_t msr_perf_ctl)
+                 off_t msr_perf_status)
 {
-    int nsockets, ncores, nthreads;
-    int i;
+    unsigned nsockets, ncores, nthreads;
+    unsigned i;
     static struct perf_data *pd;
     static int init = 0;
 
@@ -311,7 +327,7 @@ void set_p_state(int cpu_freq_mhz, enum ctl_domains_e domain,
     if (!init)
     {
         init = 1;
-        perf_storage_temp(&pd, msr_perf_status, msr_perf_ctl, domain);
+        perf_storage_temp(&pd, msr_perf_status, domain);
     }
 
     switch (domain)
@@ -442,8 +458,7 @@ void set_p_state(int cpu_freq_mhz, enum ctl_domains_e domain,
 
 void get_available_frequencies_skx(FILE *writedest, off_t *msr_platform_info,
                                    off_t *msr_turbo_ratio_limit, off_t *msr_turbo_ratio_limit_cores,
-                                   off_t *msr_config_tdp_l1, off_t *msr_config_tdp_l2,
-                                   off_t *msr_config_tdp_nominal)
+                                   off_t *msr_config_tdp_l1, off_t *msr_config_tdp_l2)
 {
     /* Turbo Range
      * Default ratio for 1C Max Turbo == P01
@@ -462,8 +477,7 @@ void get_available_frequencies_skx(FILE *writedest, off_t *msr_platform_info,
 
     /* AVX2, AVX512 (i.e., AVX3) */
     fprintf(writedest, "=== AVX Schedule ===\n");
-    get_avx_limits(msr_platform_info, msr_config_tdp_l1, msr_config_tdp_l2,
-                   msr_config_tdp_nominal);
+    get_avx_limits(msr_platform_info, msr_config_tdp_l1, msr_config_tdp_l2);
 
     fprintf(writedest, "\n");
 
@@ -500,8 +514,7 @@ void get_available_frequencies_skx(FILE *writedest, off_t *msr_platform_info,
 
 void get_available_frequencies(FILE *writedest, off_t *msr_platform_info,
                                off_t *msr_turbo_ratio_limit, off_t *msr_turbo_ratio_limit1,
-                               off_t *msr_config_tdp_l1, off_t *msr_config_tdp_l2,
-                               off_t *msr_config_tdp_nominal)
+                               off_t *msr_config_tdp_l1, off_t *msr_config_tdp_l2)
 {
     /* Turbo Range
      * Default ratio for 1C Max Turbo == P01
@@ -520,8 +533,7 @@ void get_available_frequencies(FILE *writedest, off_t *msr_platform_info,
 
     /* AVX2, AVX512 (i.e., AVX3) */
     fprintf(writedest, "=== AVX Schedule ===\n");
-    get_avx_limits(msr_platform_info, msr_config_tdp_l1, msr_config_tdp_l2,
-                   msr_config_tdp_nominal);
+    get_avx_limits(msr_platform_info, msr_config_tdp_l1, msr_config_tdp_l2);
 
     fprintf(writedest, "\n");
 

--- a/src/variorum/Intel/clocks_features.c
+++ b/src/variorum/Intel/clocks_features.c
@@ -96,8 +96,8 @@ void perf_storage(struct perf_data **pd, off_t msr_perf_status)
 }
 
 int dump_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
-                      off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info,
-                      enum ctl_domains_e control_domains)
+                     off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info,
+                     enum ctl_domains_e control_domains)
 {
     static struct clocks_data *cd;
     static struct perf_data *pd;
@@ -181,8 +181,8 @@ int dump_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
 }
 
 int print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
-                       off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info,
-                       enum ctl_domains_e control_domains)
+                      off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info,
+                      enum ctl_domains_e control_domains)
 {
     static struct clocks_data *cd;
     static struct perf_data *pd;

--- a/src/variorum/Intel/clocks_features.h
+++ b/src/variorum/Intel/clocks_features.h
@@ -78,6 +78,10 @@ void clocks_storage(struct clocks_data **cd,
 void perf_storage(struct perf_data **pd,
                   off_t msr_perf_status);
 
+void perf_storage_temp(struct perf_data **pd,
+                       off_t msr_perf_ctl,
+                       enum ctl_domains_e control_domains);
+
 ///// @brief Print the label for the abbreviated clocks data print out.
 /////
 ///// @param [in] writedest File stream where output will be written to.
@@ -92,13 +96,13 @@ void perf_storage(struct perf_data **pd,
 /// @param [in] msr_perf_status Unique MSR address for IA32_PERF_STATUS.
 /// @param [in] msr_platform_info Unique MSR address for MSR_PLATFORM_INFO.
 /// @param [in] control_domain Specific granularity of control.
-void dump_clocks_data(FILE *writedest,
-                      off_t msr_aperf,
-                      off_t msr_mperf,
-                      off_t msr_tsc,
-                      off_t msr_perf_status,
-                      off_t msr_platform_info,
-                      enum ctl_domains_e control_domain);
+int dump_clocks_data(FILE *writedest,
+                     off_t msr_aperf,
+                     off_t msr_mperf,
+                     off_t msr_tsc,
+                     off_t msr_perf_status,
+                     off_t msr_platform_info,
+                     enum ctl_domains_e control_domain);
 
 /// @brief Print clocks data in long format.
 ///
@@ -109,29 +113,27 @@ void dump_clocks_data(FILE *writedest,
 /// @param [in] msr_perf_status Unique MSR address for IA32_PERF_STATUS.
 /// @param [in] msr_platform_info Unique MSR address for MSR_PLATFORM_INFO.
 /// @param [in] control_domain Specific granularity of control.
-void print_clocks_data(FILE *writedest,
-                       off_t msr_aperf,
-                       off_t msr_mperf,
-                       off_t msr_tsc,
-                       off_t msr_perf_status,
-                       off_t msr_platform_info,
-                       enum ctl_domains_e control_domain);
+int print_clocks_data(FILE *writedest,
+                      off_t msr_aperf,
+                      off_t msr_mperf,
+                      off_t msr_tsc,
+                      off_t msr_perf_status,
+                      off_t msr_platform_info,
+                      enum ctl_domains_e control_domain);
 
 void get_available_frequencies(FILE *writedest,
                                off_t *msr_platform_info,
                                off_t *msr_turbo_ratio_limit,
                                off_t *msr_turbo_ratio_limit_cores,
                                off_t *msr_config_tdp_l1,
-                               off_t *msr_config_tdp_l2,
-                               off_t *msr_config_tdp_nominal);
+                               off_t *msr_config_tdp_l2);
 
 void get_available_frequencies_skx(FILE *writedest,
                                    off_t *msr_platform_info,
                                    off_t *msr_turbo_ratio_limit,
                                    off_t *msr_turbo_ratio_limit_cores,
                                    off_t *msr_config_tdp_l1,
-                                   off_t *msr_config_tdp_l2,
-                                   off_t *msr_config_tdp_nominal);
+                                   off_t *msr_config_tdp_l2);
 
 ///// @brief Print current p-state.
 /////
@@ -147,8 +149,7 @@ void get_available_frequencies_skx(FILE *writedest,
 //                 uint64_t pstate);
 void set_p_state(int cpu_freq_mhz,
                  enum ctl_domains_e domain,
-                 off_t msr_perf_status,
-                 off_t msr_perf_ctl);
+                 off_t msr_perf_status);
 //
 ///****************************************/
 ///* Software Controlled Clock Modulation */

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -37,7 +37,7 @@ uint64_t *detect_intel_arch(void)
     //return (((rax >> 28) & 0x0F)+((rax >> 8) & 0x0F) << 8) | ((rax >> 12) & 0xF0)+((rax >> 4) & 0xF);
 }
 
-int gpu_power_ratio_unimplemented(int long_ver)
+int gpu_power_ratio_unimplemented()
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -37,7 +37,7 @@ uint64_t *detect_intel_arch(void)
     //return (((rax >> 28) & 0x0F)+((rax >> 8) & 0x0F) << 8) | ((rax >> 12) & 0xF0)+((rax >> 4) & 0xF);
 }
 
-int gpu_power_ratio_unimplemented()
+int gpu_power_ratio_unimplemented(void)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/config_intel.h
+++ b/src/variorum/Intel/config_intel.h
@@ -12,6 +12,6 @@ uint64_t *detect_intel_arch(void);
 
 int set_intel_func_ptrs(void);
 
-int gpu_power_ratio_unimplemented();
+int gpu_power_ratio_unimplemented(void);
 
 #endif

--- a/src/variorum/Intel/config_intel.h
+++ b/src/variorum/Intel/config_intel.h
@@ -12,6 +12,6 @@ uint64_t *detect_intel_arch(void);
 
 int set_intel_func_ptrs(void);
 
-int gpu_power_ratio_unimplemented(int long_ver);
+int gpu_power_ratio_unimplemented();
 
 #endif

--- a/src/variorum/Intel/counters_features.c
+++ b/src/variorum/Intel/counters_features.c
@@ -44,7 +44,7 @@ void fixed_counter_storage(struct fixed_counter **ctr0,
 {
     static struct fixed_counter c0, c1, c2;
     static int init = 0;
-    static int nthreads;
+    static unsigned nthreads;
 
     if (!init)
     {
@@ -74,7 +74,7 @@ void fixed_counter_storage(struct fixed_counter **ctr0,
 
 void init_fixed_counter(struct fixed_counter *ctr)
 {
-    int nthreads = 0;
+    unsigned nthreads = 0;
     variorum_get_topology(NULL, NULL, &nthreads);
 
     ctr->enable = (uint64_t *) malloc(nthreads * sizeof(uint64_t));
@@ -91,8 +91,8 @@ void init_fixed_counter(struct fixed_counter *ctr)
 void enable_fixed_counters(off_t *msrs_fixed_ctrs, off_t msr1, off_t msr2)
 {
     struct fixed_counter *c0, *c1, *c2;
-    int i;
-    int nthreads = 0;
+    unsigned i;
+    unsigned nthreads = 0;
 
     variorum_get_topology(NULL, NULL, &nthreads);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
@@ -110,8 +110,8 @@ void enable_fixed_counters(off_t *msrs_fixed_ctrs, off_t msr1, off_t msr2)
 void disable_fixed_counters(off_t *msrs_fixed_ctrs, off_t msr1, off_t msr2)
 {
     struct fixed_counter *c0, *c1, *c2;
-    int i;
-    int nthreads = 0;
+    unsigned i;
+    unsigned nthreads = 0;
 
     variorum_get_topology(NULL, NULL, &nthreads);
     fixed_counter_storage(&c0, &c1, &c2, msrs_fixed_ctrs);
@@ -132,8 +132,8 @@ void set_fixed_counter_ctrl(struct fixed_counter *ctr0,
     static uint64_t **perf_global_ctrl = NULL;
     static uint64_t **fixed_ctr_ctrl = NULL;
     static int init = 0;
-    int i;
-    int nthreads = 0;
+    unsigned i;
+    unsigned nthreads = 0;
 
     if (!init)
     {
@@ -188,7 +188,7 @@ void fixed_counter_ctrl_storage(uint64_t ***perf_ctrl, uint64_t ***fixed_ctrl,
 {
     static uint64_t **perf_global_ctrl = NULL;
     static uint64_t **fixed_ctr_ctrl = NULL;
-    static int nthreads = 0;
+    static unsigned nthreads = 0;
     static int init = 0;
 
     if (!init)
@@ -214,35 +214,30 @@ void fixed_counter_ctrl_storage(uint64_t ***perf_ctrl, uint64_t ***fixed_ctrl,
 }
 
 void dump_all_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
-                           off_t msr_perf_global_ctrl, off_t msr_fixed_counter_ctrl,
                            off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs,
                            off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
 {
-    dump_fixed_counter_data(writedest, msrs_fixed_ctrs, msr_perf_global_ctrl,
-                            msr_fixed_counter_ctrl);
+    dump_fixed_counter_data(writedest, msrs_fixed_ctrs);
     dump_perfmon_counter_data(writedest, msrs_perfevtsel_ctrs, msrs_perfmon_ctrs);
     dump_unc_counter_data(writedest, msrs_pcu_pmon_evtsel, msrs_pcu_pmon_ctrs);
 }
 
 void print_all_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
-                            off_t msr_perf_global_ctrl, off_t msr_fixed_counter_ctrl,
                             off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs,
                             off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
 {
-    print_fixed_counter_data(writedest, msrs_fixed_ctrs, msr_perf_global_ctrl,
-                             msr_fixed_counter_ctrl);
+    print_fixed_counter_data(writedest, msrs_fixed_ctrs);
     print_perfmon_counter_data(writedest, msrs_perfevtsel_ctrs, msrs_perfmon_ctrs);
     print_unc_counter_data(writedest, msrs_pcu_pmon_evtsel, msrs_pcu_pmon_ctrs);
 }
 
-void dump_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
-                             off_t msr_perf_global_ctrl, off_t msr_fixed_counter_ctrl)
+void dump_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
 {
     static int init = 0;
     struct fixed_counter *c0, *c1, *c2;
-    int i;
+    unsigned i;
     char hostname[1024];
-    int nthreads = 0;
+    unsigned nthreads = 0;
 
     if (!init)
     {
@@ -267,9 +262,9 @@ void dump_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
 {
     static struct pmc *p = NULL;
     static int init = 0;
-    int i;
+    unsigned i;
     char hostname[1024];
-    int nthreads;
+    unsigned nthreads;
     int avail = 0;
 
     gethostname(hostname, 1024);
@@ -367,14 +362,13 @@ void dump_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
     }
 }
 
-void print_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
-                              off_t msr_perf_global_ctrl, off_t msr_fixed_counter_ctrl)
+void print_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
 {
     static int init = 0;
     struct fixed_counter *c0, *c1, *c2;
-    int i;
+    unsigned i;
     char hostname[1024];
-    int nthreads = 0;
+    unsigned nthreads = 0;
 
     if (!init)
     {
@@ -398,9 +392,9 @@ void print_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
 {
     static struct pmc *p = NULL;
     static int init = 0;
-    int i;
+    unsigned i;
     char hostname[1024];
-    int nthreads;
+    unsigned nthreads;
     int avail = 0;
 
     gethostname(hostname, 1024);
@@ -481,7 +475,7 @@ void print_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
 /// counters is less than 1.
 static int init_pmc(struct pmc *p, off_t *msrs_perfmon_ctrs)
 {
-    int nthreads = 0;
+    unsigned nthreads = 0;
     int avail = cpuid_num_pmc();
 
     variorum_get_topology(NULL, NULL, &nthreads);
@@ -542,7 +536,7 @@ static int init_pmc(struct pmc *p, off_t *msrs_perfmon_ctrs)
 /// counters is less than 1.
 static int init_perfevtsel(struct perfevtsel *evt, off_t *msrs_perfevtsel_ctrs)
 {
-    int nthreads;
+    unsigned nthreads;
     int avail = cpuid_num_pmc();
 
     variorum_get_topology(NULL, NULL, &nthreads);
@@ -596,8 +590,8 @@ static int init_perfevtsel(struct perfevtsel *evt, off_t *msrs_perfevtsel_ctrs)
 void set_all_pmc_ctrl(uint64_t cmask, uint64_t flags, uint64_t umask,
                       uint64_t eventsel, int pmcnum, off_t *msrs_perfevtsel_ctrs)
 {
-    int nthreads;
-    int i;
+    unsigned nthreads;
+    unsigned i;
 
     variorum_get_topology(NULL, NULL, &nthreads);
     for (i = 0; i < nthreads; i++)
@@ -712,9 +706,9 @@ void pmc_storage(struct pmc **p, off_t *msrs_perfmon_ctrs)
 void clear_all_pmc(off_t *msrs_perfmon_ctrs)
 {
     static struct pmc *p = NULL;
-    static int nthreads = 0;
+    static unsigned nthreads = 0;
     static int avail = 0;
-    int i;
+    unsigned i;
 
     if (p == NULL)
     {
@@ -760,7 +754,7 @@ static void init_unc_perfevtsel(struct unc_perfevtsel *uevt,
                                 off_t *msrs_pcu_pmon_evtsel)
 {
     static int init = 0;
-    int nsockets;
+    unsigned nsockets;
 
     variorum_get_topology(&nsockets, NULL, NULL);
 
@@ -789,7 +783,7 @@ static void init_unc_counters(struct unc_counters *uc,
                               off_t *msrs_pcu_pmon_ctrs)
 {
     static int init = 0;
-    int nsockets;
+    unsigned nsockets;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     if (!init)
@@ -852,8 +846,8 @@ void enable_pcu(off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
 void clear_all_pcu(off_t *msrs_pcu_pmon_ctrs)
 {
     static struct unc_counters *uc = NULL;
-    int nsockets = 0;
-    int i;
+    unsigned nsockets = 0;
+    unsigned i;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     if (uc == NULL)
@@ -875,8 +869,8 @@ void dump_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel,
 {
     static int init = 0;
     struct unc_counters *uc;
-    int i;
-    int nsockets;
+    unsigned i;
+    unsigned nsockets;
     char hostname[1024];
 
     variorum_get_topology(&nsockets, NULL, NULL);
@@ -900,8 +894,8 @@ void print_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel,
                             off_t *msrs_pcu_pmon_ctrs)
 {
     struct unc_counters *uc;
-    int i;
-    int nsockets;
+    unsigned i;
+    unsigned nsockets;
     char hostname[1024];
 
     variorum_get_topology(&nsockets, NULL, NULL);
@@ -930,9 +924,9 @@ void get_all_power_data_fixed(FILE *writedest, off_t msr_pkg_power_limit,
     static struct fixed_counter *c0, *c1, *c2;
     static struct clocks_data *cd;
     static int init_get_power_data = 0;
-    static int nsockets, nthreads;
+    static unsigned nsockets, nthreads;
     char hostname[1024];
-    int i;
+    unsigned i;
     int rlim_idx = 0;
 
     variorum_get_topology(&nsockets, NULL, &nthreads);

--- a/src/variorum/Intel/counters_features.c
+++ b/src/variorum/Intel/counters_features.c
@@ -484,45 +484,74 @@ static int init_pmc(struct pmc *p, off_t *msrs_perfmon_ctrs)
     {
         return -1;
     }
-    switch (avail)
+
+    if (avail == 8)
     {
-        case 8:
-            p->pmc7 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 7:
-            p->pmc6 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 6:
-            p->pmc5 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 5:
-            p->pmc4 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 4:
-            p->pmc3 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 3:
-            p->pmc2 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 2:
-            p->pmc1 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 1:
-            p->pmc0 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+        p->pmc7 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
     }
+    if (avail == 7)
+    {
+        p->pmc6 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 6)
+    {
+        p->pmc5 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 5)
+    {
+        p->pmc4 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 4)
+    {
+        p->pmc3 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 3)
+    {
+        p->pmc2 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 2)
+    {
+        p->pmc1 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 1)
+    {
+        p->pmc0 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+
     allocate_batch(COUNTERS_DATA, avail * nthreads);
-    switch (avail)
+    if (avail == 8)
     {
-        case 8:
-            load_thread_batch(msrs_perfmon_ctrs[7], p->pmc7, COUNTERS_DATA);
-        case 7:
-            load_thread_batch(msrs_perfmon_ctrs[6], p->pmc6, COUNTERS_DATA);
-        case 6:
-            load_thread_batch(msrs_perfmon_ctrs[5], p->pmc5, COUNTERS_DATA);
-        case 5:
-            load_thread_batch(msrs_perfmon_ctrs[4], p->pmc4, COUNTERS_DATA);
-        case 4:
-            load_thread_batch(msrs_perfmon_ctrs[3], p->pmc3, COUNTERS_DATA);
-        case 3:
-            load_thread_batch(msrs_perfmon_ctrs[2], p->pmc2, COUNTERS_DATA);
-        case 2:
-            load_thread_batch(msrs_perfmon_ctrs[1], p->pmc1, COUNTERS_DATA);
-        case 1:
-            load_thread_batch(msrs_perfmon_ctrs[0], p->pmc0, COUNTERS_DATA);
+        load_thread_batch(msrs_perfmon_ctrs[7], p->pmc7, COUNTERS_DATA);
     }
+    if (avail == 7)
+    {
+        load_thread_batch(msrs_perfmon_ctrs[6], p->pmc6, COUNTERS_DATA);
+    }
+    if (avail == 6)
+    {
+        load_thread_batch(msrs_perfmon_ctrs[5], p->pmc5, COUNTERS_DATA);
+    }
+    if (avail == 5)
+    {
+        load_thread_batch(msrs_perfmon_ctrs[4], p->pmc4, COUNTERS_DATA);
+    }
+    if (avail == 4)
+    {
+        load_thread_batch(msrs_perfmon_ctrs[3], p->pmc3, COUNTERS_DATA);
+    }
+    if (avail == 3)
+    {
+        load_thread_batch(msrs_perfmon_ctrs[2], p->pmc2, COUNTERS_DATA);
+    }
+    if (avail == 2)
+    {
+        load_thread_batch(msrs_perfmon_ctrs[1], p->pmc1, COUNTERS_DATA);
+    }
+    if (avail == 1)
+    {
+        load_thread_batch(msrs_perfmon_ctrs[0], p->pmc0, COUNTERS_DATA);
+    }
+
     return 0;
 }
 
@@ -545,45 +574,74 @@ static int init_perfevtsel(struct perfevtsel *evt, off_t *msrs_perfevtsel_ctrs)
     {
         return -1;
     }
-    switch (avail)
+
+    if (avail == 8)
     {
-        case 8:
-            evt->perf_evtsel7 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 7:
-            evt->perf_evtsel6 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 6:
-            evt->perf_evtsel5 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 5:
-            evt->perf_evtsel4 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 4:
-            evt->perf_evtsel3 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 3:
-            evt->perf_evtsel2 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 2:
-            evt->perf_evtsel1 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
-        case 1:
-            evt->perf_evtsel0 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+        evt->perf_evtsel7 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
     }
+    if (avail == 7)
+    {
+        evt->perf_evtsel6 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 6)
+    {
+        evt->perf_evtsel5 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 5)
+    {
+        evt->perf_evtsel4 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 4)
+    {
+        evt->perf_evtsel3 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 3)
+    {
+        evt->perf_evtsel2 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 2)
+    {
+        evt->perf_evtsel1 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+    if (avail == 1)
+    {
+        evt->perf_evtsel0 = (uint64_t **) calloc(nthreads, sizeof(uint64_t *));
+    }
+
     allocate_batch(COUNTERS_CTRL, avail * nthreads);
-    switch (avail)
+    if (avail == 8)
     {
-        case 8:
-            load_thread_batch(msrs_perfevtsel_ctrs[7], evt->perf_evtsel7, COUNTERS_CTRL);
-        case 7:
-            load_thread_batch(msrs_perfevtsel_ctrs[6], evt->perf_evtsel6, COUNTERS_CTRL);
-        case 6:
-            load_thread_batch(msrs_perfevtsel_ctrs[5], evt->perf_evtsel5, COUNTERS_CTRL);
-        case 5:
-            load_thread_batch(msrs_perfevtsel_ctrs[4], evt->perf_evtsel4, COUNTERS_CTRL);
-        case 4:
-            load_thread_batch(msrs_perfevtsel_ctrs[3], evt->perf_evtsel3, COUNTERS_CTRL);
-        case 3:
-            load_thread_batch(msrs_perfevtsel_ctrs[2], evt->perf_evtsel2, COUNTERS_CTRL);
-        case 2:
-            load_thread_batch(msrs_perfevtsel_ctrs[1], evt->perf_evtsel1, COUNTERS_CTRL);
-        case 1:
-            load_thread_batch(msrs_perfevtsel_ctrs[0], evt->perf_evtsel0, COUNTERS_CTRL);
+        load_thread_batch(msrs_perfevtsel_ctrs[7], evt->perf_evtsel7, COUNTERS_CTRL);
     }
+    if (avail == 7)
+    {
+        load_thread_batch(msrs_perfevtsel_ctrs[6], evt->perf_evtsel6, COUNTERS_CTRL);
+    }
+    if (avail == 6)
+    {
+        load_thread_batch(msrs_perfevtsel_ctrs[5], evt->perf_evtsel5, COUNTERS_CTRL);
+    }
+    if (avail == 5)
+    {
+        load_thread_batch(msrs_perfevtsel_ctrs[4], evt->perf_evtsel4, COUNTERS_CTRL);
+    }
+    if (avail == 4)
+    {
+        load_thread_batch(msrs_perfevtsel_ctrs[3], evt->perf_evtsel3, COUNTERS_CTRL);
+    }
+    if (avail == 3)
+    {
+        load_thread_batch(msrs_perfevtsel_ctrs[2], evt->perf_evtsel2, COUNTERS_CTRL);
+    }
+    if (avail == 2)
+    {
+        load_thread_batch(msrs_perfevtsel_ctrs[1], evt->perf_evtsel1, COUNTERS_CTRL);
+    }
+    if (avail == 1)
+    {
+        load_thread_batch(msrs_perfevtsel_ctrs[0], evt->perf_evtsel0, COUNTERS_CTRL);
+    }
+
     return 0;
 }
 
@@ -718,24 +776,37 @@ void clear_all_pmc(off_t *msrs_perfmon_ctrs)
     }
     for (i = 0; i < nthreads; i++)
     {
-        switch (avail)
+        if (avail == 8)
         {
-            case 8:
-                *p->pmc7[i] = 0;
-            case 7:
-                *p->pmc6[i] = 0;
-            case 6:
-                *p->pmc5[i] = 0;
-            case 5:
-                *p->pmc4[i] = 0;
-            case 4:
-                *p->pmc3[i] = 0;
-            case 3:
-                *p->pmc2[i] = 0;
-            case 2:
-                *p->pmc1[i] = 0;
-            case 1:
-                *p->pmc0[i] = 0;
+            *p->pmc7[i] = 0;
+        }
+        if (avail == 7)
+        {
+            *p->pmc6[i] = 0;
+        }
+        if (avail == 6)
+        {
+            *p->pmc5[i] = 0;
+        }
+        if (avail == 5)
+        {
+            *p->pmc4[i] = 0;
+        }
+        if (avail == 4)
+        {
+            *p->pmc3[i] = 0;
+        }
+        if (avail == 3)
+        {
+            *p->pmc2[i] = 0;
+        }
+        if (avail == 2)
+        {
+            *p->pmc1[i] = 0;
+        }
+        if (avail == 1)
+        {
+            *p->pmc0[i] = 0;
         }
     }
     write_batch(COUNTERS_DATA);

--- a/src/variorum/Intel/counters_features.h
+++ b/src/variorum/Intel/counters_features.h
@@ -127,14 +127,10 @@ void disable_fixed_counters(off_t *msrs_fixed_ctrs,
                             off_t msr2);
 
 void dump_fixed_counter_data(FILE *writedest,
-                             off_t *msrs_fixed_ctrs,
-                             off_t perf_global,
-                             off_t fixed_ctr_ctrl);
+                             off_t *msrs_fixed_ctrs);
 
 void print_fixed_counter_data(FILE *writedest,
-                              off_t *msrs_fixed_ctrs,
-                              off_t msr_perf_global_ctrl,
-                              off_t msr_fixed_counter_ctrl);
+                              off_t *msrs_fixed_ctrs);
 
 void dump_perfmon_counter_data(FILE *writedest,
                                off_t *msrs_perfevtsel_ctrs,
@@ -146,8 +142,6 @@ void print_perfmon_counter_data(FILE *writedest,
 
 void dump_all_counter_data(FILE *writedest,
                            off_t *msrs_fixed_ctrs,
-                           off_t msr_perf_global_ctrl,
-                           off_t msr_fixed_counter_ctrl,
                            off_t *msrs_perfevtsel_ctrs,
                            off_t *msrs_perfmon_ctrs,
                            off_t *msrs_pcu_pmon_evtsel,
@@ -155,8 +149,6 @@ void dump_all_counter_data(FILE *writedest,
 
 void print_all_counter_data(FILE *writedest,
                             off_t *msrs_fixed_ctrs,
-                            off_t msr_perf_global_ctrl,
-                            off_t msr_fixed_counter_ctrl,
                             off_t *msrs_perfevtsel_ctrs,
                             off_t *msrs_perfmon_ctrs,
                             off_t *msrs_pcu_pmon_evtsel,

--- a/src/variorum/Intel/misc_features.c
+++ b/src/variorum/Intel/misc_features.c
@@ -20,7 +20,7 @@
 int get_max_non_turbo_ratio(off_t msr_platform_info, int *val)
 {
     static int init = 0;
-    static int nsockets = 0;
+    static unsigned nsockets = 0;
     static uint64_t **raw_val = NULL;
     int max_non_turbo_ratio;
 
@@ -63,10 +63,9 @@ int get_max_non_turbo_ratio(off_t msr_platform_info, int *val)
 int get_max_efficiency_ratio(off_t msr_platform_info, int *val)
 {
     static int init = 0;
-    static int nsockets = 0;
+    static unsigned nsockets = 0;
     static uint64_t **raw_val = NULL;
     int max_efficiency_ratio;
-    int socket;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     if (!init)
@@ -108,10 +107,9 @@ int get_max_efficiency_ratio(off_t msr_platform_info, int *val)
 int get_min_operating_ratio(off_t msr_platform_info, int *val)
 {
     static int init = 0;
-    static int nsockets = 0;
+    static unsigned nsockets = 0;
     static uint64_t **raw_val = NULL;
     int min_operating_ratio;
-    int socket;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     if (!init)
@@ -146,9 +144,9 @@ int get_min_operating_ratio(off_t msr_platform_info, int *val)
 int get_turbo_ratio_limit(off_t msr_turbo_ratio_limit)
 {
     static int init = 0;
-    static int nsockets = 0;
+    static unsigned nsockets = 0;
     static uint64_t **val = NULL;
-    int socket, ncores, nbits;
+    unsigned ncores, nbits;
 
     variorum_get_topology(&nsockets, &ncores, NULL);
     if (!init)
@@ -169,7 +167,7 @@ int get_turbo_ratio_limit(off_t msr_turbo_ratio_limit)
         }
     }
 
-    int core = 1;
+    unsigned core = 1;
     for (nbits = 0; nbits < 64; nbits += 8)
     {
         printf("%2dC = %d MHz\n", core, (int)(MASK_VAL(*val[0], nbits + 7,
@@ -195,10 +193,10 @@ int get_turbo_ratio_limits(off_t msr_turbo_ratio_limit,
                            off_t msr_turbo_ratio_limit1)
 {
     static int init = 0;
-    static int nsockets = 0;
+    static unsigned nsockets = 0;
     static uint64_t **val = NULL;
     static uint64_t **val2 = NULL;
-    int socket, ncores, nbits;
+    unsigned ncores, nbits;
 
     variorum_get_topology(&nsockets, &ncores, NULL);
     if (!init)
@@ -224,7 +222,7 @@ int get_turbo_ratio_limits(off_t msr_turbo_ratio_limit,
         }
     }
 
-    int core = 1;
+    unsigned core = 1;
     for (nbits = 0; nbits < 64; nbits += 8)
     {
         printf("%2dC = %d MHz\n", core, (int)(MASK_VAL(*val[0], nbits + 7,
@@ -253,10 +251,10 @@ int get_turbo_ratio_limits_skx(off_t msr_turbo_ratio_limit,
                                off_t msr_turbo_ratio_limit_cores)
 {
     static int init = 0;
-    static int nsockets = 0;
+    static unsigned nsockets = 0;
     static uint64_t **val = NULL;
     static uint64_t **val2 = NULL;
-    int socket, ncores, nbits;
+    unsigned ncores, nbits;
 
     variorum_get_topology(&nsockets, &ncores, NULL);
     if (!init)
@@ -282,7 +280,7 @@ int get_turbo_ratio_limits_skx(off_t msr_turbo_ratio_limit,
         }
     }
 
-    int core;
+    unsigned core;
     for (nbits = 0; nbits < 64; nbits += 8)
     {
         core = (int)(MASK_VAL(*val2[0], nbits + 7, nbits));
@@ -302,10 +300,9 @@ int get_turbo_ratio_limits_skx(off_t msr_turbo_ratio_limit,
 int config_tdp(int nlevels, off_t msr_config_tdp_level)
 {
     static int init = 0;
-    static int nsockets = 0;
+    static unsigned nsockets = 0;
     static uint64_t **l = NULL;
     int level;
-    int socket;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     if (!init)
@@ -357,13 +354,11 @@ int config_tdp(int nlevels, off_t msr_config_tdp_level)
  * ratio
  */
 int get_avx_limits(off_t *msr_platform_info, off_t *msr_config_tdp_l1,
-                   off_t *msr_config_tdp_l2, off_t *msr_config_tdp_nominal)
+                   off_t *msr_config_tdp_l2)
 {
     static int init = 0;
-    static int nsockets = 0;
-    static uint64_t **val, **l1, **l2 = NULL;
-    int socket;
-    uint64_t nominal;
+    static unsigned nsockets = 0;
+    static uint64_t **val = NULL;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     if (!init)
@@ -415,14 +410,15 @@ int get_avx_limits(off_t *msr_platform_info, off_t *msr_config_tdp_l1,
             // Reserved
             break;
     }
+    return 0;
 }
 
 /// For socket level
 int set_turbo_on(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
 {
     int ret = 0;
-    int socket;
-    int nsockets;
+    unsigned socket;
+    unsigned nsockets;
     uint64_t mask = 0;
     uint64_t msr_val = 0;
 
@@ -466,8 +462,8 @@ int set_turbo_on(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
 int set_turbo_off(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
 {
     int ret = 0;
-    int socket;
-    int nsockets;
+    unsigned socket;
+    unsigned nsockets;
     uint64_t mask = 0;
     uint64_t msr_val = 0;
 
@@ -512,8 +508,8 @@ int dump_turbo_status(FILE *writedest, off_t msr_misc_enable,
                       unsigned int turbo_mode_disable_bit)
 {
     int ret = 0;
-    int socket;
-    int nsockets;
+    unsigned socket;
+    unsigned nsockets;
     uint64_t mask = 0;
     uint64_t msr_val = 0;
 

--- a/src/variorum/Intel/misc_features.c
+++ b/src/variorum/Intel/misc_features.c
@@ -391,25 +391,26 @@ int get_avx_limits(off_t *msr_platform_info, off_t *msr_config_tdp_l1,
      */
     int nvalues = (int)(MASK_VAL(*val[0], 34, 33));
     int max_non_turbo_ratio;
-    switch (nvalues)
+
+    if (nvalues == 2)
     {
-        case 2:
-            config_tdp(2, *msr_config_tdp_l2);
-        case 1:
-            config_tdp(1, *msr_config_tdp_l1);
-        case 0:
-            // Read 648h = normal P1
-            /// @todo Should we be reading from PLATFORM_INFO or CONFIG_TDP_NOMINAL 0x648?
-            err = get_max_non_turbo_ratio(*msr_platform_info, &max_non_turbo_ratio);
-            if (!err)
-            {
-                printf("Non-AVX = %d MHz\n", max_non_turbo_ratio);
-            }
-            break;
-        case 3:
-            // Reserved
-            break;
+        config_tdp(2, *msr_config_tdp_l2);
     }
+    if (nvalues == 1)
+    {
+        config_tdp(1, *msr_config_tdp_l1);
+    }
+    if (nvalues == 0)
+    {
+        // Read 648h = normal P1
+        /// @todo Should we be reading from PLATFORM_INFO or CONFIG_TDP_NOMINAL 0x648?
+        err = get_max_non_turbo_ratio(*msr_platform_info, &max_non_turbo_ratio);
+        if (!err)
+        {
+            printf("Non-AVX = %d MHz\n", max_non_turbo_ratio);
+        }
+    }
+
     return 0;
 }
 

--- a/src/variorum/Intel/misc_features.h
+++ b/src/variorum/Intel/misc_features.h
@@ -33,8 +33,7 @@ int get_turbo_ratio_limits_skx(off_t msr_turbo_ratio_limit,
 
 int get_avx_limits(off_t *msr_platform_info,
                    off_t *msr_config_tdp_l1,
-                   off_t *msr_config_tdp_l2,
-                   off_t *msr_config_tdp_nominal);
+                   off_t *msr_config_tdp_l2);
 
 int config_tdp(int nlevels,
                off_t msr_config_tdp_level);

--- a/src/variorum/Intel/msr_core.h
+++ b/src/variorum/Intel/msr_core.h
@@ -148,49 +148,25 @@ struct msr_batch_op
 ///
 /// @param [in] socket Unique socket/package identifier.
 ///
-/// @param [in] location Line number in source file where error occurred (use
-///        standard predefined macro __LINE__).
-///
-/// @param [in] file Name of source file where error occurred (use standard
-///        predefined macro __FILE__).
-///
 /// @return 0 if successful, else -1 if socket requested is greater than number
 /// of sockets in the platform.
-int sockets_assert(const unsigned *socket,
-                   const int location,
-                   const char *file);
+int sockets_assert(const unsigned *socket);
 
 /// @brief Validate specific thread exists in the platform configuration.
 ///
 /// @param [in] thread Unique thread identifier.
 ///
-/// @param [in] location Line number in source file where error occurred (use
-///        standard predefined macro __LINE__).
-///
-/// @param [in] file Name of source file where error occurred (use standard
-///        predefined macro __FILE__).
-///
 /// @return 0 if successful, else -1 if thread requested is greater than number
 /// of threads per core in the platform.
-int threads_assert(const unsigned *thread,
-                   const int location,
-                   const char *file);
+int threads_assert(const unsigned *thread);
 
 /// @brief Validate specific core exists in the platform configuration.
 ///
 /// @param [in] core Unique core identifier.
 ///
-/// @param [in] location Line number in source file where error occurred (use
-///        standard predefined macro __LINE__).
-///
-/// @param [in] file Name of source file where error occurred (use standard
-///        predefined macro __FILE__).
-///
 /// @return 0 if successful, else -1 if core requested is greater than number
 /// of cores per socket in the platform.
-int cores_assert(const unsigned *core,
-                 const int location,
-                 const char *file);
+int cores_assert(const unsigned *core);
 
 /// @brief Check status of a file.
 ///

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -54,6 +54,11 @@ static int translate(const unsigned socket, uint64_t *bits, double *units,
 #endif
                 return 0;
             }
+            else
+            {
+                *units = (double)(*bits) / ru[socket].joules;
+            }
+            break;
         /* No break statement, if not Haswell or Broadwell, use energy units defined in MSR_RAPL_POWER_UNIT. */
         case BITS_TO_JOULES:
             *units = (double)(*bits) / ru[socket].joules;

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -933,7 +933,8 @@ void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit,
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
-    char sockID[4];
+    static size_t sockID_len = 11; // large enough to avoid format truncation
+    char sockID[sockID_len+1];
     int i;
     double node_power = 0.0;
 
@@ -960,7 +961,7 @@ void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit,
         char mem_str[24] = "power_mem_socket_";
         char gpu_str[24] = "power_gpu_socket_";
 
-        sprintf(sockID, "%d", i);
+        snprintf(sockID, sockID_len, "%d", i);
         strcat(cpu_str, sockID);
         strcat(mem_str, sockID);
         strcat(gpu_str, sockID);

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -25,7 +25,7 @@ static int translate(const unsigned socket, uint64_t *bits, double *units,
     static struct rapl_units *ru = NULL;
     uint64_t timeval_z = 0;
     uint64_t timeval_y = 0;
-    static int nsockets;
+    static unsigned nsockets;
 
 #ifdef VARIORUM_DEBUG
     fprintf(stderr, "DEBUG: (translate) bits are at %p\n", bits);
@@ -185,7 +185,7 @@ static int calc_rapl_from_bits(const unsigned socket, struct rapl_limit *limit,
     uint64_t seconds_bits = 0;
     int ret = 0;
 
-    sockets_assert(&socket, __LINE__, __FILE__);
+    sockets_assert(&socket);
 
 #ifdef VARIORUM_DEBUG
     fprintf(stderr, "%s %s::%d DEBUG: (calc_rapl_from_bits)\n", getenv("HOSTNAME"),
@@ -290,7 +290,7 @@ static int calc_dram_rapl_limit(const unsigned socket, struct rapl_limit *limit,
 static void create_rapl_data_batch(struct rapl_data *rapl,
                                    off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
-    int nsockets;
+    unsigned nsockets;
     variorum_get_topology(&nsockets, NULL, NULL);
 
     allocate_batch(RAPL_DATA, 2UL * nsockets);
@@ -328,8 +328,8 @@ int get_rapl_power_unit(struct rapl_units *ru, off_t msr)
 {
     static int init_get_rapl_power_unit = 0;
     static uint64_t **val = NULL;
-    static int nsockets, ncores, nthreads;
-    int i;
+    static unsigned nsockets, ncores, nthreads;
+    unsigned i;
 
     variorum_get_topology(&nsockets, &ncores, &nthreads);
     if (!init_get_rapl_power_unit)
@@ -391,10 +391,10 @@ int get_rapl_power_unit(struct rapl_units *ru, off_t msr)
 
 void dump_rapl_power_unit(FILE *writedest, off_t msr)
 {
-    int socket;
+    unsigned socket;
     struct rapl_units *ru;
     char hostname[1024];
-    int nsockets;
+    unsigned nsockets;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
@@ -415,10 +415,10 @@ void dump_rapl_power_unit(FILE *writedest, off_t msr)
 
 void print_rapl_power_unit(FILE *writedest, off_t msr)
 {
-    int socket;
+    unsigned socket;
     struct rapl_units *ru;
     char hostname[1024];
-    int nsockets;
+    unsigned nsockets;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
@@ -481,7 +481,7 @@ void dump_package_power_limit(FILE *writedest, off_t msr_power_limit,
     struct rapl_limit l1, l2;
     static int init_dump_package_power_limit = 0;
     char hostname[1024];
-    int nsockets;
+    unsigned nsockets;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
@@ -507,7 +507,7 @@ void dump_dram_power_limit(FILE *writedest, off_t msr_power_limit,
     struct rapl_limit l1;
     static int init_dump_dram_power_limit = 0;
     char hostname[1024];
-    int nsockets;
+    unsigned nsockets;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
@@ -603,7 +603,7 @@ int set_package_power_limit(const unsigned socket, int package_power_limit,
     limit1->bits = 0;
     limit1->translate_bits = 0;
 
-    sockets_assert(&socket, __LINE__, __FILE__);
+    sockets_assert(&socket);
 
     /* If there is only one limit, grab the other existing one. */
     if (limit1 == NULL)
@@ -656,7 +656,7 @@ int get_rapl_power_info(const unsigned socket, struct rapl_power_info *info,
 {
     uint64_t val = 0;
 
-    sockets_assert(&socket, __LINE__, __FILE__);
+    sockets_assert(&socket);
 
 #ifdef VARIORUM_DEBUG
     fprintf(stderr, "%s %s::%d DEBUG: (get_rapl_power_info)\n", getenv("HOSTNAME"),
@@ -682,7 +682,7 @@ int get_rapl_power_info(const unsigned socket, struct rapl_power_info *info,
 int rapl_storage(struct rapl_data **data)
 {
     static struct rapl_data *rapl = NULL;
-    static int nsockets = 0;
+    static unsigned nsockets = 0;
     static int init = 0;
 
     if (!init)
@@ -715,12 +715,12 @@ int get_power(off_t msr_rapl_unit, off_t msr_pkg_energy_status,
               off_t msr_dram_energy_status)
 {
     static struct rapl_data *rapl = NULL;
-    int nsockets;
+    unsigned nsockets;
 
     variorum_get_topology(&nsockets, NULL, NULL);
 
 #ifdef VARIORUM_DEBUG
-    fprintf(stderr, "%s %s::%d DEBUG: (get_power) socket=%lu\n", getenv("HOSTNAME"),
+    fprintf(stderr, "%s %s::%d DEBUG: (get_power) socket=%u\n", getenv("HOSTNAME"),
             __FILE__, __LINE__, nsockets);
 #endif
 
@@ -750,9 +750,9 @@ int delta_rapl_data(off_t msr_rapl_unit)
     /* The energy status register holds 32 bits, this is max unsigned int. */
     static double max_joules = UINT_MAX;
     static int init = 0;
-    static int nsockets = 0;
+    static unsigned nsockets = 0;
     static struct rapl_data *rapl;
-    int i = 0;
+    unsigned i = 0;
 
 #ifdef VARIORUM_DEBUG
     fprintf(stderr, "%s %s::%d DEBUG: (delta_rapl_data)\n", getenv("HOSTNAME"),
@@ -833,16 +833,16 @@ int delta_rapl_data(off_t msr_rapl_unit)
     return 0;
 }
 
-void print_power_data(FILE *writedest, off_t msr_power_limit,
+void print_power_data(FILE *writedest, 
                       off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     static int init = 0;
     static struct rapl_data *rapl = NULL;
     static struct timeval start;
-    int nsockets = 0;
+    unsigned nsockets = 0;
     struct timeval now;
     char hostname[1024];
-    int i;
+    unsigned i;
 
     gethostname(hostname, 1024);
     variorum_get_topology(&nsockets, NULL, NULL);
@@ -859,8 +859,8 @@ void print_power_data(FILE *writedest, off_t msr_power_limit,
     for (i = 0; i < nsockets; i++)
     {
 #ifdef VARIORUM_DEBUG
-        fprintf(writedest, "pkg%d_bits = %8.4lx   pkg%d_joules= %8.4lf\n", i,
-                *rapl->pkg_bits[i], rapl->pkg_joules[i]);
+        fprintf(writedest, "pkg%d_bits = %8.4lx   pkg%d_joules= %8.4f\n", i,
+                *rapl->pkg_bits[i], i, rapl->pkg_joules[i]);
 #endif
         fprintf(writedest,
                 "_PACKAGE_ENERGY_STATUS Offset: 0x%lx Host: %s Socket: %d Bits: 0x%lx Joules: %lf Watts: %lf Elapsed: %lf s Timestamp: %lf s\n",
@@ -875,16 +875,16 @@ void print_power_data(FILE *writedest, off_t msr_power_limit,
     }
 }
 
-void dump_power_data(FILE *writedest, off_t msr_power_limit,
+void dump_power_data(FILE *writedest,
                      off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     static int init = 0;
     static struct rapl_data *rapl = NULL;
     static struct timeval start;
-    int nsockets = 0;
+    unsigned nsockets = 0;
     struct timeval now;
     char hostname[1024];
-    int i;
+    unsigned i;
 
     gethostname(hostname, 1024);
     variorum_get_topology(&nsockets, NULL, NULL);
@@ -929,13 +929,13 @@ void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit,
     static int init = 0;
     static struct rapl_data *rapl = NULL;
     struct rapl_limit l1, l2;
-    int nsockets = 0;
+    unsigned nsockets = 0;
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
     static size_t sockID_len = 11; // large enough to avoid format truncation
     char sockID[sockID_len + 1];
-    int i;
+    unsigned i;
     double node_power = 0.0;
 
     gethostname(hostname, 1024);
@@ -1042,8 +1042,8 @@ int read_rapl_data(off_t msr_rapl_unit, off_t msr_pkg_energy_status,
 {
     static struct rapl_data *rapl = NULL;
     static int init = 0;
-    static int nsockets = 0;
-    int i;
+    static unsigned nsockets = 0;
+    unsigned i;
 
     if (!init)
     {
@@ -1065,7 +1065,7 @@ int read_rapl_data(off_t msr_rapl_unit, off_t msr_pkg_energy_status,
         }
     }
 #ifdef VARIORUM_DEBUG
-    fprintf(stderr, "%s %s::%d DEBUG: (read_rapl_data): socket=%lu at address %p\n",
+    fprintf(stderr, "%s %s::%d DEBUG: (read_rapl_data): socket=%u at address %p\n",
             getenv("HOSTNAME"), __FILE__, __LINE__, nsockets, rapl);
 #endif
     /* Move current variables to "old" variables. */
@@ -1086,7 +1086,7 @@ int read_rapl_data(off_t msr_rapl_unit, off_t msr_pkg_energy_status,
         for (i = 0; i < nsockets; i++)
         {
 #ifdef VARIORUM_DEBUG
-            fprintf(stderr, "DEBUG: socket %lu msr 0x611 has destination %p\n", nsockets,
+            fprintf(stderr, "DEBUG: socket %u msr 0x611 has destination %p\n", nsockets,
                     rapl->pkg_bits);
 #endif
             rapl->old_pkg_bits[i] = *rapl->pkg_bits[i];
@@ -1149,9 +1149,9 @@ void get_all_power_data(FILE *writedest, off_t msr_pkg_power_limit,
     //static struct rapl_limit rlim[6];
     static struct rapl_data *rapl = NULL;
     static int init_get_power_data = 0;
-    static int nsockets;
+    static unsigned nsockets;
     char hostname[1024];
-    int i;
+    unsigned i;
     int rlim_idx = 0;
 
     variorum_get_topology(&nsockets, NULL, NULL);

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -934,7 +934,7 @@ void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit,
     struct timeval tv;
     uint64_t ts;
     static size_t sockID_len = 11; // large enough to avoid format truncation
-    char sockID[sockID_len+1];
+    char sockID[sockID_len + 1];
     int i;
     double node_power = 0.0;
 

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -838,8 +838,8 @@ int delta_rapl_data(off_t msr_rapl_unit)
     return 0;
 }
 
-void print_power_data(FILE *writedest, 
-                      off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
+void print_power_data(FILE *writedest, off_t msr_rapl_unit,
+                      off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     static int init = 0;
     static struct rapl_data *rapl = NULL;
@@ -880,8 +880,8 @@ void print_power_data(FILE *writedest,
     }
 }
 
-void dump_power_data(FILE *writedest,
-                     off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
+void dump_power_data(FILE *writedest, off_t msr_rapl_unit,
+                     off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     static int init = 0;
     static struct rapl_data *rapl = NULL;

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -209,13 +209,11 @@ int set_package_power_limit(const unsigned socket,
                             off_t msr_rapl_unit);
 
 void dump_power_data(FILE *writedest,
-                     off_t msr_power_limit,
                      off_t msr_rapl_unit,
                      off_t msr_pkg_energy_status,
                      off_t msr_dram_energy_status);
 
 void print_power_data(FILE *writedest,
-                      off_t msr_power_limit,
                       off_t msr_rapl_unit,
                       off_t msr_pkg_energy_status,
                       off_t msr_dram_energy_status);

--- a/src/variorum/Intel/thermal_features.c
+++ b/src/variorum/Intel/thermal_features.c
@@ -14,10 +14,10 @@
 
 void get_temp_target(struct msr_temp_target *s, off_t msr)
 {
-    int nsockets;
+    unsigned nsockets;
     static uint64_t **val = NULL;
     static int init_tt = 0;
-    int i;
+    unsigned i;
 
     variorum_get_topology(&nsockets, NULL, NULL);
 
@@ -44,10 +44,10 @@ void get_temp_target(struct msr_temp_target *s, off_t msr)
 
 void get_therm_stat(struct therm_stat *s, off_t msr)
 {
-    int nthreads;
+    unsigned nthreads;
     static uint64_t **val = NULL;
     static int init_ts = 0;
-    int i;
+    unsigned i;
 
     variorum_get_topology(NULL, NULL, &nthreads);
 
@@ -150,10 +150,10 @@ void get_therm_stat(struct therm_stat *s, off_t msr)
 
 int get_pkg_therm_stat(struct pkg_therm_stat *s, off_t msr)
 {
-    int nsockets;
+    unsigned nsockets;
     static uint64_t **val = NULL;
     static int init_pkg_ts = 0;
-    int i;
+    unsigned i;
 
     variorum_get_topology(&nsockets, NULL, NULL);
 
@@ -241,9 +241,9 @@ int print_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
     struct pkg_therm_stat *pkg_stat = NULL;
     struct msr_temp_target *t_target = NULL;
     struct therm_stat *t_stat = NULL;
-    int idx;
-    int i, j, k;
-    int nsockets, ncores, nthreads;
+    unsigned idx;
+    unsigned i, j, k;
+    unsigned nsockets, ncores, nthreads;
 
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 
@@ -300,9 +300,9 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
     struct pkg_therm_stat *pkg_stat = NULL;
     struct msr_temp_target *t_target = NULL;
     struct therm_stat *t_stat = NULL;
-    int idx;
-    int i, j, k;
-    int nsockets, ncores, nthreads;
+    unsigned idx;
+    unsigned i, j, k;
+    unsigned nsockets, ncores, nthreads;
 
     variorum_get_topology(&nsockets, &ncores, &nthreads);
 

--- a/src/variorum/Nvidia/Volta.c
+++ b/src/variorum/Nvidia/Volta.c
@@ -16,8 +16,8 @@ int volta_get_power(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    int iter = 0;
-    int nsockets;
+    unsigned iter = 0;
+    unsigned nsockets;
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
@@ -32,8 +32,8 @@ int volta_get_thermals(int long_ver)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    int iter = 0;
-    int nsockets;
+    unsigned iter = 0;
+    unsigned nsockets;
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
@@ -47,8 +47,8 @@ int volta_get_clocks(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    int iter = 0;
-    int nsockets;
+    unsigned iter = 0;
+    unsigned nsockets;
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
@@ -62,8 +62,8 @@ int volta_get_power_limits(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    int iter = 0;
-    int nsockets;
+    unsigned iter = 0;
+    unsigned nsockets;
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
@@ -77,8 +77,8 @@ int volta_get_gpu_utilization(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    int iter = 0;
-    int nsockets;
+    unsigned iter = 0;
+    unsigned nsockets;
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {

--- a/src/variorum/Nvidia/config_nvidia.c
+++ b/src/variorum/Nvidia/config_nvidia.c
@@ -8,6 +8,7 @@
 
 #include <config_nvidia.h>
 #include <config_architecture.h>
+#include <power_features.h>
 #include <Volta.h>
 #include <variorum_error.h>
 

--- a/src/variorum/Nvidia/power_features.c
+++ b/src/variorum/Nvidia/power_features.c
@@ -12,10 +12,10 @@
 #include <variorum_error.h>
 #include <variorum_timers.h>
 
-void initNVML()
+void initNVML(void)
 {
     unsigned int d;
-    int m_num_package;
+    unsigned m_num_package;
     /* Initialize GPU reading */
     nvmlReturn_t result = nvmlInit();
     nvmlDeviceGetCount(&m_total_unit_devices);
@@ -43,7 +43,7 @@ void initNVML()
     gethostname(m_hostname, 1024);
 }
 
-void shutdownNVML()
+void shutdownNVML(void)
 {
     nvmlShutdown();
 }
@@ -56,8 +56,8 @@ void dump_power_data(int chipid, int verbose, FILE *output)
     static int init_output = 0;
 
     //Iterate over all GPU device handles for this socket and print power
-    for (d = chipid * m_gpus_per_socket;
-         d < (chipid + 1) * m_gpus_per_socket; ++d)
+    for (d = chipid * (int)m_gpus_per_socket;
+         d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
         nvmlDeviceGetPowerUsage(m_unit_devices_file_desc[d], &power);
         value = (double)power * 0.001f;
@@ -83,13 +83,13 @@ void dump_power_data(int chipid, int verbose, FILE *output)
 
 void dump_thermal_data(int chipid, int verbose, FILE *output)
 {
-    unsigned int gpu_temp;
+    unsigned gpu_temp;
     int d;
     static int init_output = 0;
 
     /* Iterate over all GPU device handles populated at init and print temperature (SM) */
-    for (d = chipid * m_gpus_per_socket;
-         d < (chipid + 1) * m_gpus_per_socket; ++d)
+    for (d = chipid * (int)m_gpus_per_socket;
+         d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
         nvmlDeviceGetTemperature(m_unit_devices_file_desc[d], NVML_TEMPERATURE_GPU,
                                  &gpu_temp);
@@ -97,7 +97,7 @@ void dump_thermal_data(int chipid, int verbose, FILE *output)
         if (verbose)
         {
             fprintf(output,
-                    "_GPU_TEMPERATURE Host: %s, Socket:%d, Device ID: %d, Temperature: %ld\n",
+                    "_GPU_TEMPERATURE Host: %s, Socket:%d, Device ID: %d, Temperature: %u\n",
                     m_hostname, chipid, d, gpu_temp);
         }
         else
@@ -107,7 +107,7 @@ void dump_thermal_data(int chipid, int verbose, FILE *output)
                 fprintf(output, "_GPU_TEMPERATURE Host Socket Device Temperature\n");
                 init_output = 1;
             }
-            fprintf(output, "_GPU_TEMPERATURE %s %d %d %ld\n",
+            fprintf(output, "_GPU_TEMPERATURE %s %d %d %d\n",
                     m_hostname, chipid, d, gpu_temp);
         }
     }
@@ -123,8 +123,8 @@ void dump_power_limits(int chipid, int verbose, FILE *output)
     static int init_output = 0;
 
     /* Iterate over all GPU device handles populated at init and print GPU power limit */
-    for (d = chipid * m_gpus_per_socket;
-         d < (chipid + 1) * m_gpus_per_socket; ++d)
+    for (d = chipid * (int)m_gpus_per_socket;
+         d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
         nvmlDeviceGetPowerManagementLimit(m_unit_devices_file_desc[d], &power_limit);
         value = (double) power_limit * 0.001f;
@@ -156,8 +156,8 @@ void dump_clocks_data(int chipid, int verbose, FILE *output)
     static int init_output = 0;
 
     /* Iterate over all GPU device handles and print GPU clock */
-    for (d = chipid * m_gpus_per_socket;
-         d < (chipid + 1) * m_gpus_per_socket; ++d)
+    for (d = chipid * (int)m_gpus_per_socket;
+         d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
         nvmlDeviceGetClock(m_unit_devices_file_desc[d], NVML_CLOCK_SM,
                            NVML_CLOCK_ID_CURRENT, &gpu_clock);
@@ -188,15 +188,15 @@ void dump_gpu_utilization(int chipid, int verbose, FILE *output)
     static int init_output = 0;
 
     /* Iterate over all GPU device handles and print GPU SM and memory utilization */
-    for (d = chipid * m_gpus_per_socket;
-         d < (chipid + 1) * m_gpus_per_socket; ++d)
+    for (d = chipid * (int)m_gpus_per_socket;
+         d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
         nvmlDeviceGetUtilizationRates(m_unit_devices_file_desc[d], &util);
 
         if (verbose)
         {
             fprintf(output,
-                    "_GPU_UTILIZATION Host: %s, Socket: %d, Device ID: %d, GPU Utilization (%): SM: %d, Memory: %d\n",
+                    "_GPU_UTILIZATION Host: %s, Socket: %d, Device ID: %d, GPU Utilization (%%): SM: %d, Memory: %d\n",
                     m_hostname, chipid, d, util.gpu, util.memory);
         }
         else

--- a/src/variorum/Nvidia/power_features.h
+++ b/src/variorum/Nvidia/power_features.h
@@ -11,9 +11,9 @@
 
 #include <nvml.h>
 
-unsigned int m_total_unit_devices;
+unsigned m_total_unit_devices;
 nvmlDevice_t *m_unit_devices_file_desc;
-unsigned int m_gpus_per_socket;
+unsigned m_gpus_per_socket;
 char m_hostname[1024];
 
 void initNVML(void);

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -27,7 +27,11 @@
 #include <config_nvidia.h>
 #endif
 
+#ifdef VARIORUM_LOG
 int variorum_enter(const char *filename, const char *func_name, int line_num)
+#else
+int variorum_enter()
+#endif
 {
     int err = 0;
 #ifdef VARIORUM_LOG
@@ -57,7 +61,11 @@ int variorum_enter(const char *filename, const char *func_name, int line_num)
     return err;
 }
 
+#ifdef VARIORUM_LOG
 int variorum_exit(const char *filename, const char *func_name, int line_num)
+#else
+int variorum_exit()
+#endif
 {
     int err = 0;
 #ifdef VARIORUM_LOG
@@ -125,7 +133,7 @@ int variorum_detect_arch(void)
 }
 
 
-void variorum_get_topology(int *nsockets, int *ncores, int *nthreads)
+void variorum_get_topology(unsigned *nsockets, unsigned *ncores, unsigned *nthreads)
 {
     hwloc_topology_t topology;
     int rc;

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -124,12 +124,12 @@ int variorum_detect_arch(void)
     return 0;
 }
 
+
 void variorum_get_topology(int *nsockets, int *ncores, int *nthreads)
 {
     hwloc_topology_t topology;
-    unsigned int core_depth, pu_depth;
-    static int init_variorum_get_topology = 0;
     int rc;
+    static int init_variorum_get_topology = 0;
 
     gethostname(g_platform.hostname, 1024);
 
@@ -141,44 +141,89 @@ void variorum_get_topology(int *nsockets, int *ncores, int *nthreads)
         // If something goes wrong, there's no sense in trying to keep
         // marching forward.  Thus the asserts.
         rc = hwloc_topology_init(&topology);
-        assert(0 == rc);
+        if(0 != rc) exit(-1);
         rc = hwloc_topology_load(topology);
-        assert(0 == rc);
+        if(0 != rc) exit(-1);
 
-        // The hwloc documentation gives an example of a machine having
-        // depth=0, each package having a depth=1, each cache associated
-        // with a package having depth=2, each core associated with a cache
-        // having a depth=3, and each processing unit (pu) associated with
-        // a core having a depth=4.
-        core_depth = hwloc_get_type_depth(topology, HWLOC_OBJ_CORE);
-        assert(HWLOC_TYPE_DEPTH_UNKNOWN != core_depth);
-        assert(HWLOC_TYPE_DEPTH_MULTIPLE != core_depth);
-
-        pu_depth = hwloc_get_type_depth(topology, HWLOC_OBJ_PU);
-        assert(HWLOC_TYPE_DEPTH_UNKNOWN != pu_depth);
-        assert(HWLOC_TYPE_DEPTH_MULTIPLE != pu_depth);
 
         g_platform.num_sockets = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
         //-1 if Several levels exist with OBJ_SOCKET
-        assert(-1 != g_platform.num_sockets);
+        if(-1 == g_platform.num_sockets){ 
+		fprintf( stderr,"%s:%d "
+				"hwloc reports that HWLOC_OBJ_SOCKETs exist "
+				"at multiple levels of the topology DAG.  "
+				"Variorum doesn't handle this case.  "
+				"Exiting.", __FILE__, __LINE__);
+		exit(-1);
+	}
         // 0 if No levels exist with OBJ_SOCKET
-        assert(0 != g_platform.num_sockets);
+        if(0 == g_platform.num_sockets){ 
+		fprintf( stderr, "%s:%d "
+				"hwloc reports no HWLOC_OBJ_SOCKETs exist.  "
+				"Variorum doesn't handle this case.  "
+				"Exiting.", __FILE__, __LINE__);
+		exit(-1);
+	}
 
         g_platform.total_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
-        assert(-1 != g_platform.total_cores);
-        assert(0 != g_platform.total_cores);
+        if(-1 == g_platform.total_cores){ 
+		fprintf( stderr, "%s:%d "
+				"hwloc reports HWLOC_OJB_COREs exist "
+				"at multiple levels of the topology DAG.  "
+				"Variorum doesn't handle this case.  "
+				"Exiting.", __FILE__, __LINE__);
+		exit(-1);
+	}
+        if(0 == g_platform.total_cores){ 
+		fprintf( stderr, "%s:%d "
+				"hwloc reports no HWLOC_OBJ_COREs exist."
+				"Variorum doesn't handle this case."
+				"Exiting.", __FILE__, __LINE__);
+		exit(-1);
+	}
 
         g_platform.total_threads = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
-        assert(-1 != g_platform.total_threads);
-        assert(0 != g_platform.total_threads);
+        if(-1 == g_platform.total_threads){
+		fprintf( stderr, "%s:%d "
+				"hwloc reports that HWLOC_OBJ_PUs exist "
+				"at multiple levels of the topology DAG.  "
+				"Variorum doesn't handle this case."
+				"Exiting.", __FILE__, __LINE__);
+		exit(-1);
+	}
+        if(0 == g_platform.total_threads){
+		fprintf( stderr, "%s:%d "
+				"hwloc reports no HWLOC_OBJ_COREs exist.  "
+				"Variorum doesn't handle this case.  "
+				"Exiting.", __FILE__, __LINE__);
+		exit(-1);
+	}
 
         g_platform.num_cores_per_socket = g_platform.total_cores /
                                           g_platform.num_sockets;
-        assert(0 == g_platform.total_cores % g_platform.num_sockets);
+        if(0 != g_platform.total_cores % g_platform.num_sockets){
+		fprintf( stderr, "%s:%d "
+				"hwloc reports the number of cores (%d) mod "
+				"the number of sockets (%d) is not zero.  "
+				"Something is amiss.  Exiting.",
+				__FILE__, __LINE__,
+				g_platform.total_cores, 
+				g_platform.num_sockets);
+		exit(-1);
+	}
 
         g_platform.num_threads_per_core = g_platform.total_threads /
                                           g_platform.total_cores;
-        assert(0 == g_platform.total_threads % g_platform.total_cores);
+        if(0 != g_platform.total_threads % g_platform.total_cores){
+		fprintf( stderr, "%s:%d "
+				"hwloc reports the number of threads (%d) mod "
+				"the number of cores (%d) is not zero.  "
+				"Something is amiss.  Exiting.",
+				__FILE__, __LINE__,
+				g_platform.total_threads, 
+				g_platform.total_cores);
+		exit(-1);
+	}
 
         hwloc_topology_destroy(topology);
     }

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -141,89 +141,102 @@ void variorum_get_topology(int *nsockets, int *ncores, int *nthreads)
         // If something goes wrong, there's no sense in trying to keep
         // marching forward.  Thus the asserts.
         rc = hwloc_topology_init(&topology);
-        if(0 != rc) exit(-1);
+        if (rc != 0)
+        {
+            exit(-1);
+        }
         rc = hwloc_topology_load(topology);
-        if(0 != rc) exit(-1);
-
+        if (rc != 0)
+        {
+            exit(-1);
+        }
 
         g_platform.num_sockets = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
         //-1 if Several levels exist with OBJ_SOCKET
-        if(-1 == g_platform.num_sockets){ 
-		fprintf( stderr,"%s:%d "
-				"hwloc reports that HWLOC_OBJ_SOCKETs exist "
-				"at multiple levels of the topology DAG.  "
-				"Variorum doesn't handle this case.  "
-				"Exiting.", __FILE__, __LINE__);
-		exit(-1);
-	}
+        if (g_platform.num_sockets == -1)
+        {
+            fprintf(stderr, "%s:%d "
+                    "hwloc reports that HWLOC_OBJ_SOCKETs exist "
+                    "at multiple levels of the topology DAG.  "
+                    "Variorum doesn't handle this case.  "
+                    "Exiting.", __FILE__, __LINE__);
+            exit(-1);
+        }
         // 0 if No levels exist with OBJ_SOCKET
-        if(0 == g_platform.num_sockets){ 
-		fprintf( stderr, "%s:%d "
-				"hwloc reports no HWLOC_OBJ_SOCKETs exist.  "
-				"Variorum doesn't handle this case.  "
-				"Exiting.", __FILE__, __LINE__);
-		exit(-1);
-	}
+        if (g_platform.num_sockets == 0)
+        {
+            fprintf(stderr, "%s:%d "
+                    "hwloc reports no HWLOC_OBJ_SOCKETs exist.  "
+                    "Variorum doesn't handle this case.  "
+                    "Exiting.", __FILE__, __LINE__);
+            exit(-1);
+        }
 
         g_platform.total_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
-        if(-1 == g_platform.total_cores){ 
-		fprintf( stderr, "%s:%d "
-				"hwloc reports HWLOC_OJB_COREs exist "
-				"at multiple levels of the topology DAG.  "
-				"Variorum doesn't handle this case.  "
-				"Exiting.", __FILE__, __LINE__);
-		exit(-1);
-	}
-        if(0 == g_platform.total_cores){ 
-		fprintf( stderr, "%s:%d "
-				"hwloc reports no HWLOC_OBJ_COREs exist."
-				"Variorum doesn't handle this case."
-				"Exiting.", __FILE__, __LINE__);
-		exit(-1);
-	}
+        if (g_platform.total_cores == -1)
+        {
+            fprintf(stderr, "%s:%d "
+                    "hwloc reports HWLOC_OJB_COREs exist "
+                    "at multiple levels of the topology DAG.  "
+                    "Variorum doesn't handle this case.  "
+                    "Exiting.", __FILE__, __LINE__);
+            exit(-1);
+        }
+        if (g_platform.total_cores == 0)
+        {
+            fprintf(stderr, "%s:%d "
+                    "hwloc reports no HWLOC_OBJ_COREs exist."
+                    "Variorum doesn't handle this case."
+                    "Exiting.", __FILE__, __LINE__);
+            exit(-1);
+        }
 
         g_platform.total_threads = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
-        if(-1 == g_platform.total_threads){
-		fprintf( stderr, "%s:%d "
-				"hwloc reports that HWLOC_OBJ_PUs exist "
-				"at multiple levels of the topology DAG.  "
-				"Variorum doesn't handle this case."
-				"Exiting.", __FILE__, __LINE__);
-		exit(-1);
-	}
-        if(0 == g_platform.total_threads){
-		fprintf( stderr, "%s:%d "
-				"hwloc reports no HWLOC_OBJ_COREs exist.  "
-				"Variorum doesn't handle this case.  "
-				"Exiting.", __FILE__, __LINE__);
-		exit(-1);
-	}
+        if (g_platform.total_threads == -1)
+        {
+            fprintf(stderr, "%s:%d "
+                    "hwloc reports that HWLOC_OBJ_PUs exist "
+                    "at multiple levels of the topology DAG.  "
+                    "Variorum doesn't handle this case."
+                    "Exiting.", __FILE__, __LINE__);
+            exit(-1);
+        }
+        if (g_platform.total_threads == 0)
+        {
+            fprintf(stderr, "%s:%d "
+                    "hwloc reports no HWLOC_OBJ_COREs exist.  "
+                    "Variorum doesn't handle this case.  "
+                    "Exiting.", __FILE__, __LINE__);
+            exit(-1);
+        }
 
         g_platform.num_cores_per_socket = g_platform.total_cores /
                                           g_platform.num_sockets;
-        if(0 != g_platform.total_cores % g_platform.num_sockets){
-		fprintf( stderr, "%s:%d "
-				"hwloc reports the number of cores (%d) mod "
-				"the number of sockets (%d) is not zero.  "
-				"Something is amiss.  Exiting.",
-				__FILE__, __LINE__,
-				g_platform.total_cores, 
-				g_platform.num_sockets);
-		exit(-1);
-	}
+        if (g_platform.total_cores % g_platform.num_sockets != 0)
+        {
+            fprintf(stderr, "%s:%d "
+                    "hwloc reports the number of cores (%d) mod "
+                    "the number of sockets (%d) is not zero.  "
+                    "Something is amiss.  Exiting.",
+                    __FILE__, __LINE__,
+                    g_platform.total_cores,
+                    g_platform.num_sockets);
+            exit(-1);
+        }
 
         g_platform.num_threads_per_core = g_platform.total_threads /
                                           g_platform.total_cores;
-        if(0 != g_platform.total_threads % g_platform.total_cores){
-		fprintf( stderr, "%s:%d "
-				"hwloc reports the number of threads (%d) mod "
-				"the number of cores (%d) is not zero.  "
-				"Something is amiss.  Exiting.",
-				__FILE__, __LINE__,
-				g_platform.total_threads, 
-				g_platform.total_cores);
-		exit(-1);
-	}
+        if (g_platform.total_threads % g_platform.total_cores != 0)
+        {
+            fprintf(stderr, "%s:%d "
+                    "hwloc reports the number of threads (%d) mod "
+                    "the number of cores (%d) is not zero.  "
+                    "Something is amiss.  Exiting.",
+                    __FILE__, __LINE__,
+                    g_platform.total_threads,
+                    g_platform.total_cores);
+            exit(-1);
+        }
 
         hwloc_topology_destroy(topology);
     }

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -127,8 +127,6 @@ int variorum_detect_arch(void)
 void variorum_get_topology(int *nsockets, int *ncores, int *nthreads)
 {
     hwloc_topology_t topology;
-    hwloc_obj_t obj;
-    unsigned int i;
     unsigned int core_depth, pu_depth;
     static int init_variorum_get_topology = 0;
     int rc;
@@ -241,11 +239,9 @@ int variorum_set_func_ptrs()
 #endif
 #ifdef VARIORUM_WITH_NVIDIA
     err = set_nvidia_func_ptrs();
-    if (err)
-    {
-        return err;
-    }
 #endif
+
+    return err;
 }
 
 ////setfixedcounters = fixed_ctr0,

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -133,7 +133,8 @@ int variorum_detect_arch(void)
 }
 
 
-void variorum_get_topology(unsigned *nsockets, unsigned *ncores, unsigned *nthreads)
+void variorum_get_topology(unsigned *nsockets, unsigned *ncores,
+                           unsigned *nthreads)
 {
     hwloc_topology_t topology;
     int rc;

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -231,17 +231,25 @@ struct platform
 
 struct platform g_platform;
 
+#ifdef VARIORUM_LOG
 int variorum_enter(const char *filename,
                    const char *func_name,
                    int line_num);
+#else
+int variorum_enter();
+#endif
 
+#ifdef VARIORUM_LOG
 int variorum_exit(const char *filename,
                   const char *func_name,
                   int line_num);
+#else
+int variorum_exit(void);
+#endif
 
-void variorum_get_topology(int *nsockets,
-                           int *ncores,
-                           int *nthreads);
+void variorum_get_topology(unsigned *nsockets,
+                           unsigned *ncores,
+                           unsigned *nthreads);
 
 int variorum_set_func_ptrs(void);
 

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -41,12 +41,20 @@ static void print_children(hwloc_topology_t topology, hwloc_obj_t obj,
 int variorum_tester(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -57,7 +65,11 @@ int variorum_tester(void)
 int variorum_poll_power(FILE *output)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -75,7 +87,11 @@ int variorum_poll_power(FILE *output)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -86,7 +102,11 @@ int variorum_poll_power(FILE *output)
 int variorum_monitoring(FILE *output)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -104,7 +124,11 @@ int variorum_monitoring(FILE *output)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -115,7 +139,11 @@ int variorum_monitoring(FILE *output)
 int variorum_print_power_limits(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -133,7 +161,11 @@ int variorum_print_power_limits(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -144,7 +176,11 @@ int variorum_print_power_limits(void)
 int variorum_print_verbose_power_limits(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -162,7 +198,11 @@ int variorum_print_verbose_power_limits(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -213,7 +253,11 @@ void variorum_print_topology(void)
 int variorum_set_best_effort_node_power_limit(int node_power_limit)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -231,7 +275,11 @@ int variorum_set_best_effort_node_power_limit(int node_power_limit)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -243,7 +291,11 @@ int variorum_set_best_effort_node_power_limit(int node_power_limit)
 int variorum_set_and_verify_node_power_limit(int node_power_limit)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -261,7 +313,11 @@ int variorum_set_and_verify_node_power_limit(int node_power_limit)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -273,7 +329,11 @@ int variorum_set_and_verify_node_power_limit(int node_power_limit)
 int variorum_set_gpu_power_ratio(int gpu_power_ratio)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -291,7 +351,11 @@ int variorum_set_gpu_power_ratio(int gpu_power_ratio)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -302,7 +366,11 @@ int variorum_set_gpu_power_ratio(int gpu_power_ratio)
 int variorum_set_each_socket_power_limit(int socket_power_limit)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -320,7 +388,11 @@ int variorum_set_each_socket_power_limit(int socket_power_limit)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -331,7 +403,11 @@ int variorum_set_each_socket_power_limit(int socket_power_limit)
 int variorum_cap_each_core_frequency(int core_freq_mhz)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -349,7 +425,11 @@ int variorum_cap_each_core_frequency(int core_freq_mhz)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -360,7 +440,11 @@ int variorum_cap_each_core_frequency(int core_freq_mhz)
 int variorum_print_features(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -378,7 +462,11 @@ int variorum_print_features(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -389,7 +477,11 @@ int variorum_print_features(void)
 int variorum_print_thermals(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -407,7 +499,11 @@ int variorum_print_thermals(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -418,7 +514,11 @@ int variorum_print_thermals(void)
 int variorum_print_verbose_thermals(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -436,7 +536,11 @@ int variorum_print_verbose_thermals(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -447,7 +551,11 @@ int variorum_print_verbose_thermals(void)
 int variorum_print_counters(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -465,7 +573,11 @@ int variorum_print_counters(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -476,7 +588,11 @@ int variorum_print_counters(void)
 int variorum_print_verbose_counters(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -494,7 +610,11 @@ int variorum_print_verbose_counters(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -505,7 +625,11 @@ int variorum_print_verbose_counters(void)
 int variorum_print_clock_speed(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -523,7 +647,11 @@ int variorum_print_clock_speed(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -534,7 +662,11 @@ int variorum_print_clock_speed(void)
 int variorum_print_verbose_clock_speed(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -552,7 +684,11 @@ int variorum_print_verbose_clock_speed(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -563,7 +699,11 @@ int variorum_print_verbose_clock_speed(void)
 int variorum_print_power(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -581,7 +721,11 @@ int variorum_print_power(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -592,7 +736,11 @@ int variorum_print_power(void)
 int variorum_print_verbose_power(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -610,7 +758,11 @@ int variorum_print_verbose_power(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -621,7 +773,11 @@ int variorum_print_verbose_power(void)
 int variorum_print_hyperthreading(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -637,7 +793,11 @@ int variorum_print_hyperthreading(void)
     {
         fprintf(stdout, "  Hyperthreading:       Disabled\n");
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -648,7 +808,11 @@ int variorum_print_hyperthreading(void)
 int variorum_print_turbo(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -666,7 +830,11 @@ int variorum_print_turbo(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -678,7 +846,11 @@ int variorum_print_turbo(void)
 int variorum_print_gpu_utilization(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -696,7 +868,11 @@ int variorum_print_gpu_utilization(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -707,7 +883,11 @@ int variorum_print_gpu_utilization(void)
 int variorum_print_verbose_gpu_utilization(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -725,7 +905,11 @@ int variorum_print_verbose_gpu_utilization(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -736,7 +920,11 @@ int variorum_print_verbose_gpu_utilization(void)
 int variorum_enable_turbo(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -754,7 +942,11 @@ int variorum_enable_turbo(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -765,7 +957,11 @@ int variorum_enable_turbo(void)
 int variorum_disable_turbo(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -783,7 +979,11 @@ int variorum_disable_turbo(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -794,7 +994,11 @@ int variorum_disable_turbo(void)
 int variorum_get_node_power_json(json_t *get_power_obj)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -812,7 +1016,11 @@ int variorum_get_node_power_json(json_t *get_power_obj)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;
@@ -823,7 +1031,11 @@ int variorum_get_node_power_json(json_t *get_power_obj)
 int variorum_print_available_frequencies(void)
 {
     int err = 0;
+#ifdef VARIORUM_LOG
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
     if (err)
     {
         return -1;
@@ -840,7 +1052,11 @@ int variorum_print_available_frequencies(void)
     {
         return -1;
     }
+#ifdef VARIORUM_LOG
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
     if (err)
     {
         return -1;

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -172,8 +172,6 @@ int variorum_print_verbose_power_limits(void)
 
 void variorum_print_topology(void)
 {
-    int i;
-    int hyperthreading = 0;
     hwloc_topology_t topo;
 
     hwloc_topology_init(&topo);

--- a/src/variorum/variorum_error.c
+++ b/src/variorum/variorum_error.c
@@ -55,6 +55,9 @@ void variorum_error_message(enum variorum_error_e err, char *msg, size_t size)
         case VARIORUM_ERROR_FEATURE_NOT_AVAILABLE:
             strncpy(msg, "_ERROR_VARIORUM_FEATURE_NOT_AVAILABLE", size);
             break;
+        case VARIORUM_ERROR_FUNCTION:
+            strncpy(msg, "_ERROR_VARIORUM_FUNCTION", size);
+            break;
         default:
             strncpy(msg, "Unknown variorum error code.", size);
             break;

--- a/src/variorum/variorum_error.h
+++ b/src/variorum/variorum_error.h
@@ -25,7 +25,8 @@ enum variorum_error_e
     VARIORUM_ERROR_UNSUPPORTED_PLATFORM    = -11,
     VARIORUM_ERROR_UNSUPPORTED_ARCH        = -12,
     VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED = -13,
-    VARIORUM_ERROR_FEATURE_NOT_AVAILABLE   = -14
+    VARIORUM_ERROR_FEATURE_NOT_AVAILABLE   = -14,
+    VARIORUM_ERROR_FUNCTION                = -15
 };
 
 void variorum_error_handler(const char *desc,


### PR DESCRIPTION
Variorum has accumulated a fair amount of code that generates warnings in gcc 9.3.0.  There is a disjoint set of warnings in the debug and release builds.  

This PR adds -Wall and -Werror to both builds, encouraging cleanup.  (Stephanie and I had discussed adding this to just the debug build; if we can figure out why only some warnings are caught in release mode, I'm find with that.) --> These changes have been removed, and the -Wall -Werror flags will be added to the Travis CI build encouraging warnings to be addressed by developers as part of their PRs.

WIP builds for all build types without warnings or errors -- catalyst, quartz, thompson, rhetoric.

Fixes #141