### PR TITLE
Rename dump functions to print and print to print_verbose

### DIFF
--- a/src/variorum/ARM/ARM.c
+++ b/src/variorum/ARM/ARM.c
@@ -21,7 +21,7 @@ int arm_get_power(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    ret = dump_power_data(long_ver, stdout);
+    ret = get_power_data(long_ver, stdout);
     return ret;
 }
 
@@ -31,7 +31,7 @@ int arm_get_thermals(int long_ver)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    ret = dump_thermal_data(long_ver, stdout);
+    ret = get_thermal_data(long_ver, stdout);
     return ret;
 }
 
@@ -47,7 +47,7 @@ int arm_get_clocks(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
-        ret = dump_clocks_data(iter, long_ver, stdout);
+        ret = get_clocks_data(iter, long_ver, stdout);
     }
     return ret;
 }
@@ -63,7 +63,7 @@ int arm_get_frequencies(void)
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
-        ret = dump_frequencies(iter, stdout);
+        ret = get_frequencies(iter, stdout);
     }
     return ret;
 }

--- a/src/variorum/ARM/config_arm.c
+++ b/src/variorum/ARM/config_arm.c
@@ -27,11 +27,11 @@ int set_arm_func_ptrs(void)
     if (*g_platform.arm_arch == ARMV8)
     {
         /* Initialize interfaces */
-        g_platform.variorum_dump_power                      = arm_get_power;
-        g_platform.variorum_dump_thermals                   = arm_get_thermals;
-        g_platform.variorum_dump_clocks                     = arm_get_clocks;
-        g_platform.variorum_print_available_frequencies     = arm_get_frequencies;
-        g_platform.variorum_cap_socket_frequency            = arm_cap_socket_frequency;
+        g_platform.variorum_print_power                 = arm_get_power;
+        g_platform.variorum_print_thermals              = arm_get_thermals;
+        g_platform.variorum_print_clocks                = arm_get_clocks;
+        g_platform.variorum_print_available_frequencies = arm_get_frequencies;
+        g_platform.variorum_cap_socket_frequency        = arm_cap_socket_frequency;
     }
     else
     {

--- a/src/variorum/ARM/power_features.c
+++ b/src/variorum/ARM/power_features.c
@@ -76,7 +76,7 @@ void shutdown_arm(void)
     printf("Shutdown ARM\n");
 }
 
-int dump_power_data(int verbose, FILE *output)
+int get_power_data(int verbose, FILE *output)
 {
     static int init_output = 0;
 
@@ -166,7 +166,7 @@ int dump_power_data(int verbose, FILE *output)
     return 0;
 }
 
-int dump_thermal_data(int verbose, FILE *output)
+int get_thermal_data(int verbose, FILE *output)
 {
     static int init_output = 0;
     uint64_t sys_therm_val;
@@ -238,7 +238,7 @@ int dump_thermal_data(int verbose, FILE *output)
     return 0;
 }
 
-int dump_clocks_data(int chipid, int verbose, FILE *output)
+int get_clocks_data(int chipid, int verbose, FILE *output)
 {
     static int init_output = 0;
     uint64_t freq_val;
@@ -287,7 +287,7 @@ int dump_clocks_data(int chipid, int verbose, FILE *output)
     return 0;
 }
 
-int dump_frequencies(int chipid, FILE *output)
+int get_frequencies(int chipid, FILE *output)
 {
     static int init_output = 0;
     char freq_fname[4096];

--- a/src/variorum/IBM/config_ibm.c
+++ b/src/variorum/IBM/config_ibm.c
@@ -25,8 +25,8 @@ int set_ibm_func_ptrs(void)
 
     if (*g_platform.ibm_arch == POWER9)
     {
-        g_platform.variorum_dump_power = p9_get_power;
-        g_platform.variorum_dump_power_limits = p9_get_power_limits;
+        g_platform.variorum_print_power = p9_get_power;
+        g_platform.variorum_print_power_limits = p9_get_power_limits;
         g_platform.variorum_cap_best_effort_node_power_limit =
             p9_cap_node_power_limit;
         g_platform.variorum_cap_each_socket_power_limit =

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -85,11 +85,13 @@ int fm_06_4f_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                      msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                              msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -97,11 +99,13 @@ int fm_06_4f_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_dram_power_limit(stdout, msrs.msr_dram_power_limit,
+                                   msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit,
+                                           msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -263,11 +267,13 @@ int fm_06_4f_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                         msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -281,18 +287,18 @@ int fm_06_4f_get_counters(int long_ver)
     if (long_ver == 0)
     {
         print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perfevtsel_counters,
-                              msrs.ia32_perfmon_counters,
-                              msrs.msrs_pcu_pmon_evtsel,
-                              msrs.ia32_perfevtsel_counters);
-    }
-    else if (long_ver == 1)
-    {
-        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
                                msrs.ia32_perfevtsel_counters,
                                msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel,
                                msrs.ia32_perfevtsel_counters);
+    }
+    else if (long_ver == 1)
+    {
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                                       msrs.ia32_perfevtsel_counters,
+                                       msrs.ia32_perfmon_counters,
+                                       msrs.msrs_pcu_pmon_evtsel,
+                                       msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -305,11 +311,15 @@ int fm_06_4f_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                          CORE);
     }
     else if (long_ver == 1)
     {
-        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                                  msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                                  CORE);
     }
     return 0;
 }
@@ -322,11 +332,13 @@ int fm_06_4f_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                         msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit,
+                                 msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }
@@ -403,7 +415,9 @@ int fm_06_4f_get_node_power_json(json_t *get_power_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+    json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
+                        msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                        msrs.msr_dram_energy_status);
 
     return 0;
 }

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -85,13 +85,11 @@ int fm_06_4f_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                     msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                      msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -99,35 +97,33 @@ int fm_06_4f_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_dram_power_limit(stdout, msrs.msr_dram_power_limit,
-                                  msrs.msr_rapl_power_unit, socket);
+            print_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_dram_power_limit(stdout, msrs.msr_dram_power_limit,
-                                   msrs.msr_rapl_power_unit, socket);
+            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
     for (socket = 0; socket < nsockets; socket++)
     {
         if (long_ver == 0)
-        {
-            dump_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
-        }
-        else if (long_ver == 1)
         {
             print_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
         }
     }
 
     if (long_ver == 0)
     {
-        dump_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
     else if (long_ver == 1)
     {
-        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_verbose_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
 
     return 0;
@@ -267,15 +263,11 @@ int fm_06_4f_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                msrs.ia32_package_therm_status,
-                                msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                 msrs.ia32_package_therm_status,
-                                 msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -288,7 +280,7 @@ int fm_06_4f_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
                               msrs.ia32_perfevtsel_counters,
                               msrs.ia32_perfmon_counters,
                               msrs.msrs_pcu_pmon_evtsel,
@@ -296,7 +288,7 @@ int fm_06_4f_get_counters(int long_ver)
     }
     else if (long_ver == 1)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
                                msrs.ia32_perfevtsel_counters,
                                msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel,
@@ -313,15 +305,11 @@ int fm_06_4f_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                         msrs.ia32_time_stamp_counter, msrs.ia32_perf_status,
-                         msrs.msr_platform_info, CORE);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
     }
     else if (long_ver == 1)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status,
-                          msrs.msr_platform_info, CORE);
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
     }
     return 0;
 }
@@ -334,15 +322,11 @@ int fm_06_4f_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout,
-                        msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
-                        msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout,
-                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
-                         msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }
@@ -378,7 +362,7 @@ int fm_06_4f_get_turbo_status(void)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    dump_turbo_status(stdout, msrs.ia32_misc_enable, turbo_mode_disable_bit);
+    print_turbo_status(stdout, msrs.ia32_misc_enable, turbo_mode_disable_bit);
 
     return 0;
 }
@@ -419,9 +403,7 @@ int fm_06_4f_get_node_power_json(json_t *get_power_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_dump_power_data(get_power_obj, msrs.msr_pkg_power_limit,
-                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
-                         msrs.msr_dram_energy_status);
+    json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
 
     return 0;
 }

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -80,11 +80,13 @@ int fm_06_3f_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                      msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                              msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -92,11 +94,13 @@ int fm_06_3f_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_dram_power_limit(stdout, msrs.msr_dram_power_limit,
+                                   msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit,
+                                           msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -248,11 +252,13 @@ int fm_06_3f_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                         msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -265,13 +271,15 @@ int fm_06_3f_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
         print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+                                       msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                                       msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -284,13 +292,15 @@ int fm_06_3f_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                          CORE);
     }
     else if (long_ver == 1)
     {
         print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                          CORE);
+                                  msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                                  CORE);
     }
     return 0;
 }
@@ -303,12 +313,13 @@ int fm_06_3f_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                         msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
         print_verbose_power_data(stdout, msrs.msr_rapl_power_unit,
-                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+                                 msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -80,13 +80,11 @@ int fm_06_3f_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                     msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                      msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -94,35 +92,33 @@ int fm_06_3f_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_dram_power_limit(stdout, msrs.msr_dram_power_limit,
-                                  msrs.msr_rapl_power_unit, socket);
+            print_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_dram_power_limit(stdout, msrs.msr_dram_power_limit,
-                                   msrs.msr_rapl_power_unit, socket);
+            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
     for (socket = 0; socket < nsockets; socket++)
     {
         if (long_ver == 0)
-        {
-            dump_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
-        }
-        else if (long_ver == 1)
         {
             print_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
         }
     }
 
     if (long_ver == 0)
     {
-        dump_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
     else if (long_ver == 1)
     {
-        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_verbose_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
 
     return 0;
@@ -252,13 +248,11 @@ int fm_06_3f_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -271,13 +265,11 @@ int fm_06_3f_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                              msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
                                msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
@@ -292,13 +284,11 @@ int fm_06_3f_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                         msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                         CORE);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
     }
     else if (long_ver == 1)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
                           msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
                           CORE);
     }
@@ -313,12 +303,11 @@ int fm_06_3f_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_rapl_power_unit,
-                        msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit,
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit,
                          msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
