### PR TITLE
add new CMake option for toggling between msr-safe versions

### DIFF
--- a/host-configs/catalyst-toss_3_x86_64_ib-gcc@4.9.3.cmake
+++ b/host-configs/catalyst-toss_3_x86_64_ib-gcc@4.9.3.cmake
@@ -12,8 +12,15 @@ set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/g++" CACHE PATH "")
 # fortran compiler
 set(CMAKE_Fortran_COMPILER  "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")
 
+set(USE_MSR_SAFE_BEFORE_1_5_0 ON CACHE BOOL "")
+
 set(BUILD_DOCS ON CACHE BOOL "")
-set(BUILD_TESTS ON CACHE BOOL "")
+set(BUILD_TESTS OFF CACHE BOOL "")
+
+set(VARIORUM_WITH_AMD OFF CACHE BOOL "")
+set(VARIORUM_WITH_NVIDIA OFF CACHE BOOL "")
+set(VARIORUM_WITH_IBM OFF CACHE BOOL "")
+set(VARIORUM_WITH_INTEL ON CACHE BOOL "")
 
 #SPHINX documentation building
 set("SPHINX_EXECUTABLE" "/usr/bin/sphinx-build" CACHE PATH "")

--- a/host-configs/quartz-toss_3_x86_64_ib-gcc@4.9.3.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-gcc@4.9.3.cmake
@@ -12,8 +12,10 @@ set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/g++" CACHE PATH "")
 # fortran compiler
 set(CMAKE_Fortran_COMPILER  "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")
 
+set(USE_MSR_SAFE_BEFORE_1_5_0 ON CACHE BOOL "")
+
 set(BUILD_DOCS ON CACHE BOOL "")
-set(BUILD_TESTS ON CACHE BOOL "")
+set(BUILD_TESTS OFF CACHE BOOL "")
 
 set(VARIORUM_WITH_AMD OFF CACHE BOOL "")
 set(VARIORUM_WITH_NVIDIA OFF CACHE BOOL "")

--- a/src/CMake/CMakeBasics.cmake
+++ b/src/CMake/CMakeBasics.cmake
@@ -25,6 +25,15 @@ macro(ENABLE_WARNINGS)
     add_definitions(-Wall -Wextra)
 endmacro()
 
+#######################
+# Msr-Safe Dependency #
+#######################
+if (USE_MSR_SAFE_BEFORE_1_5_0)
+    message(STATUS "Building for msr-safe before v1.5.0 (USE_MSR_SAFE_BEFORE_1_5_0 == ON)")
+else()
+    message(STATUS "Building for msr-safe v1.5.0 and beyond (USE_MSR_SAFE_BEFORE_1_5_0 == OFF)")
+endif()
+
 ##########################
 # Platform Architectures #
 ##########################
@@ -53,14 +62,14 @@ endif()
 # DEBUGGING #
 #############
 if (VARIORUM_DEBUG)
-    message(STATUS "Building with debug statements (VARIORUM_DEBUG = ON)")
+    message(STATUS "Building with debug statements (VARIORUM_DEBUG == ON)")
 else()
-    message(STATUS "Building without debug statements (VARIORUM_DEBUG = OFF)")
+    message(STATUS "Building without debug statements (VARIORUM_DEBUG == OFF)")
 endif()
 if (VARIORUM_LOG)
-    message(STATUS "Building with logging statements (VARIORUM_LOG = ON)")
+    message(STATUS "Building with logging statements (VARIORUM_LOG == ON)")
 else()
-    message(STATUS "Building without logging statements (VARIORUM_LOG = OFF)")
+    message(STATUS "Building without logging statements (VARIORUM_LOG == OFF)")
 endif()
 
 #################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,24 +10,30 @@ project(variorum VERSION "0.3.0" LANGUAGES C CXX)
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-option(BUILD_SHARED_LIBS    "Build shared libraries"       ON)
-option(BUILD_DOCS           "Build documentation"          ON)
-option(BUILD_TESTS          "Build tests"                  ON)
+option(USE_MSR_SAFE_BEFORE_1_5_0 "Use msr-safe before v1.5.0"   ON)
 
-option(ENABLE_FORTRAN       "Build Fortran support"        ON)
+option(BUILD_SHARED_LIBS         "Build shared libraries"       ON)
+option(BUILD_DOCS                "Build documentation"          ON)
+option(BUILD_TESTS               "Build tests"                  ON)
 
-option(VARIORUM_WITH_INTEL  "Support Intel architectures"  ON)
-option(VARIORUM_WITH_AMD    "Support AMD architectures"    OFF)
-option(VARIORUM_WITH_IBM    "Support IBM architectures"    OFF)
-option(VARIORUM_WITH_NVIDIA "Support Nvidia architectures" OFF)
-option(VARIORUM_DEBUG       "Enable debug statements"      OFF)
-option(VARIORUM_LOG         "Enable logging statements"    ON)
+option(ENABLE_FORTRAN            "Build Fortran support"        ON)
+
+option(VARIORUM_WITH_INTEL       "Support Intel architectures"  ON)
+option(VARIORUM_WITH_AMD         "Support AMD architectures"    OFF)
+option(VARIORUM_WITH_IBM         "Support IBM architectures"    OFF)
+option(VARIORUM_WITH_NVIDIA      "Support Nvidia architectures" OFF)
+option(VARIORUM_DEBUG            "Enable debug statements"      OFF)
+option(VARIORUM_LOG              "Enable logging statements"    ON)
 
 set(HWLOC_DIR "" CACHE PATH "path to hwloc installation")
 set(JANSSON_DIR "" CACHE PATH "path to jansson installation")
 
 if(ENABLE_FORTRAN)
     enable_language(Fortran)
+endif()
+
+if(USE_MSR_SAFE_BEFORE_1_5_0)
+    add_definitions(-DUSE_MSR_SAFE_BEFORE_1_5_0)
 endif()
 
 include(CMake/CMakeBasics.cmake)


### PR DESCRIPTION
- update quartz and catalyst host configs with new option
- add cmake output for this option
- small cleanup of other outputs in cmake output

Version 1.5.0 and later of msr-safe uses the msr_allowlist interface, while
versions prior to 1.5.0 use the msr_whitelist interface. Variorum encounters
both versions of msr-safe on different machines, so this provides an easy way
of switching between the two.

The default msr-safe version in variorum's build will be "before v1.5.0" (i.e.,
msr_whitelist interface) until more systems start migrating to the newer
msr-safe version. Set this option to ON in host config files for quartz and
catalyst for redundancy.

@tpatki @rountree @amarathe84 