### PR TITLE
print CMake build type to CMake output

### DIFF
--- a/src/CMake/VariorumBuildType.cmake
+++ b/src/CMake/VariorumBuildType.cmake
@@ -10,9 +10,11 @@
 set(default_build_type "Release")
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  message(STATUS "Setting variorum build type to \"${default_build_type}\" as none was specified.")
   set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
       STRING "Choose the type of build." FORCE)
   # Set the possible values of build type for cmake-gui
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+else()
+  message(STATUS "Setting variorum build type to \"${CMAKE_BUILD_TYPE}\"")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,11 +37,11 @@ if(USE_MSR_SAFE_BEFORE_1_5_0)
     add_definitions(-DUSE_MSR_SAFE_BEFORE_1_5_0)
 endif()
 
+include(CMake/VariorumBuildType.cmake)
+
 include(CMake/CMakeBasics.cmake)
 
 include(CMake/SetupFortran.cmake)
-
-include(CMake/VariorumBuildType.cmake)
 
 include(CMake/SetupCompilerOptions.cmake)
 


### PR DESCRIPTION
- previous implementation only showed default build type (if none was selected)

Resolves #151 