@@ -354,7 +343,7 @@ int fm_06_3f_get_turbo_status(void)
 #endif
 
     unsigned int turbo_mode_disable_bit = 38;
-    dump_turbo_status(stdout, msrs.ia32_misc_enable, turbo_mode_disable_bit);
+    print_turbo_status(stdout, msrs.ia32_misc_enable, turbo_mode_disable_bit);
 
     return 0;
 }

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -84,13 +84,11 @@ int fm_06_3e_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                     msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                      msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -98,35 +96,33 @@ int fm_06_3e_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_dram_power_limit(stdout, msrs.msr_dram_power_limit,
-                                  msrs.msr_rapl_power_unit, socket);
+            print_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_dram_power_limit(stdout, msrs.msr_dram_power_limit,
-                                   msrs.msr_rapl_power_unit, socket);
+            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
     for (socket = 0; socket < nsockets; socket++)
     {
         if (long_ver == 0)
-        {
-            dump_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
-        }
-        else if (long_ver == 1)
         {
             print_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
         }
     }
 
     if (long_ver == 0)
     {
-        dump_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
     else if (long_ver == 1)
     {
-        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_verbose_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
 
     return 0;
@@ -265,13 +261,11 @@ int fm_06_3e_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -284,15 +278,11 @@ int fm_06_3e_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                              msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -305,15 +295,11 @@ int fm_06_3e_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                         msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                         SOCKET);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
     }
     else if (long_ver == 1)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                          SOCKET);
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
     }
     return 0;
 }
@@ -326,13 +312,11 @@ int fm_06_3e_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_rapl_power_unit,
-                        msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit,
-                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }
@@ -368,7 +352,7 @@ int fm_06_3e_get_turbo_status(void)
 #endif
 
     unsigned int turbo_mode_disable_bit = 38;
-    dump_turbo_status(stdout, msrs.ia32_misc_enable, turbo_mode_disable_bit);
+    print_turbo_status(stdout, msrs.ia32_misc_enable, turbo_mode_disable_bit);
 
     return 0;
 }

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -84,11 +84,13 @@ int fm_06_3e_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                      msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                              msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -96,11 +98,13 @@ int fm_06_3e_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_dram_power_limit(stdout, msrs.msr_dram_power_limit,
+                                   msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit,
+                                           msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -261,11 +265,13 @@ int fm_06_3e_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                         msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -278,11 +284,15 @@ int fm_06_3e_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
-        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                                       msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                                       msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -295,11 +305,15 @@ int fm_06_3e_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                          SOCKET);
     }
     else if (long_ver == 1)
     {
-        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                                  msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                                  SOCKET);
     }
     return 0;
 }
@@ -312,11 +326,13 @@ int fm_06_3e_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                         msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit,
+                                 msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -80,11 +80,13 @@ int fm_06_9e_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                      msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                              msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -237,11 +239,13 @@ int fm_06_9e_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                         msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -254,13 +258,15 @@ int fm_06_9e_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
         print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+                                       msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                                       msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -273,13 +279,15 @@ int fm_06_9e_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                          CORE);
     }
     else if (long_ver == 1)
     {
         print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                          CORE);
+                                  msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                                  CORE);
     }
     return 0;
 }
@@ -292,11 +300,13 @@ int fm_06_9e_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                         msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit,
+                                 msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -80,13 +80,11 @@ int fm_06_9e_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                     msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                      msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -94,21 +92,21 @@ int fm_06_9e_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+            print_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
         }
         else if (long_ver == 1)
         {
-            print_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+            print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
         }
     }
 
     if (long_ver == 0)
     {
-        dump_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
     else if (long_ver == 1)
     {
-        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_verbose_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
 
     return 0;
@@ -239,13 +237,11 @@ int fm_06_9e_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -258,13 +254,11 @@ int fm_06_9e_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                              msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
                                msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
                                msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
@@ -279,13 +273,11 @@ int fm_06_9e_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                         msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                         CORE);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
     }
     else if (long_ver == 1)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
                           msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
                           CORE);
     }
@@ -300,13 +292,11 @@ int fm_06_9e_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_rapl_power_unit,
-                        msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit,
-                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -73,13 +73,11 @@ int fm_06_2a_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                     msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                      msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -87,35 +85,33 @@ int fm_06_2a_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_dram_power_limit(stdout, msrs.msr_dram_power_limit,
-                                  msrs.msr_rapl_power_unit, socket);
+            print_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_dram_power_limit(stdout, msrs.msr_dram_power_limit,
-                                   msrs.msr_rapl_power_unit, socket);
+            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
     for (socket = 0; socket < nsockets; socket++)
     {
         if (long_ver == 0)
-        {
-            dump_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
-        }
-        else if (long_ver == 1)
         {
             print_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
         }
     }
 
     if (long_ver == 0)
     {
-        dump_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
     else if (long_ver == 1)
     {
-        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_verbose_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
 
     return 0;
@@ -233,13 +229,11 @@ int fm_06_2a_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -252,15 +246,11 @@ int fm_06_2a_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                              msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -273,15 +263,11 @@ int fm_06_2a_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                         msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                         SOCKET);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
     }
     else if (long_ver == 1)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                          SOCKET);
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
     }
     return 0;
 }
@@ -294,13 +280,11 @@ int fm_06_2a_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_rapl_power_unit,
-                        msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit,
-                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }
@@ -336,7 +320,7 @@ int fm_06_2a_get_turbo_status(void)
 #endif
 
     unsigned int turbo_mode_disable_bit = 38;
-    dump_turbo_status(stdout, msrs.ia32_misc_enable, turbo_mode_disable_bit);
+    print_turbo_status(stdout, msrs.ia32_misc_enable, turbo_mode_disable_bit);
 
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -73,11 +73,13 @@ int fm_06_2a_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                      msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                              msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -85,11 +87,13 @@ int fm_06_2a_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_dram_power_limit(stdout, msrs.msr_dram_power_limit,
+                                   msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit,
+                                           msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -229,11 +233,13 @@ int fm_06_2a_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                         msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -246,11 +252,15 @@ int fm_06_2a_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
-        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                                       msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                                       msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -263,11 +273,15 @@ int fm_06_2a_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                          SOCKET);
     }
     else if (long_ver == 1)
     {
-        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                                  msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                                  SOCKET);
     }
     return 0;
 }
@@ -280,11 +294,13 @@ int fm_06_2a_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                         msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit,
+                                 msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -74,11 +74,13 @@ int fm_06_2d_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                      msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                              msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -86,11 +88,13 @@ int fm_06_2d_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_dram_power_limit(stdout, msrs.msr_dram_power_limit,
+                                   msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit,
+                                           msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -232,11 +236,13 @@ int fm_06_2d_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                         msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -249,11 +255,15 @@ int fm_06_2d_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
-        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                                       msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                                       msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -266,11 +276,15 @@ int fm_06_2d_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                          SOCKET);
     }
     else if (long_ver == 1)
     {
-        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                                  msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                                  SOCKET);
     }
     return 0;
 }
@@ -283,11 +297,13 @@ int fm_06_2d_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                         msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit,
+                                 msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -74,13 +74,11 @@ int fm_06_2d_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                     msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                      msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -88,35 +86,33 @@ int fm_06_2d_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_dram_power_limit(stdout, msrs.msr_dram_power_limit,
-                                  msrs.msr_rapl_power_unit, socket);
+            print_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_dram_power_limit(stdout, msrs.msr_dram_power_limit,
-                                   msrs.msr_rapl_power_unit, socket);
+            print_verbose_dram_power_limit(stdout, msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
     for (socket = 0; socket < nsockets; socket++)
     {
         if (long_ver == 0)
-        {
-            dump_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
-        }
-        else if (long_ver == 1)
         {
             print_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
         }
     }
 
     if (long_ver == 0)
     {
-        dump_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
     else if (long_ver == 1)
     {
-        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_verbose_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
 
     return 0;
@@ -236,13 +232,11 @@ int fm_06_2d_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -255,15 +249,11 @@ int fm_06_2d_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                              msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -276,15 +266,11 @@ int fm_06_2d_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                         msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                         SOCKET);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
     }
     else if (long_ver == 1)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                          SOCKET);
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, SOCKET);
     }
     return 0;
 }
@@ -297,13 +283,11 @@ int fm_06_2d_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_rapl_power_unit,
-                        msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit,
-                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }
@@ -339,7 +323,7 @@ int fm_06_2d_get_turbo_status(void)
 #endif
 
     unsigned int turbo_mode_disable_bit = 38;
-    dump_turbo_status(stdout, msrs.ia32_misc_enable, turbo_mode_disable_bit);
+    print_turbo_status(stdout, msrs.ia32_misc_enable, turbo_mode_disable_bit);
 
     return 0;
 }

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -79,13 +79,11 @@ int fm_06_55_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                     msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
-                                      msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -93,21 +91,21 @@ int fm_06_55_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            dump_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+            print_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
         }
         else if (long_ver == 1)
         {
-            print_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+            print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
         }
     }
 
     if (long_ver == 0)
     {
-        dump_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
     else if (long_ver == 1)
     {
-        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+        print_verbose_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
     }
 
     return 0;
@@ -237,13 +235,11 @@ int fm_06_55_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
-                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -256,15 +252,11 @@ int fm_06_55_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                              msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                              msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
-                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
-                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -277,15 +269,11 @@ int fm_06_55_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                         msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                         CORE);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
     }
     else if (long_ver == 1)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
-                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
-                          CORE);
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
     }
     return 0;
 }
@@ -298,13 +286,11 @@ int fm_06_55_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        dump_power_data(stdout, msrs.msr_rapl_power_unit,
-                        msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit,
-                         msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -79,11 +79,13 @@ int fm_06_55_get_power_limits(int long_ver)
     {
         if (long_ver == 0)
         {
-            print_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                      msrs.msr_rapl_power_unit, socket);
         }
         else if (long_ver == 1)
         {
-            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit, msrs.msr_rapl_power_unit, socket);
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                              msrs.msr_rapl_power_unit, socket);
         }
     }
 
@@ -235,11 +237,13 @@ int fm_06_55_get_thermals(int long_ver)
 
     if (long_ver == 0)
     {
-        print_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                 msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     else if (long_ver == 1)
     {
-        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status, msrs.ia32_package_therm_status, msrs.msr_temperature_target);
+        print_verbose_therm_temp_reading(stdout, msrs.ia32_therm_status,
+                                         msrs.ia32_package_therm_status, msrs.msr_temperature_target);
     }
     return 0;
 }
@@ -252,11 +256,15 @@ int fm_06_55_get_counters(int long_ver)
 
     if (long_ver == 0)
     {
-        print_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                               msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                               msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     else if (long_ver == 1)
     {
-        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters, msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters, msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
+        print_verbose_all_counter_data(stdout, msrs.ia32_fixed_counters,
+                                       msrs.ia32_perfevtsel_counters, msrs.ia32_perfmon_counters,
+                                       msrs.msrs_pcu_pmon_evtsel, msrs.ia32_perfevtsel_counters);
     }
     return 0;
 }
@@ -269,11 +277,15 @@ int fm_06_55_get_clocks(int long_ver)
 
     if (long_ver == 0)
     {
-        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
+        print_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                          msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                          CORE);
     }
     else if (long_ver == 1)
     {
-        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf, msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info, CORE);
+        print_verbose_clocks_data(stdout, msrs.ia32_aperf, msrs.ia32_mperf,
+                                  msrs.ia32_time_stamp_counter, msrs.ia32_perf_status, msrs.msr_platform_info,
+                                  CORE);
     }
     return 0;
 }
@@ -286,11 +298,13 @@ int fm_06_55_get_power(int long_ver)
 
     if (long_ver == 0)
     {
-        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                         msrs.msr_dram_energy_status);
     }
     else if (long_ver == 1)
     {
-        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit,
+                                 msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
     }
     return 0;
 }

--- a/src/variorum/Intel/clocks_features.c
+++ b/src/variorum/Intel/clocks_features.c
@@ -95,9 +95,7 @@ void perf_storage(struct perf_data **pd, off_t msr_perf_status)
     }
 }
 
-int dump_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
-                     off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info,
-                     enum ctl_domains_e control_domains)
+int print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info, enum ctl_domains_e control_domains)
 {
     static struct clocks_data *cd;
     static struct perf_data *pd;
@@ -180,9 +178,7 @@ int dump_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
     return 0;
 }
 
-int print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
-                      off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info,
-                      enum ctl_domains_e control_domains)
+int print_verbose_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info, enum ctl_domains_e control_domains)
 {
     static struct clocks_data *cd;
     static struct perf_data *pd;
@@ -253,7 +249,7 @@ int print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
     return 0;
 }
 
-//void print_clocks_data_socket(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info)
+//void print_verbose_clocks_data_socket(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info)
 //{
 //    static struct clocks_data *cd;
 //    static struct perf_data *pd;
@@ -284,7 +280,7 @@ int print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
 //    }
 //}
 //
-//void print_clocks_data_core(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info)
+//void print_verbose_clocks_data_core(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info)
 //{
 //    static struct clocks_data *cd;
 //    static struct perf_data *pd;
@@ -383,7 +379,7 @@ void cap_p_state(int cpu_freq_mhz, enum ctl_domains_e domain,
 //#endif
 //}
 
-//void dump_clock_mod(struct clock_mod *s, FILE *writedest)
+//void print_clock_mod(struct clock_mod *s, FILE *writedest)
 //{
 //    double percent = 0.0;
 //

--- a/src/variorum/Intel/clocks_features.c
+++ b/src/variorum/Intel/clocks_features.c
@@ -95,7 +95,9 @@ void perf_storage(struct perf_data **pd, off_t msr_perf_status)
     }
 }
 
-int print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info, enum ctl_domains_e control_domains)
+int print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
+                      off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info,
+                      enum ctl_domains_e control_domains)
 {
     static struct clocks_data *cd;
     static struct perf_data *pd;
@@ -178,7 +180,9 @@ int print_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t m
     return 0;
 }
 
-int print_verbose_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf, off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info, enum ctl_domains_e control_domains)
+int print_verbose_clocks_data(FILE *writedest, off_t msr_aperf, off_t msr_mperf,
+                              off_t msr_tsc, off_t msr_perf_status, off_t msr_platform_info,
+                              enum ctl_domains_e control_domains)
 {
     static struct clocks_data *cd;
     static struct perf_data *pd;

--- a/src/variorum/Intel/clocks_features.h
+++ b/src/variorum/Intel/clocks_features.h
@@ -85,26 +85,9 @@ void perf_storage_temp(struct perf_data **pd,
 ///// @brief Print the label for the abbreviated clocks data print out.
 /////
 ///// @param [in] writedest File stream where output will be written to.
-//void dump_clocks_data_terse_label(FILE *writedest);
+//void print_clocks_data_terse_label(FILE *writedest);
 
 /// @brief Print clocks data in CSV format.
-///
-/// @param [in] writedest File stream where output will be written to.
-/// @param [in] msr_aperf Unique MSR address for IA32_APERF.
-/// @param [in] msr_mperf Unique MSR address for IA32_MPERF.
-/// @param [in] msr_tsc Unique MSR address for IA32_TIME_STAMP_COUNTER.
-/// @param [in] msr_perf_status Unique MSR address for IA32_PERF_STATUS.
-/// @param [in] msr_platform_info Unique MSR address for MSR_PLATFORM_INFO.
-/// @param [in] control_domain Specific granularity of control.
-int dump_clocks_data(FILE *writedest,
-                     off_t msr_aperf,
-                     off_t msr_mperf,
-                     off_t msr_tsc,
-                     off_t msr_perf_status,
-                     off_t msr_platform_info,
-                     enum ctl_domains_e control_domain);
-
-/// @brief Print clocks data in long format.
 ///
 /// @param [in] writedest File stream where output will be written to.
 /// @param [in] msr_aperf Unique MSR address for IA32_APERF.
@@ -120,6 +103,23 @@ int print_clocks_data(FILE *writedest,
                       off_t msr_perf_status,
                       off_t msr_platform_info,
                       enum ctl_domains_e control_domain);
+
+/// @brief Print clocks data in long format.
+///
+/// @param [in] writedest File stream where output will be written to.
+/// @param [in] msr_aperf Unique MSR address for IA32_APERF.
+/// @param [in] msr_mperf Unique MSR address for IA32_MPERF.
+/// @param [in] msr_tsc Unique MSR address for IA32_TIME_STAMP_COUNTER.
+/// @param [in] msr_perf_status Unique MSR address for IA32_PERF_STATUS.
+/// @param [in] msr_platform_info Unique MSR address for MSR_PLATFORM_INFO.
+/// @param [in] control_domain Specific granularity of control.
+int print_verbose_clocks_data(FILE *writedest,
+                              off_t msr_aperf,
+                              off_t msr_mperf,
+                              off_t msr_tsc,
+                              off_t msr_perf_status,
+                              off_t msr_platform_info,
+                              enum ctl_domains_e control_domain);
 
 void get_available_frequencies(FILE *writedest,
                                off_t *msr_platform_info,
@@ -138,7 +138,7 @@ void get_available_frequencies_skx(FILE *writedest,
 ///// @brief Print current p-state.
 /////
 ///// @param [in] writedest File stream where output will be written to.
-//void dump_p_state(FILE *writedest);
+//void print_p_state(FILE *writedest);
 //
 ///// @brief Request new current p-state.
 /////
@@ -160,8 +160,8 @@ void cap_p_state(int cpu_freq_mhz,
 ///// @param [in] s Data for clock modulation.
 /////
 ///// @param [in] writedest File stream where output will be written to.
-//void dump_clock_mod(struct clock_mod *s,
-//                    FILE *writedest);
+//void print_clock_mod(struct clock_mod *s,
+//                     FILE *writedest);
 //
 ///// @brief Get contents of IA32_CLOCK_MODULATION.
 /////

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -68,15 +68,15 @@ int set_intel_func_ptrs(void)
     // Sandy Bridge 06_2A
     if (*g_platform.intel_arch == FM_06_2A)
     {
-        g_platform.variorum_dump_power_limits = fm_06_2a_get_power_limits;
+        g_platform.variorum_print_power_limits = fm_06_2a_get_power_limits;
         g_platform.variorum_cap_each_socket_power_limit =
             fm_06_2a_cap_power_limits;
         g_platform.variorum_print_features = fm_06_2a_get_features;
-        g_platform.variorum_dump_thermals = fm_06_2a_get_thermals;
-        g_platform.variorum_dump_counters = fm_06_2a_get_counters;
-        g_platform.variorum_dump_clocks = fm_06_2a_get_clocks;
-        g_platform.variorum_dump_power = fm_06_2a_get_power;
-        g_platform.variorum_dump_turbo = fm_06_2a_get_turbo_status;
+        g_platform.variorum_print_thermals = fm_06_2a_get_thermals;
+        g_platform.variorum_print_counters = fm_06_2a_get_counters;
+        g_platform.variorum_print_clocks = fm_06_2a_get_clocks;
+        g_platform.variorum_print_power = fm_06_2a_get_power;
+        g_platform.variorum_print_turbo = fm_06_2a_get_turbo_status;
         g_platform.variorum_enable_turbo = fm_06_2a_enable_turbo;
         g_platform.variorum_disable_turbo = fm_06_2a_disable_turbo;
         g_platform.variorum_poll_power = fm_06_2a_poll_power;
@@ -88,14 +88,14 @@ int set_intel_func_ptrs(void)
     }
     else if (*g_platform.intel_arch == FM_06_2D)
     {
-        g_platform.variorum_dump_power_limits = fm_06_2d_get_power_limits;
+        g_platform.variorum_print_power_limits = fm_06_2d_get_power_limits;
         g_platform.variorum_cap_each_socket_power_limit = fm_06_2d_cap_power_limits;
         g_platform.variorum_print_features = fm_06_2d_get_features;
-        g_platform.variorum_dump_thermals = fm_06_2d_get_thermals;
-        g_platform.variorum_dump_counters = fm_06_2d_get_counters;
-        g_platform.variorum_dump_clocks = fm_06_2d_get_clocks;
-        g_platform.variorum_dump_power = fm_06_2d_get_power;
-        g_platform.variorum_dump_turbo = fm_06_2d_get_turbo_status;
+        g_platform.variorum_print_thermals = fm_06_2d_get_thermals;
+        g_platform.variorum_print_counters = fm_06_2d_get_counters;
+        g_platform.variorum_print_clocks = fm_06_2d_get_clocks;
+        g_platform.variorum_print_power = fm_06_2d_get_power;
+        g_platform.variorum_print_turbo = fm_06_2d_get_turbo_status;
         g_platform.variorum_enable_turbo = fm_06_2d_enable_turbo;
         g_platform.variorum_disable_turbo = fm_06_2d_disable_turbo;
         g_platform.variorum_poll_power = fm_06_2d_poll_power;
@@ -108,15 +108,15 @@ int set_intel_func_ptrs(void)
     // Ivy Bridge 06_3E
     else if (*g_platform.intel_arch == FM_06_3E)
     {
-        g_platform.variorum_dump_power_limits = fm_06_3e_get_power_limits;
+        g_platform.variorum_print_power_limits = fm_06_3e_get_power_limits;
         g_platform.variorum_cap_each_socket_power_limit =
             fm_06_3e_cap_power_limits;
         g_platform.variorum_print_features = fm_06_3e_get_features;
-        g_platform.variorum_dump_thermals = fm_06_3e_get_thermals;
-        g_platform.variorum_dump_counters = fm_06_3e_get_counters;
-        g_platform.variorum_dump_clocks = fm_06_3e_get_clocks;
-        g_platform.variorum_dump_power = fm_06_3e_get_power;
-        g_platform.variorum_dump_turbo = fm_06_3e_get_turbo_status;
+        g_platform.variorum_print_thermals = fm_06_3e_get_thermals;
+        g_platform.variorum_print_counters = fm_06_3e_get_counters;
+        g_platform.variorum_print_clocks = fm_06_3e_get_clocks;
+        g_platform.variorum_print_power = fm_06_3e_get_power;
+        g_platform.variorum_print_turbo = fm_06_3e_get_turbo_status;
         g_platform.variorum_enable_turbo = fm_06_3e_enable_turbo;
         g_platform.variorum_disable_turbo = fm_06_3e_disable_turbo;
         g_platform.variorum_poll_power = fm_06_3e_poll_power;
@@ -129,15 +129,15 @@ int set_intel_func_ptrs(void)
     // Haswell 06_3F
     else if (*g_platform.intel_arch == FM_06_3F)
     {
-        g_platform.variorum_dump_power_limits = fm_06_3f_get_power_limits;
+        g_platform.variorum_print_power_limits = fm_06_3f_get_power_limits;
         g_platform.variorum_cap_each_socket_power_limit =
             fm_06_3f_cap_power_limits;
         g_platform.variorum_print_features = fm_06_3f_get_features;
-        g_platform.variorum_dump_thermals = fm_06_3f_get_thermals;
-        g_platform.variorum_dump_counters = fm_06_3f_get_counters;
-        g_platform.variorum_dump_clocks = fm_06_3f_get_clocks;
-        g_platform.variorum_dump_power = fm_06_3f_get_power;
-        g_platform.variorum_dump_turbo = fm_06_3f_get_turbo_status;
+        g_platform.variorum_print_thermals = fm_06_3f_get_thermals;
+        g_platform.variorum_print_counters = fm_06_3f_get_counters;
+        g_platform.variorum_print_clocks = fm_06_3f_get_clocks;
+        g_platform.variorum_print_power = fm_06_3f_get_power;
+        g_platform.variorum_print_turbo = fm_06_3f_get_turbo_status;
         g_platform.variorum_enable_turbo = fm_06_3f_enable_turbo;
         g_platform.variorum_disable_turbo = fm_06_3f_disable_turbo;
         g_platform.variorum_poll_power = fm_06_3f_poll_power;
@@ -150,15 +150,15 @@ int set_intel_func_ptrs(void)
     // Broadwell 06_4F
     else if (*g_platform.intel_arch == FM_06_4F)
     {
-        g_platform.variorum_dump_power_limits = fm_06_4f_get_power_limits;
+        g_platform.variorum_print_power_limits = fm_06_4f_get_power_limits;
         g_platform.variorum_cap_each_socket_power_limit =
             fm_06_4f_cap_power_limits;
         g_platform.variorum_print_features = fm_06_4f_get_features;
-        g_platform.variorum_dump_thermals = fm_06_4f_get_thermals;
-        g_platform.variorum_dump_counters = fm_06_4f_get_counters;
-        g_platform.variorum_dump_clocks = fm_06_4f_get_clocks;
-        g_platform.variorum_dump_power = fm_06_4f_get_power;
-        g_platform.variorum_dump_turbo = fm_06_4f_get_turbo_status;
+        g_platform.variorum_print_thermals = fm_06_4f_get_thermals;
+        g_platform.variorum_print_counters = fm_06_4f_get_counters;
+        g_platform.variorum_print_clocks = fm_06_4f_get_clocks;
+        g_platform.variorum_print_power = fm_06_4f_get_power;
+        g_platform.variorum_print_turbo = fm_06_4f_get_turbo_status;
         g_platform.variorum_enable_turbo = fm_06_4f_enable_turbo;
         g_platform.variorum_disable_turbo = fm_06_4f_disable_turbo;
         g_platform.variorum_poll_power = fm_06_4f_poll_power;
@@ -175,15 +175,15 @@ int set_intel_func_ptrs(void)
     // Skylake 06_55
     else if (*g_platform.intel_arch == FM_06_55)
     {
-        g_platform.variorum_dump_power_limits = fm_06_55_get_power_limits;
+        g_platform.variorum_print_power_limits = fm_06_55_get_power_limits;
         g_platform.variorum_cap_each_socket_power_limit =
             fm_06_55_cap_power_limits;
         g_platform.variorum_print_features = fm_06_55_get_features;
-        g_platform.variorum_dump_thermals = fm_06_55_get_thermals;
-        g_platform.variorum_dump_counters = fm_06_55_get_counters;
-        g_platform.variorum_dump_clocks = fm_06_55_get_clocks;
-        g_platform.variorum_dump_power = fm_06_55_get_power;
-        //g_platform.variorum_dump_turbo = fm_06_55_get_turbo_status;
+        g_platform.variorum_print_thermals = fm_06_55_get_thermals;
+        g_platform.variorum_print_counters = fm_06_55_get_counters;
+        g_platform.variorum_print_clocks = fm_06_55_get_clocks;
+        g_platform.variorum_print_power = fm_06_55_get_power;
+        //g_platform.variorum_print_turbo = fm_06_55_get_turbo_status;
         //g_platform.variorum_enable_turbo = fm_06_55_enable_turbo;
         //g_platform.variorum_disable_turbo = fm_06_55_disable_turbo;
         g_platform.variorum_poll_power = fm_06_55_poll_power;
@@ -195,15 +195,15 @@ int set_intel_func_ptrs(void)
     // Kaby Lake 06_9E
     else if (*g_platform.intel_arch == FM_06_9E)
     {
-        g_platform.variorum_dump_power_limits = fm_06_9e_get_power_limits;
+        g_platform.variorum_print_power_limits = fm_06_9e_get_power_limits;
         g_platform.variorum_cap_each_socket_power_limit =
             fm_06_9e_cap_power_limits;
         g_platform.variorum_print_features = fm_06_9e_get_features;
-        g_platform.variorum_dump_thermals = fm_06_9e_get_thermals;
-        g_platform.variorum_dump_counters = fm_06_9e_get_counters;
-        g_platform.variorum_dump_clocks = fm_06_9e_get_clocks;
-        g_platform.variorum_dump_power = fm_06_9e_get_power;
-        //g_platform.variorum_dump_turbo = fm_06_9e_get_turbo_status;
+        g_platform.variorum_print_thermals = fm_06_9e_get_thermals;
+        g_platform.variorum_print_counters = fm_06_9e_get_counters;
+        g_platform.variorum_print_clocks = fm_06_9e_get_clocks;
+        g_platform.variorum_print_power = fm_06_9e_get_power;
+        //g_platform.variorum_print_turbo = fm_06_9e_get_turbo_status;
         //g_platform.variorum_enable_turbo = fm_06_9e_enable_turbo;
         //g_platform.variorum_disable_turbo = fm_06_9e_disable_turbo;
         g_platform.variorum_poll_power = fm_06_9e_poll_power;

--- a/src/variorum/Intel/counters_features.c
+++ b/src/variorum/Intel/counters_features.c
@@ -213,18 +213,24 @@ void fixed_counter_ctrl_storage(uint64_t ***perf_ctrl, uint64_t ***fixed_ctrl,
     }
 }
 
-void print_all_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs, off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs, off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
+void print_all_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
+                            off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs,
+                            off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
 {
     print_fixed_counter_data(writedest, msrs_fixed_ctrs);
     print_perfmon_counter_data(writedest, msrs_perfevtsel_ctrs, msrs_perfmon_ctrs);
     print_unc_counter_data(writedest, msrs_pcu_pmon_evtsel, msrs_pcu_pmon_ctrs);
 }
 
-void print_verbose_all_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs, off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs, off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
+void print_verbose_all_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
+                                    off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs,
+                                    off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
 {
     print_verbose_fixed_counter_data(writedest, msrs_fixed_ctrs);
-    print_verbose_perfmon_counter_data(writedest, msrs_perfevtsel_ctrs, msrs_perfmon_ctrs);
-    print_verbose_unc_counter_data(writedest, msrs_pcu_pmon_evtsel, msrs_pcu_pmon_ctrs);
+    print_verbose_perfmon_counter_data(writedest, msrs_perfevtsel_ctrs,
+                                       msrs_perfmon_ctrs);
+    print_verbose_unc_counter_data(writedest, msrs_pcu_pmon_evtsel,
+                                   msrs_pcu_pmon_ctrs);
 }
 
 void print_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
@@ -253,7 +259,8 @@ void print_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
     }
 }
 
-void print_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs)
+void print_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
+                                off_t *msrs_perfmon_ctrs)
 {
     static struct pmc *p = NULL;
     static int init = 0;
@@ -382,7 +389,8 @@ void print_verbose_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
     }
 }
 
-void print_verbose_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs)
+void print_verbose_perfmon_counter_data(FILE *writedest,
+                                        off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs)
 {
     static struct pmc *p = NULL;
     static int init = 0;
@@ -1040,7 +1048,8 @@ void clear_all_pcu(off_t *msrs_pcu_pmon_ctrs)
     write_batch(UNCORE_COUNT);
 }
 
-void print_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
+void print_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel,
+                            off_t *msrs_pcu_pmon_ctrs)
 {
     static int init = 0;
     struct unc_counters *uc;
@@ -1066,7 +1075,8 @@ void print_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel, off_t 
     }
 }
 
-void print_verbose_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
+void print_verbose_unc_counter_data(FILE *writedest,
+                                    off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
 {
     struct unc_counters *uc;
     unsigned i;

--- a/src/variorum/Intel/counters_features.c
+++ b/src/variorum/Intel/counters_features.c
@@ -213,25 +213,21 @@ void fixed_counter_ctrl_storage(uint64_t ***perf_ctrl, uint64_t ***fixed_ctrl,
     }
 }
 
-void dump_all_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
-                           off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs,
-                           off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
-{
-    dump_fixed_counter_data(writedest, msrs_fixed_ctrs);
-    dump_perfmon_counter_data(writedest, msrs_perfevtsel_ctrs, msrs_perfmon_ctrs);
-    dump_unc_counter_data(writedest, msrs_pcu_pmon_evtsel, msrs_pcu_pmon_ctrs);
-}
-
-void print_all_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs,
-                            off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs,
-                            off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
+void print_all_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs, off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs, off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
 {
     print_fixed_counter_data(writedest, msrs_fixed_ctrs);
     print_perfmon_counter_data(writedest, msrs_perfevtsel_ctrs, msrs_perfmon_ctrs);
     print_unc_counter_data(writedest, msrs_pcu_pmon_evtsel, msrs_pcu_pmon_ctrs);
 }
 
-void dump_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
+void print_verbose_all_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs, off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs, off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
+{
+    print_verbose_fixed_counter_data(writedest, msrs_fixed_ctrs);
+    print_verbose_perfmon_counter_data(writedest, msrs_perfevtsel_ctrs, msrs_perfmon_ctrs);
+    print_verbose_unc_counter_data(writedest, msrs_pcu_pmon_evtsel, msrs_pcu_pmon_ctrs);
+}
+
+void print_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
 {
     static int init = 0;
     struct fixed_counter *c0, *c1, *c2;
@@ -257,8 +253,7 @@ void dump_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
     }
 }
 
-void dump_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
-                               off_t *msrs_perfmon_ctrs)
+void print_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs)
 {
     static struct pmc *p = NULL;
     static int init = 0;
@@ -362,7 +357,7 @@ void dump_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
     }
 }
 
-void print_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
+void print_verbose_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
 {
     static int init = 0;
     struct fixed_counter *c0, *c1, *c2;
@@ -387,8 +382,7 @@ void print_fixed_counter_data(FILE *writedest, off_t *msrs_fixed_ctrs)
     }
 }
 
-void print_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs,
-                                off_t *msrs_perfmon_ctrs)
+void print_verbose_perfmon_counter_data(FILE *writedest, off_t *msrs_perfevtsel_ctrs, off_t *msrs_perfmon_ctrs)
 {
     static struct pmc *p = NULL;
     static int init = 0;
@@ -1046,8 +1040,7 @@ void clear_all_pcu(off_t *msrs_pcu_pmon_ctrs)
     write_batch(UNCORE_COUNT);
 }
 
-void dump_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel,
-                           off_t *msrs_pcu_pmon_ctrs)
+void print_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
 {
     static int init = 0;
     struct unc_counters *uc;
@@ -1073,8 +1066,7 @@ void dump_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel,
     }
 }
 
-void print_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel,
-                            off_t *msrs_pcu_pmon_ctrs)
+void print_verbose_unc_counter_data(FILE *writedest, off_t *msrs_pcu_pmon_evtsel, off_t *msrs_pcu_pmon_ctrs)
 {
     struct unc_counters *uc;
     unsigned i;

--- a/src/variorum/Intel/counters_features.h
+++ b/src/variorum/Intel/counters_features.h
@@ -126,26 +126,19 @@ void disable_fixed_counters(off_t *msrs_fixed_ctrs,
                             off_t msr1,
                             off_t msr2);
 
-void dump_fixed_counter_data(FILE *writedest,
-                             off_t *msrs_fixed_ctrs);
-
 void print_fixed_counter_data(FILE *writedest,
                               off_t *msrs_fixed_ctrs);
 
-void dump_perfmon_counter_data(FILE *writedest,
-                               off_t *msrs_perfevtsel_ctrs,
-                               off_t *msrs_perfmon_ctrs);
+void print_verbose_fixed_counter_data(FILE *writedest,
+                                      off_t *msrs_fixed_ctrs);
 
 void print_perfmon_counter_data(FILE *writedest,
                                 off_t *msrs_perfevtsel_ctrs,
                                 off_t *msrs_perfmon_ctrs);
 
-void dump_all_counter_data(FILE *writedest,
-                           off_t *msrs_fixed_ctrs,
-                           off_t *msrs_perfevtsel_ctrs,
-                           off_t *msrs_perfmon_ctrs,
-                           off_t *msrs_pcu_pmon_evtsel,
-                           off_t *msrs_pcu_pmon_ctrs);
+void print_verbose_perfmon_counter_data(FILE *writedest,
+                                        off_t *msrs_perfevtsel_ctrs,
+                                        off_t *msrs_perfmon_ctrs);
 
 void print_all_counter_data(FILE *writedest,
                             off_t *msrs_fixed_ctrs,
@@ -153,6 +146,13 @@ void print_all_counter_data(FILE *writedest,
                             off_t *msrs_perfmon_ctrs,
                             off_t *msrs_pcu_pmon_evtsel,
                             off_t *msrs_pcu_pmon_ctrs);
+
+void print_verbose_all_counter_data(FILE *writedest,
+                                    off_t *msrs_fixed_ctrs,
+                                    off_t *msrs_perfevtsel_ctrs,
+                                    off_t *msrs_perfmon_ctrs,
+                                    off_t *msrs_pcu_pmon_evtsel,
+                                    off_t *msrs_pcu_pmon_ctrs);
 
 /*************************************/
 /* Programmable Performance Counters */
@@ -347,13 +347,13 @@ void clear_all_pcu(off_t *msrs_pcu_pmon_ctrs);
 ///        PCU_PMON_EVTSEL.
 /// @param [in] msrs_pcu_pmon_ctrs Array of unique addresses for
 ///        PCU_PMON_CTRS.
-void dump_unc_counter_data(FILE *writedest,
-                           off_t *msrs_pcu_pmon_evtsel,
-                           off_t *msrs_pcu_pmon_ctrs);
-
 void print_unc_counter_data(FILE *writedest,
                             off_t *msrs_pcu_pmon_evtsel,
                             off_t *msrs_pcu_pmon_ctrs);
+
+void print_verbose_unc_counter_data(FILE *writedest,
+                                    off_t *msrs_pcu_pmon_evtsel,
+                                    off_t *msrs_pcu_pmon_ctrs);
 
 void get_all_power_data_fixed(FILE *writedest,
                               off_t msr_pkg_power_limit,

--- a/src/variorum/Intel/misc_features.c
+++ b/src/variorum/Intel/misc_features.c
@@ -505,8 +505,7 @@ int set_turbo_off(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
     return ret;
 }
 
-int dump_turbo_status(FILE *writedest, off_t msr_misc_enable,
-                      unsigned int turbo_mode_disable_bit)
+int print_turbo_status(FILE *writedest, off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
 {
     int ret = 0;
     unsigned socket;

--- a/src/variorum/Intel/misc_features.c
+++ b/src/variorum/Intel/misc_features.c
@@ -505,7 +505,8 @@ int set_turbo_off(off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
     return ret;
 }
 
-int print_turbo_status(FILE *writedest, off_t msr_misc_enable, unsigned int turbo_mode_disable_bit)
+int print_turbo_status(FILE *writedest, off_t msr_misc_enable,
+                       unsigned int turbo_mode_disable_bit)
 {
     int ret = 0;
     unsigned socket;

--- a/src/variorum/Intel/misc_features.h
+++ b/src/variorum/Intel/misc_features.h
@@ -71,9 +71,9 @@ int set_turbo_off(off_t msr_misc_enable,
 ///             register for disabling turbo mode.
 ///
 /// @return 0 if successful, else non-zero.
-int dump_turbo_status(FILE *writedest,
-                      off_t msr_misc_enable,
-                      unsigned int turbo_mode_disable_bit);
+int print_turbo_status(FILE *writedest,
+                       off_t msr_misc_enable,
+                       unsigned int turbo_mode_disable_bit);
 
 
 ///// These per core functions seemingly only for Intel Signatures 06_57H (KNL) and

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -394,7 +394,7 @@ int get_rapl_power_unit(struct rapl_units *ru, off_t msr)
     return 0;
 }
 
-void dump_rapl_power_unit(FILE *writedest, off_t msr)
+void print_rapl_power_unit(FILE *writedest, off_t msr)
 {
     unsigned socket;
     struct rapl_units *ru;
@@ -418,7 +418,7 @@ void dump_rapl_power_unit(FILE *writedest, off_t msr)
     free(ru);
 }
 
-void print_rapl_power_unit(FILE *writedest, off_t msr)
+void print_verbose_rapl_power_unit(FILE *writedest, off_t msr)
 {
     unsigned socket;
     struct rapl_units *ru;
@@ -441,17 +441,17 @@ void print_rapl_power_unit(FILE *writedest, off_t msr)
     free(ru);
 }
 
-void dump_package_power_info(FILE *writedest, off_t msr, int socket)
+void print_package_power_info(FILE *writedest, off_t msr, int socket)
 {
     struct rapl_power_info info;
     char hostname[1024];
-    static int init_dump_package_power_info = 0;
+    static int init_print_package_power_info = 0;
 
     gethostname(hostname, 1024);
 
-    if (!init_dump_package_power_info)
+    if (!init_print_package_power_info)
     {
-        init_dump_package_power_info = 1;
+        init_print_package_power_info = 1;
         fprintf(writedest,
                 "_PACKAGE_POWER_INFO Offset Host Socket Bits MaxPower MinPower MaxTimeWindow ThermPower\n");
     }
@@ -464,7 +464,7 @@ void dump_package_power_info(FILE *writedest, off_t msr, int socket)
     }
 }
 
-void print_package_power_info(FILE *writedest, off_t msr, int socket)
+void print_verbose_package_power_info(FILE *writedest, off_t msr, int socket)
 {
     struct rapl_power_info info;
     char hostname[1024];
@@ -480,20 +480,20 @@ void print_package_power_info(FILE *writedest, off_t msr, int socket)
     }
 }
 
-void dump_package_power_limit(FILE *writedest, off_t msr_power_limit,
+void print_package_power_limit(FILE *writedest, off_t msr_power_limit,
                               off_t msr_rapl_unit, int socket)
 {
     struct rapl_limit l1, l2;
-    static int init_dump_package_power_limit = 0;
+    static int init_print_package_power_limit = 0;
     char hostname[1024];
     unsigned nsockets;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
-    if (!init_dump_package_power_limit)
+    if (!init_print_package_power_limit)
     {
-        init_dump_package_power_limit = 1;
+        init_print_package_power_limit = 1;
         fprintf(writedest,
                 "_PACKAGE_POWER_LIMITS Offset Host Socket PowerLimBits Watts1 Seconds1 Watts2 Seconds2\n");
     }
@@ -506,20 +506,19 @@ void dump_package_power_limit(FILE *writedest, off_t msr_power_limit,
     }
 }
 
-void dump_dram_power_limit(FILE *writedest, off_t msr_power_limit,
-                           off_t msr_rapl_unit, int socket)
+void print_dram_power_limit(FILE *writedest, off_t msr_power_limit, off_t msr_rapl_unit, int socket)
 {
     struct rapl_limit l1;
-    static int init_dump_dram_power_limit = 0;
+    static int init_print_dram_power_limit = 0;
     char hostname[1024];
     unsigned nsockets;
 
     variorum_get_topology(&nsockets, NULL, NULL);
     gethostname(hostname, 1024);
 
-    if (!init_dump_dram_power_limit)
+    if (!init_print_dram_power_limit)
     {
-        init_dump_dram_power_limit = 1;
+        init_print_dram_power_limit = 1;
         fprintf(writedest,
                 "_DRAM_POWER_LIMIT Offset Host Socket PowerLimBits Watts Seconds\n");
     }
@@ -531,8 +530,7 @@ void dump_dram_power_limit(FILE *writedest, off_t msr_power_limit,
     }
 }
 
-void print_package_power_limit(FILE *writedest, off_t msr_power_limit,
-                               off_t msr_rapl_unit, int socket)
+void print_verbose_package_power_limit(FILE *writedest, off_t msr_power_limit, off_t msr_rapl_unit, int socket)
 {
     struct rapl_limit l1, l2;
     char hostname[1024];
@@ -548,8 +546,7 @@ void print_package_power_limit(FILE *writedest, off_t msr_power_limit,
     }
 }
 
-void print_dram_power_limit(FILE *writedest, off_t msr_power_limit,
-                            off_t msr_rapl_unit, int socket)
+void print_verbose_dram_power_limit(FILE *writedest, off_t msr_power_limit, off_t msr_rapl_unit, int socket)
 {
     struct rapl_limit l1;
     char hostname[1024];
@@ -838,8 +835,7 @@ int delta_rapl_data(off_t msr_rapl_unit)
     return 0;
 }
 
-void print_power_data(FILE *writedest, off_t msr_rapl_unit,
-                      off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
+void print_verbose_power_data(FILE *writedest, off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     static int init = 0;
     static struct rapl_data *rapl = NULL;
@@ -880,8 +876,7 @@ void print_power_data(FILE *writedest, off_t msr_rapl_unit,
     }
 }
 
-void dump_power_data(FILE *writedest, off_t msr_rapl_unit,
-                     off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
+void print_power_data(FILE *writedest, off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     static int init = 0;
     static struct rapl_data *rapl = NULL;
@@ -927,9 +922,7 @@ void dump_power_data(FILE *writedest, off_t msr_rapl_unit,
     }
 }
 
-void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit,
-                          off_t msr_rapl_unit, off_t msr_pkg_energy_status,
-                          off_t msr_dram_energy_status)
+void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit, off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     static int init = 0;
     static struct rapl_data *rapl = NULL;
@@ -1003,7 +996,7 @@ void json_dump_power_data(json_t *get_power_obj, off_t msr_power_limit,
 }
 
 
-//int dump_rapl_data(FILE *writedest)
+//int print_rapl_data(FILE *writedest)
 //{
 //    static int init = 0;
 //    static uint64_t *rapl_flags = NULL;

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -481,7 +481,7 @@ void print_verbose_package_power_info(FILE *writedest, off_t msr, int socket)
 }
 
 void print_package_power_limit(FILE *writedest, off_t msr_power_limit,
-                              off_t msr_rapl_unit, int socket)
+                               off_t msr_rapl_unit, int socket)
 {
     struct rapl_limit l1, l2;
     static int init_print_package_power_limit = 0;
@@ -506,7 +506,8 @@ void print_package_power_limit(FILE *writedest, off_t msr_power_limit,
     }
 }
 
-void print_dram_power_limit(FILE *writedest, off_t msr_power_limit, off_t msr_rapl_unit, int socket)
+void print_dram_power_limit(FILE *writedest, off_t msr_power_limit,
+                            off_t msr_rapl_unit, int socket)
 {
     struct rapl_limit l1;
     static int init_print_dram_power_limit = 0;
@@ -530,7 +531,8 @@ void print_dram_power_limit(FILE *writedest, off_t msr_power_limit, off_t msr_ra
     }
 }
 
-void print_verbose_package_power_limit(FILE *writedest, off_t msr_power_limit, off_t msr_rapl_unit, int socket)
+void print_verbose_package_power_limit(FILE *writedest, off_t msr_power_limit,
+                                       off_t msr_rapl_unit, int socket)
 {
     struct rapl_limit l1, l2;
     char hostname[1024];
@@ -546,7 +548,8 @@ void print_verbose_package_power_limit(FILE *writedest, off_t msr_power_limit, o
     }
 }
 
-void print_verbose_dram_power_limit(FILE *writedest, off_t msr_power_limit, off_t msr_rapl_unit, int socket)
+void print_verbose_dram_power_limit(FILE *writedest, off_t msr_power_limit,
+                                    off_t msr_rapl_unit, int socket)
 {
     struct rapl_limit l1;
     char hostname[1024];
@@ -835,7 +838,8 @@ int delta_rapl_data(off_t msr_rapl_unit)
     return 0;
 }
 
-void print_verbose_power_data(FILE *writedest, off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
+void print_verbose_power_data(FILE *writedest, off_t msr_rapl_unit,
+                              off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     static int init = 0;
     static struct rapl_data *rapl = NULL;
@@ -876,7 +880,8 @@ void print_verbose_power_data(FILE *writedest, off_t msr_rapl_unit, off_t msr_pk
     }
 }
 
-void print_power_data(FILE *writedest, off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
+void print_power_data(FILE *writedest, off_t msr_rapl_unit,
+                      off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     static int init = 0;
     static struct rapl_data *rapl = NULL;
@@ -922,7 +927,8 @@ void print_power_data(FILE *writedest, off_t msr_rapl_unit, off_t msr_pkg_energy
     }
 }
 
-void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit, off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
+void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit,
+                         off_t msr_rapl_unit, off_t msr_pkg_energy_status, off_t msr_dram_energy_status)
 {
     static int init = 0;
     static struct rapl_data *rapl = NULL;

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -154,20 +154,20 @@ int get_package_power_limits(struct rapl_units *ru,
 int get_rapl_power_unit(struct rapl_units *ru,
                         off_t msr);
 
-void dump_package_power_limit(FILE *writedest,
-                              off_t msr_power_limit,
-                              off_t msr_rapl_unit,
-                              int socket);
-
-void dump_dram_power_limit(FILE *writedest,
-                           off_t msr_power_limit,
-                           off_t msr_rapl_unit,
-                           int socket);
+void print_package_power_limit(FILE *writedest,
+                               off_t msr_power_limit,
+                               off_t msr_rapl_unit,
+                               int socket);
 
 void print_dram_power_limit(FILE *writedest,
                             off_t msr_power_limit,
                             off_t msr_rapl_unit,
                             int socket);
+
+void print_verbose_dram_power_limit(FILE *writedest,
+                                    off_t msr_power_limit,
+                                    off_t msr_rapl_unit,
+                                    int socket);
 
 int get_package_rapl_limit(const unsigned socket,
                            struct rapl_limit *limit1,
@@ -180,50 +180,49 @@ int get_dram_rapl_limit(const unsigned socket,
                         off_t msr_power_limit,
                         off_t msr_rapl_unit);
 
-void dump_rapl_power_unit(FILE *writedest,
-                          off_t msr);
+void print_rapl_power_unit(FILE *writedest,
+                           off_t msr);
 
 int get_rapl_power_info(const unsigned socket,
                         struct rapl_power_info *info,
                         off_t msr);
 
-void dump_package_power_info(FILE *writedest,
-                             off_t msr,
-                             int socket);
-
-void print_rapl_power_unit(FILE *writedest,
-                           off_t msr);
-
-void print_package_power_limit(FILE *writedest,
-                               off_t msr_power_limit,
-                               off_t msr_rapl_unit,
-                               int socket);
-
 void print_package_power_info(FILE *writedest,
                               off_t msr,
                               int socket);
+
+void print_verbose_rapl_power_unit(FILE *writedest,
+                                   off_t msr);
+
+void print_verbose_package_power_limit(FILE *writedest,
+                                       off_t msr_power_limit,
+                                       off_t msr_rapl_unit,
+                                       int socket);
+
+void print_verbose_package_power_info(FILE *writedest,
+                                      off_t msr,
+                                      int socket);
 
 int cap_package_power_limit(const unsigned socket,
                             int package_power_limit,
                             off_t msr_power_limit,
                             off_t msr_rapl_unit);
 
-void dump_power_data(FILE *writedest,
-                     off_t msr_rapl_unit,
-                     off_t msr_pkg_energy_status,
-                     off_t msr_dram_energy_status);
-
 void print_power_data(FILE *writedest,
                       off_t msr_rapl_unit,
                       off_t msr_pkg_energy_status,
                       off_t msr_dram_energy_status);
 
+void print_verbose_power_data(FILE *writedest,
+                              off_t msr_rapl_unit,
+                              off_t msr_pkg_energy_status,
+                              off_t msr_dram_energy_status);
 
-void json_dump_power_data(json_t *get_power_obj,
-                          off_t msr_power_limit,
-                          off_t msr_rapl_unit,
-                          off_t msr_pkg_energy_status,
-                          off_t msr_dram_energy_status);
+void json_get_power_data(json_t *get_power_obj,
+                         off_t msr_power_limit,
+                         off_t msr_rapl_unit,
+                         off_t msr_pkg_energy_status,
+                         off_t msr_dram_energy_status);
 
 /// @brief Store the RAPL data on the heap.
 ///

--- a/src/variorum/Intel/thermal_features.c
+++ b/src/variorum/Intel/thermal_features.c
@@ -235,7 +235,8 @@ int get_pkg_therm_stat(struct pkg_therm_stat *s, off_t msr)
     return 0;
 }
 
-int print_verbose_therm_temp_reading(FILE *writedest, off_t msr_therm_stat, off_t msr_pkg_therm_stat, off_t msr_temp_target)
+int print_verbose_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
+                                     off_t msr_pkg_therm_stat, off_t msr_temp_target)
 {
     struct pkg_therm_stat *pkg_stat = NULL;
     struct msr_temp_target *t_target = NULL;
@@ -294,7 +295,8 @@ int print_verbose_therm_temp_reading(FILE *writedest, off_t msr_therm_stat, off_
     return 0;
 }
 
-int print_therm_temp_reading(FILE *writedest, off_t msr_therm_stat, off_t msr_pkg_therm_stat, off_t msr_temp_target)
+int print_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
+                             off_t msr_pkg_therm_stat, off_t msr_temp_target)
 {
     struct pkg_therm_stat *pkg_stat = NULL;
     struct msr_temp_target *t_target = NULL;

--- a/src/variorum/Intel/thermal_features.c
+++ b/src/variorum/Intel/thermal_features.c
@@ -235,8 +235,7 @@ int get_pkg_therm_stat(struct pkg_therm_stat *s, off_t msr)
     return 0;
 }
 
-int print_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
-                             off_t msr_pkg_therm_stat, off_t msr_temp_target)
+int print_verbose_therm_temp_reading(FILE *writedest, off_t msr_therm_stat, off_t msr_pkg_therm_stat, off_t msr_temp_target)
 {
     struct pkg_therm_stat *pkg_stat = NULL;
     struct msr_temp_target *t_target = NULL;
@@ -295,8 +294,7 @@ int print_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
     return 0;
 }
 
-int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
-                            off_t msr_pkg_therm_stat, off_t msr_temp_target)
+int print_therm_temp_reading(FILE *writedest, off_t msr_therm_stat, off_t msr_pkg_therm_stat, off_t msr_temp_target)
 {
     struct pkg_therm_stat *pkg_stat = NULL;
     struct msr_temp_target *t_target = NULL;
@@ -579,7 +577,7 @@ int dump_therm_temp_reading(FILE *writedest, off_t msr_therm_stat,
 //    return 0;
 //}
 //
-//int dump_therm2_ctl(FILE *writedest)
+//int print_therm2_ctl(FILE *writedest)
 //{
 //    int ret = 0;
 //    int i;

--- a/src/variorum/Intel/thermal_features.h
+++ b/src/variorum/Intel/thermal_features.h
@@ -266,10 +266,10 @@ struct pkg_therm_stat
 /// @param [in] msr_therm_stat Unique MSR address for IA32_THERM_STATUS.
 /// @param [in] msr_pkg_therm_stat Unique MSR address for IA32_PACKAGE_THERM_STATUS.
 /// @param [in] msr_temp_target Unique MSR address for TEMPERATURE_TARGET.
-int dump_therm_temp_reading(FILE *writedest,
-                            off_t msr_therm_stat,
-                            off_t msr_pkg_therm_stat,
-                            off_t msr_temp_target);
+int print_therm_temp_reading(FILE *writedest,
+                             off_t msr_therm_stat,
+                             off_t msr_pkg_therm_stat,
+                             off_t msr_temp_target);
 
 /// @brief Print only temperature data in long format.
 ///
@@ -277,10 +277,10 @@ int dump_therm_temp_reading(FILE *writedest,
 /// @param [in] msr_therm_stat Unique MSR address for IA32_THERM_STATUS.
 /// @param [in] msr_pkg_therm_stat Unique MSR address for IA32_PACKAGE_THERM_STATUS.
 /// @param [in] msr_temp_target Unique MSR address for TEMPERATURE_TARGET.
-int print_therm_temp_reading(FILE *writedest,
-                             off_t msr_therm_stat,
-                             off_t msr_pkg_therm_stat,
-                             off_t msr_temp_target);
+int print_verbose_therm_temp_reading(FILE *writedest,
+                                     off_t msr_therm_stat,
+                                     off_t msr_pkg_therm_stat,
+                                     off_t msr_temp_target);
 
 /// @brief Read value of the IA32_PACKAGE_THERM_STATUS register and translate
 /// bit fields to human-readable values.
@@ -332,7 +332,7 @@ void get_therm_stat(struct therm_stat *s,
 /////
 ///// @return 0 if successful, else return a value less than 0 if
 ///// therm2_ctl_storage() fails.
-//int dump_therm2_ctl(FILE *writedest);
+//int print_therm2_ctl(FILE *writedest);
 //
 ///// @brief Set value for IA32_THERM_STATUS across all cores.
 /////
@@ -347,7 +347,7 @@ void get_therm_stat(struct therm_stat *s,
 ///// @brief Print detailed thermal status and interrupt data.
 /////
 ///// @param [in] writedest File stream where output will be written to.
-//void dump_therm_data_verbose(FILE *writedest);
+//void print_therm_data_verbose(FILE *writedest);
 //
 ///// @brief Store the per-core thermal interrupt data on the heap.
 /////
@@ -385,17 +385,17 @@ void get_therm_stat(struct therm_stat *s,
 ///// data printout.
 /////
 ///// @param [in] writedest File stream where output will be written to.
-//void dump_therm_data_terse_label(FILE *writedest);
+//void print_therm_data_terse_label(FILE *writedest);
 //
 ///// @brief Print abbreviated thermal status and interrupt data.
 /////
 ///// @param [in] writedest File stream where output will be written to.
-//void dump_therm_data_terse(FILE *writedest);
+//void print_therm_data_terse(FILE *writedest);
 //
 ///// @brief Print the label for the detailed thermal status and interrupt data
 ///// printout.
 /////
 ///// @param [in] writedest File stream where output will be written to.
-//void dump_therm_data_verbose_label(FILE *writedest);
+//void print_therm_data_verbose_label(FILE *writedest);
 
 #endif

--- a/src/variorum/Nvidia/Volta.c
+++ b/src/variorum/Nvidia/Volta.c
@@ -21,7 +21,7 @@ int volta_get_power(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
-        dump_power_data(iter, long_ver, stdout);
+        get_power_data(iter, long_ver, stdout);
     }
     return 0;
 }
@@ -37,7 +37,7 @@ int volta_get_thermals(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
-        dump_thermal_data(iter, long_ver, stdout);
+        get_thermal_data(iter, long_ver, stdout);
     }
     return 0;
 }
@@ -52,7 +52,7 @@ int volta_get_clocks(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
-        dump_clocks_data(iter, long_ver, stdout);
+        get_clocks_data(iter, long_ver, stdout);
     }
     return 0;
 }
@@ -67,7 +67,7 @@ int volta_get_power_limits(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
-        dump_power_limits(iter, long_ver, stdout);
+        get_power_limits(iter, long_ver, stdout);
     }
     return 0;
 }
@@ -82,7 +82,7 @@ int volta_get_gpu_utilization(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
-        dump_gpu_utilization(iter, long_ver, stdout);
+        get_gpu_utilization(iter, long_ver, stdout);
     }
     return 0;
 }

--- a/src/variorum/Nvidia/config_nvidia.c
+++ b/src/variorum/Nvidia/config_nvidia.c
@@ -27,11 +27,11 @@ int set_nvidia_func_ptrs(void)
     if (*g_platform.nvidia_arch == VOLTA)
     {
         /* Initialize monitoring interfaces */
-        g_platform.variorum_dump_power           = volta_get_power;
-        g_platform.variorum_dump_thermals        = volta_get_thermals;
-        g_platform.variorum_dump_clocks          = volta_get_clocks;
-        g_platform.variorum_dump_power_limits    = volta_get_power_limits;
-        g_platform.variorum_dump_gpu_utilization = volta_get_gpu_utilization;
+        g_platform.variorum_print_power           = volta_get_power;
+        g_platform.variorum_print_thermals        = volta_get_thermals;
+        g_platform.variorum_print_clocks          = volta_get_clocks;
+        g_platform.variorum_print_power_limits    = volta_get_power_limits;
+        g_platform.variorum_print_gpu_utilization = volta_get_gpu_utilization;
     }
     else
     {

--- a/src/variorum/Nvidia/power_features.c
+++ b/src/variorum/Nvidia/power_features.c
@@ -48,7 +48,7 @@ void shutdownNVML(void)
     nvmlShutdown();
 }
 
-void dump_power_data(int chipid, int verbose, FILE *output)
+void get_power_data(int chipid, int verbose, FILE *output)
 {
     unsigned int power;
     double value = 0.0;
@@ -81,7 +81,7 @@ void dump_power_data(int chipid, int verbose, FILE *output)
     }
 }
 
-void dump_thermal_data(int chipid, int verbose, FILE *output)
+void get_thermal_data(int chipid, int verbose, FILE *output)
 {
     unsigned gpu_temp;
     int d;
@@ -115,7 +115,7 @@ void dump_thermal_data(int chipid, int verbose, FILE *output)
     /*!@todo: Print GPU memory temperature */
 }
 
-void dump_power_limits(int chipid, int verbose, FILE *output)
+void get_power_limits(int chipid, int verbose, FILE *output)
 {
     unsigned int power_limit;
     double value = 0.0;
@@ -149,7 +149,7 @@ void dump_power_limits(int chipid, int verbose, FILE *output)
     /*!@todo: Seperate interface for default power limits? */
 }
 
-void dump_clocks_data(int chipid, int verbose, FILE *output)
+void get_clocks_data(int chipid, int verbose, FILE *output)
 {
     unsigned int gpu_clock;
     int d;
@@ -181,7 +181,7 @@ void dump_clocks_data(int chipid, int verbose, FILE *output)
     }
 }
 
-void dump_gpu_utilization(int chipid, int verbose, FILE *output)
+void get_gpu_utilization(int chipid, int verbose, FILE *output)
 {
     nvmlUtilization_t util;
     int d;

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -279,22 +279,22 @@ void variorum_get_topology(unsigned *nsockets, unsigned *ncores,
 
 void variorum_init_func_ptrs()
 {
-    g_platform.variorum_dump_power_limits = NULL;
+    g_platform.variorum_print_power_limits = NULL;
     g_platform.variorum_cap_socket_frequency = NULL;
     g_platform.variorum_cap_best_effort_node_power_limit = NULL;
     g_platform.variorum_cap_and_verify_node_power_limit = NULL;
     g_platform.variorum_cap_gpu_power_ratio = NULL;
     g_platform.variorum_cap_each_socket_power_limit = NULL;
     g_platform.variorum_print_features = NULL;
-    g_platform.variorum_dump_thermals = NULL;
-    g_platform.variorum_dump_counters = NULL;
-    g_platform.variorum_dump_clocks = NULL;
-    g_platform.variorum_dump_power = NULL;
+    g_platform.variorum_print_thermals = NULL;
+    g_platform.variorum_print_counters = NULL;
+    g_platform.variorum_print_clocks = NULL;
+    g_platform.variorum_print_power = NULL;
     g_platform.variorum_enable_turbo = NULL;
     g_platform.variorum_disable_turbo = NULL;
-    g_platform.variorum_dump_turbo = NULL;
+    g_platform.variorum_print_turbo = NULL;
     g_platform.variorum_poll_power = NULL;
-    g_platform.variorum_dump_gpu_utilization = NULL;
+    g_platform.variorum_print_gpu_utilization = NULL;
     g_platform.variorum_cap_each_core_frequency = NULL;
     g_platform.variorum_monitoring = NULL;
     g_platform.variorum_get_node_power_json = NULL;

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -98,7 +98,7 @@ struct platform
     ///        output.
     ///
     /// @return Error code.
-    int (*variorum_dump_power_limits)(int long_ver);
+    int (*variorum_print_power_limits)(int long_ver);
 
     /// @brief Function pointer to set a power limit on the node.
     ///
@@ -154,7 +154,7 @@ struct platform
     ///        output.
     ///
     /// @return Error code.
-    int (*variorum_dump_thermals)(int long_ver);
+    int (*variorum_print_thermals)(int long_ver);
 
     /// @brief Function pointer to print out counter data.
     ///
@@ -162,7 +162,7 @@ struct platform
     ///        output.
     ///
     /// @return Error code.
-    int (*variorum_dump_counters)(int long_ver);
+    int (*variorum_print_counters)(int long_ver);
 
     /// @brief Function pointer to print out clocks data.
     ///
@@ -170,7 +170,7 @@ struct platform
     ///        output.
     ///
     /// @return Error code.
-    int (*variorum_dump_clocks)(int long_ver);
+    int (*variorum_print_clocks)(int long_ver);
 
     /// @brief Function pointer to print out power consumption data.
     ///
@@ -178,7 +178,7 @@ struct platform
     ///        output.
     ///
     /// @return Error code.
-    int (*variorum_dump_power)(int long_ver);
+    int (*variorum_print_power)(int long_ver);
 
     /// @brief Function pointer to enable turbo.
     ///
@@ -193,12 +193,12 @@ struct platform
     /// @brief Function pointer to get print turbo data.
     ///
     /// @return Error code.
-    int (*variorum_dump_turbo)(void);
+    int (*variorum_print_turbo)(void);
 
     /// @brief Function pointer to print GPU utilization.
     ///
     /// @return Error code.
-    int (*variorum_dump_gpu_utilization)(int long_ver);
+    int (*variorum_print_gpu_utilization)(int long_ver);
 
     /// @brief Function pointer to get JSON object for node power data.
     ///

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -148,7 +148,7 @@ int variorum_print_power_limits(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_power_limits == NULL)
+    if (g_platform.variorum_print_power_limits == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -156,7 +156,7 @@ int variorum_print_power_limits(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_power_limits(0);
+    err = g_platform.variorum_print_power_limits(0);
     if (err)
     {
         return -1;
@@ -185,7 +185,7 @@ int variorum_print_verbose_power_limits(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_power_limits == NULL)
+    if (g_platform.variorum_print_power_limits == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -193,7 +193,7 @@ int variorum_print_verbose_power_limits(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_power_limits(1);
+    err = g_platform.variorum_print_power_limits(1);
     if (err)
     {
         return -1;
@@ -523,7 +523,7 @@ int variorum_print_thermals(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_thermals == NULL)
+    if (g_platform.variorum_print_thermals == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -531,7 +531,7 @@ int variorum_print_thermals(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_thermals(0);
+    err = g_platform.variorum_print_thermals(0);
     if (err)
     {
         return -1;
@@ -560,7 +560,7 @@ int variorum_print_verbose_thermals(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_thermals == NULL)
+    if (g_platform.variorum_print_thermals == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -568,7 +568,7 @@ int variorum_print_verbose_thermals(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_thermals(1);
+    err = g_platform.variorum_print_thermals(1);
     if (err)
     {
         return -1;
@@ -597,7 +597,7 @@ int variorum_print_counters(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_counters == NULL)
+    if (g_platform.variorum_print_counters == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -605,7 +605,7 @@ int variorum_print_counters(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_counters(0);
+    err = g_platform.variorum_print_counters(0);
     if (err)
     {
         return -1;
@@ -634,7 +634,7 @@ int variorum_print_verbose_counters(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_counters == NULL)
+    if (g_platform.variorum_print_counters == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -642,7 +642,7 @@ int variorum_print_verbose_counters(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_counters(1);
+    err = g_platform.variorum_print_counters(1);
     if (err)
     {
         return -1;
@@ -671,7 +671,7 @@ int variorum_print_clock_speed(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_clocks == NULL)
+    if (g_platform.variorum_print_clocks == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -679,7 +679,7 @@ int variorum_print_clock_speed(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_clocks(0);
+    err = g_platform.variorum_print_clocks(0);
     if (err)
     {
         return -1;
@@ -708,7 +708,7 @@ int variorum_print_verbose_clock_speed(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_clocks == NULL)
+    if (g_platform.variorum_print_clocks == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -716,7 +716,7 @@ int variorum_print_verbose_clock_speed(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_clocks(1);
+    err = g_platform.variorum_print_clocks(1);
     if (err)
     {
         return -1;
@@ -745,7 +745,7 @@ int variorum_print_power(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_power == NULL)
+    if (g_platform.variorum_print_power == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -753,7 +753,7 @@ int variorum_print_power(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_power(0);
+    err = g_platform.variorum_print_power(0);
     if (err)
     {
         return -1;
@@ -782,7 +782,7 @@ int variorum_print_verbose_power(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_power == NULL)
+    if (g_platform.variorum_print_power == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -790,7 +790,7 @@ int variorum_print_verbose_power(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_power(1);
+    err = g_platform.variorum_print_power(1);
     if (err)
     {
         return -1;
@@ -854,7 +854,7 @@ int variorum_print_turbo(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_turbo == NULL)
+    if (g_platform.variorum_print_turbo == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -862,7 +862,7 @@ int variorum_print_turbo(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_turbo();
+    err = g_platform.variorum_print_turbo();
     if (err)
     {
         return -1;
@@ -892,7 +892,7 @@ int variorum_print_gpu_utilization(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_gpu_utilization == NULL)
+    if (g_platform.variorum_print_gpu_utilization == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -900,7 +900,7 @@ int variorum_print_gpu_utilization(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_gpu_utilization(0);
+    err = g_platform.variorum_print_gpu_utilization(0);
     if (err)
     {
         return -1;
@@ -929,7 +929,7 @@ int variorum_print_verbose_gpu_utilization(void)
     {
         return -1;
     }
-    if (g_platform.variorum_dump_gpu_utilization == NULL)
+    if (g_platform.variorum_print_gpu_utilization == NULL)
     {
         variorum_error_handler("Feature not yet implemented or is not supported",
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -937,7 +937,7 @@ int variorum_print_verbose_gpu_utilization(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_dump_gpu_utilization(1);
+    err = g_platform.variorum_print_gpu_utilization(1);
     if (err)
     {
         return -1;


### PR DESCRIPTION
This finishes the renaming across the code for the individual ports. So far only the top-level functions had been renamed.