### PR TITLE
    variorum: Add AMD platform support

### DIFF
--- a/host-configs/epyc-x86_64-gcc@8.4.0.cmake
+++ b/host-configs/epyc-x86_64-gcc@8.4.0.cmake
@@ -1,0 +1,22 @@
+# Copyright 2020-2021 Lawrence Livermore National Security, LLC and other
+# Variorum Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+# c compiler
+set(CMAKE_C_COMPILER "gcc" CACHE PATH "")
+
+# cpp compiler
+set(CMAKE_CXX_COMPILER "g++" CACHE PATH "")
+
+set(BUILD_DOCS ON CACHE BOOL "")
+set(BUILD_TESTS ON CACHE BOOL "")
+
+set(VARIORUM_WITH_AMD ON CACHE BOOL "")
+set(VARIORUM_WITH_GPU OFF CACHE BOOL "")
+set(VARIORUM_WITH_IBM OFF CACHE BOOL "")
+set(VARIORUM_WITH_INTEL OFF CACHE BOOL "")
+set(VARIORUM_WITH_ARM OFF CACHE BOOL "")
+
+# path to e_smi_library install
+set(ESMI_DIR "/opt/esmi/e_smi/" CACHE PATH "")

--- a/src/CMake/Setup3rdParty.cmake
+++ b/src/CMake/Setup3rdParty.cmake
@@ -5,6 +5,9 @@
 
 include(CMake/thirdparty/SetupHwloc.cmake)
 include(CMake/thirdparty/SetupJansson.cmake)
+if(VARIORUM_WITH_AMD)
+include(CMake/thirdparty/Setupesmi.cmake)
+endif()
 
 if(BUILD_DOCS)
     find_package(Doxygen)

--- a/src/CMake/thirdparty/Setupesmi.cmake
+++ b/src/CMake/thirdparty/Setupesmi.cmake
@@ -1,0 +1,49 @@
+# First check for user-specified ESMI_DIR
+if(ESMI_DIR)
+    MESSAGE(STATUS "Looking for ESMI using ESMI_DIR = ${ESMI_DIR}")
+
+    set(ESMI_FOUND TRUE)
+    set(ESMI_INCLUDE_DIRS ${ESMI_DIR}/include)
+    set(ESMI_LIBRARY ${ESMI_DIR}/lib/libe_smi64.so)
+
+    set(ESMI_DIR ${ESMI_DIR} CACHE PATH "" FORCE)
+
+    message(STATUS "FOUND ESMI at ${ESMI_DIR}")
+    message(STATUS " [*] ESMI_INCLUDE_DIRS = ${ESMI_INCLUDE_DIRS}")
+    message(STATUS " [*] ESMI_LIBRARY = ${ESMI_LIBRARY}")
+# If ESMI_DIR not specified, then try to automatically find the HWLOC header
+# and library
+elseif(NOT ESMI_DIR)
+    find_path(ESMI_INCLUDE_DIRS
+        NAMES e_smi.h
+    )
+
+    find_library(ESMI_LIBRARY
+        NAMES libe_smi64.so
+    )
+
+    if(ESMI_INCLUDE_DIRS AND ESMI_LIBRARY)
+        set(ESMI_FOUND TRUE)
+        message(STATUS "FOUND esmi using find_library()")
+        message(STATUS " [*] ESMI_INCLUDE_DIRS = ${ESMI_INCLUDE_DIRS}")
+        message(STATUS " [*] ESMI_LIBRARY = ${ESMI_LIBRARY}")
+    endif()
+endif()
+
+# If HWLOC is still not found, then download and build HWLOC from source
+#if(NOT ESMI_INCLUDE_DIRS AND ESMI_LIBRARY)
+#    MESSAGE(STATUS "Downloading and building hwloc from source")
+#
+#    ### Necessary for ExternalProject_Add
+#    include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
+#    include(../SetupExternalProjects.cmake)
+#    message(STATUS "Adding external project: hwloc")
+#    message(STATUS " [*] ESMI_INCLUDE_DIRS = ${ESMI_INCLUDE_DIRS}")
+#    message(STATUS " [*] ESMI_LIBRARY = ${ESMI_LIBRARY}")
+#    set(ESMI_FOUND TRUE)
+#endif()
+
+# Abort if all methods fail
+if(NOT ESMI_FOUND)
+    MESSAGE(FATAL_ERROR "Esmi support needed")
+endif()

--- a/src/docs/sphinx/AMD.rst
+++ b/src/docs/sphinx/AMD.rst
@@ -8,13 +8,12 @@
 ##############
 
 This implementation of the AMD port of Variorum supports the AMD processors
-for family support refer to dependent drivers.
-We have tested the AMD functionality
-of Variorum on SLES15 and Ubuntu 18.04.
+for family support refer to dependencie section. We have tested the AMD
+functionality of Variorum on SLES15 and Ubuntu 18.04.
 
-*****************
- Dependendencies
-*****************
+**************
+ Dependencies
+**************
 
 The following software stack is supported on family 19h model 0~Fh and 30h ~ 3Fh
 processors from AMD, as of April 2021.
@@ -27,15 +26,20 @@ This version of the AMD port of Variorum depends on the AMD open-sourced
 2. HSMP driver for power metrics
    https://github.com/amd/amd_hsmp
 
-*****************************************
+2. amd_energy driver for core and socket energy counters
+   https://github.com/amd/amd_energy
+
+******************************************
  Monitoring and Control Through E-SMI API
-*****************************************
+******************************************
 
 The built-in monitoring interface on the AMD EPYC™ processors is implemented by
 the SMU FW. The following subsections provide the specific metrics:
 
-Power telemetry
-===============
+All registers are updated every 1 milli second.
+
+ Power telemetry
+=================
 
 The following E-SMI APIs are used in this version of AMD port
 
@@ -51,7 +55,25 @@ esmi_socket_power_cap_max_get()
 To improve readability of the verbose output Variorum converts power into
 watts before logging.
 
-All registers are updated every 1 milli second.
+ Boostlimit telemetry
+======================
+
+Boostlimit is a maximum frequency a CPU can run at
+
+esmi_core_boostlimit_get() and esmi_core_boostlimit_set()
+- Get and set the current boostlimit for a given core
+
+esmi_socket_boostlimit_set()
+- Set boostlimit for all the cores in the socket
+
+ Energy telemetry
+==================
+
+esmi_socket_energy_get()
+- Get software accumulated 64-bit energy counter for a given socket
+
+esmi_core_energy_get()
+- Get software accumulated 64-bit energy counter for a given core
 
 ************
  References

--- a/src/docs/sphinx/AMD.rst
+++ b/src/docs/sphinx/AMD.rst
@@ -1,0 +1,61 @@
+.. # Copyright 2021 Lawrence Livermore National Security, LLC and other
+   # Variorum Project Developers. See the top-level LICENSE file for details.
+   #
+   # SPDX-License-Identifier: MIT
+
+##############
+ AMD Overview
+##############
+
+This implementation of the AMD port of Variorum supports the AMD processors
+for family support refer to dependent drivers.
+We have tested the AMD functionality
+of Variorum on SLES15 and Ubuntu 18.04.
+
+*****************
+ Dependendencies
+*****************
+
+The following software stack is supported on family 19h model 0~Fh and 30h ~ 3Fh
+processors from AMD, as of April 2021.
+
+This version of the AMD port of Variorum depends on the AMD open-sourced
+
+1. EPYC™ System Management Interface In-band Library (E-SMI library) available at
+   https://github.com/amd/esmi_ib_library
+
+2. HSMP driver for power metrics
+   https://github.com/amd/amd_hsmp
+
+*****************************************
+ Monitoring and Control Through E-SMI API
+*****************************************
+
+The built-in monitoring interface on the AMD EPYC™ processors is implemented by
+the SMU FW. The following subsections provide the specific metrics:
+
+Power telemetry
+===============
+
+The following E-SMI APIs are used in this version of AMD port
+
+esmi_socket_power_get()
+- Instantaneous power is reported in milliwatts
+
+esmi_socket_power_cap_get() and esmi_socket_power_cap_set()
+- Get and Set power limit of the socket in milliwatts
+
+esmi_socket_power_cap_max_get()
+- Maximum Power limit of the socket in milliwatts
+
+To improve readability of the verbose output Variorum converts power into
+watts before logging.
+
+All registers are updated every 1 milli second.
+
+************
+ References
+************
+
+-  `AMD EPYC™ processors Fam19h technical reference
+   <https://www.amd.com/system/files/TechDocs/55898_pub.zip>`_

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -37,6 +37,10 @@ set(BASIC_EXAMPLES
     variorum-print-verbose-power-limits-example
     variorum-print-verbose-power-example
     variorum-print-verbose-thermals-example
+    variorum-print-energy-example
+    variorum-print-boostlimit-example
+    variorum-set-and-verify-core-boostlimit-example
+    variorum-set-socket-boostlimit-example
 )
 
 message(STATUS "Adding variorum examples")

--- a/src/examples/variorum-print-boostlimit-example.c
+++ b/src/examples/variorum-print-boostlimit-example.c
@@ -1,0 +1,20 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+
+#include <variorum.h>
+
+int main(int argc, char **argv)
+{
+    int ret;
+
+    ret = variorum_print_boostlimit();
+    if (ret != 0)
+    {
+        printf("Print core boostlimit failed!\n");
+    }
+    return ret;
+}

--- a/src/examples/variorum-print-energy-example.c
+++ b/src/examples/variorum-print-energy-example.c
@@ -1,0 +1,20 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+
+#include <variorum.h>
+
+int main(int argc, char **argv)
+{
+    int ret;
+
+    ret = variorum_print_energy();
+    if (ret != 0)
+    {
+        printf("Print core and Socket energy failed!\n");
+    }
+    return ret;
+}

--- a/src/examples/variorum-set-and-verify-core-boostlimit-example.c
+++ b/src/examples/variorum-set-and-verify-core-boostlimit-example.c
@@ -1,0 +1,51 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <variorum.h>
+
+int main(int argc, char **argv)
+{
+    int ret;
+    int core;
+    unsigned int boostlimit = 0;
+
+    printf("Usage:%s <core> <boostlimit>\n", argv[0]);
+
+    if (argc == 1)
+    {
+        printf("CPU number not specified...using default cpu 0\n");
+        core = 0;
+        printf("No boostlimit specified...using default limit of 400MHz.\n");
+        boostlimit = 400;
+    }
+    else if (argc == 2)
+    {
+        core = atoi(argv[1]);
+        printf("Specified core num : %d.\n", core);
+        printf("No boostlimit specified...using default limit of 400MHz.\n");
+        boostlimit = 400;
+    }
+    else if (argc > 2)
+    {
+        core = atoi(argv[1]);
+        boostlimit = atoi(argv[2]);
+        printf("Setting boostlimit for core[%d] to %u(MHz).\n", core, boostlimit);
+    }
+
+    ret = variorum_set_and_verify_core_boostlimit(core, boostlimit);
+    if (ret != 0)
+    {
+        printf("Set and verfiy core boostlimit failed!\n");
+        return ret;
+    }
+    printf("Set and Verify Core boostlimit to %uMHz: Success\n", boostlimit);
+
+    return 0;
+}

--- a/src/examples/variorum-set-socket-boostlimit-example.c
+++ b/src/examples/variorum-set-socket-boostlimit-example.c
@@ -1,0 +1,51 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <variorum.h>
+
+int main(int argc, char **argv)
+{
+    int ret;
+    int socket;
+    unsigned int boostlimit = 0;
+
+    printf("\nUsage: %s <socket> <boostlimit>\n", argv[0]);
+
+    if (argc == 1)
+    {
+        printf("socket number not specified...using default socket 0\n");
+        socket = 0;
+        printf("No boostlimit specified...using default limit of 400MHz.\n");
+        boostlimit = 400;
+    }
+    else if (argc == 2)
+    {
+        socket = atoi(argv[1]);
+        printf("Specified socket num : %d\n", socket);
+        printf("No boostlimit specified...using default limit of 400MHz.\n");
+        boostlimit = 400;
+    }
+    else if (argc > 2)
+    {
+        socket = atoi(argv[1]);
+        boostlimit = atoi(argv[2]);
+        printf("Setting boostlimit for socket[%d] to %uMHz\n",
+                                    socket, boostlimit);
+    }
+
+    ret = variorum_set_socket_boostlimit(socket, boostlimit);
+    if (ret != 0)
+    {
+        printf("Set boostlimit failed!\n");
+        return ret;
+    }
+
+    return 0;
+}

--- a/src/variorum/AMD/CMakeLists.txt
+++ b/src/variorum/AMD/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Variorum Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+set(variorum_amd_headers
+  ${CMAKE_CURRENT_SOURCE_DIR}/epyc.h
+  CACHE INTERNAL "")
+
+set(variorum_amd_sources
+  ${CMAKE_CURRENT_SOURCE_DIR}/epyc.c
+  CACHE INTERNAL "")
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${variorum_includes})
+
+add_library(variorum_amd OBJECT
+            ${variorum_amd_sources}
+            ${variorum_amd_headers})
+
+### Shared libraries need PIC
+set_property(TARGET ${variorum_amd} PROPERTY POSITION_INDEPENDENT_CODE 1)

--- a/src/variorum/AMD/CMakeLists.txt
+++ b/src/variorum/AMD/CMakeLists.txt
@@ -5,10 +5,14 @@
 
 set(variorum_amd_headers
   ${CMAKE_CURRENT_SOURCE_DIR}/epyc.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/msr_core.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/energy_feature.h
   CACHE INTERNAL "")
 
 set(variorum_amd_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/epyc.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/msr_core.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/energy_feature.c
   CACHE INTERNAL "")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${variorum_includes})

--- a/src/variorum/AMD/config_amd.c
+++ b/src/variorum/AMD/config_amd.c
@@ -70,5 +70,10 @@ int set_amd_func_ptrs(void)
     g_platform.variorum_print_power_limits = epyc_get_power_limits;
     g_platform.variorum_cap_each_socket_power_limit = epyc_set_socket_power_limit;
     g_platform.variorum_cap_and_verify_node_power_limit = epyc_set_and_verify_node_power_limit;
+    g_platform.variorum_print_energy = epyc_print_energy;
+    g_platform.variorum_print_boostlimit = epyc_print_boostlimit;
+    g_platform.variorum_set_and_verify_core_boostlimit = epyc_set_and_verify_core_boostlimit;
+    g_platform.variorum_set_socket_boostlimit = epyc_set_socket_boostlimit;
+
     return err;
 }

--- a/src/variorum/AMD/config_amd.c
+++ b/src/variorum/AMD/config_amd.c
@@ -1,0 +1,74 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <config_amd.h>
+#include <config_architecture.h>
+#include <epyc.h>
+#include <variorum_error.h>
+
+uint64_t *detect_amd_arch(void)
+{
+    uint64_t rax = 1;
+    uint64_t rbx = 0;
+    uint64_t rcx = 0;
+    uint64_t rdx = 0;
+    uint64_t *fh_model = (uint64_t *) malloc(sizeof(uint64_t));
+
+    asm volatile(
+        "cpuid"
+        : "=a"(rax), "=b"(rbx), "=c"(rcx), "=d"(rdx)
+        : "0"(rax), "2"(rcx));
+
+    /*
+     * Functionality will depand on both Family and Model
+     * Hence return value for this function contains both Family and Model
+     * Family is the [16:8] bit and Model is [7:0] bit in return value
+     */
+    *fh_model = (((((rax >> 8) & 0xf) + ((rax >> 20) & 0xff)) << 8) |
+                (((rax >> 16) & 0xf) * 0x10 + ((rax >> 4) & 0xf))) & 0xFFFF;
+    return fh_model;
+}
+
+int set_amd_func_ptrs(void)
+{
+    int err = 0;
+    uint8_t family, model;
+    family = (*g_platform.amd_arch >> 8) & 0xFF;
+    model = *g_platform.amd_arch & 0xFF;
+
+    /* Verify for the family and model */
+    if (family == 0x19)
+    {
+        switch(model)
+        {
+        case 0x0 ... 0xF:
+        case 0x30 ... 0x3F:
+            break;
+        default:
+            return VARIORUM_ERROR_UNSUPPORTED_PLATFORM;
+        }
+    }
+    else
+        return VARIORUM_ERROR_UNSUPPORTED_PLATFORM;
+
+    /* smi monitor initialization */
+    err = esmi_init();
+    if (err != 0)
+    {
+        fprintf(stdout, "ESMI not initialized, drivers not found. "
+                "Err[%d]: %s\n", err, esmi_get_err_msg(err));
+        return err;
+    }
+
+    g_platform.variorum_print_power = epyc_get_power;
+    g_platform.variorum_print_power_limits = epyc_get_power_limits;
+    g_platform.variorum_cap_each_socket_power_limit = epyc_set_socket_power_limit;
+    g_platform.variorum_cap_and_verify_node_power_limit = epyc_set_and_verify_node_power_limit;
+    return err;
+}

--- a/src/variorum/AMD/config_amd.h
+++ b/src/variorum/AMD/config_amd.h
@@ -1,0 +1,16 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef CONFIG_AMD_H_INCLUDE
+#define CONFIG_AMD_H_INCLUDE
+
+#include <inttypes.h>
+#include <e_smi/e_smi.h>
+
+uint64_t *detect_amd_arch(void);
+
+int set_amd_func_ptrs(void);
+
+#endif

--- a/src/variorum/AMD/energy_feature.c
+++ b/src/variorum/AMD/energy_feature.c
@@ -1,0 +1,135 @@
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <config_architecture.h>
+#include <variorum_error.h>
+
+#include "msr_core.h"
+#include "energy_feature.h"
+
+static void create_rapl_data_batch(struct rapl_data *rapl,
+                                   off_t msr_core_energy_status)
+{
+    int ncores;
+    variorum_get_topology(NULL, &ncores, NULL);
+
+    allocate_batch(RAPL_DATA, 2UL * ncores);
+
+    rapl->core_bits = (uint64_t **) calloc(ncores, sizeof(uint64_t *));
+    rapl->core_joules = (double *) calloc(ncores, sizeof(double));
+    load_thread_batch(msr_core_energy_status, rapl->core_bits, RAPL_DATA);
+}
+
+static int rapl_storage(struct rapl_data **data)
+{
+    static struct rapl_data *rapl = NULL;
+    static int ncores = 0;
+    static int init = 0;
+
+    if (!init)
+    {
+        init = 1;
+        variorum_get_topology(NULL, &ncores, NULL);
+
+        rapl = (struct rapl_data *) malloc(ncores * sizeof(struct rapl_data));
+
+        if (data != NULL)
+        {
+            *data = rapl;
+        }
+#ifdef VARIORUM_DEBUG
+        fprintf(stderr, "%s %s::%d DEBUG: (storage) initialized rapl data at %p\n",
+                getenv("HOSTNAME"), __FILE__, __LINE__, rapl);
+        fprintf(stderr, "DEBUG: socket 0 has pkg_bits at %p\n",
+                &rapl[0].core_bits);
+#endif
+        return 0;
+    }
+    if (data != NULL)
+    {
+        *data = rapl;
+    }
+    return 0;
+}
+
+static int read_rapl_data(off_t msr_rapl_unit, off_t msr_core_energy_status)
+{
+    static struct rapl_data *rapl = NULL;
+    static int init = 0;
+    static int ncores = 0;
+    int i;
+
+    if (!init)
+    {
+        variorum_get_topology(NULL, &ncores, NULL);
+        if (rapl_storage(&rapl))
+        {
+            return -1;
+        }
+        create_rapl_data_batch(rapl, msr_core_energy_status);
+        for (i = 0; i < ncores; i++)
+        {
+            rapl->core_joules[i] = 0;
+        }
+    }
+    read_batch(RAPL_DATA);
+    init = 1;
+    return 0;
+}
+
+static int get_rapl_unit(off_t msr_rapl_unit, double *energy_val)
+{
+    static struct rapl_units *ru = NULL;
+    static uint64_t **val = NULL;
+
+    ru = (struct rapl_units *) malloc(1 * sizeof(struct rapl_units));
+    val = (uint64_t **) malloc(1 * sizeof(uint64_t *));
+    allocate_batch(RAPL_UNIT, 1);
+    load_socket_batch(msr_rapl_unit, val, RAPL_UNIT);
+    read_batch(RAPL_UNIT);
+    ru[1].msr_rapl_power_unit = *val[1];
+    ru[1].joules = (double)(1 << (MASK_VAL(ru[1].msr_rapl_power_unit, 12, 8)));
+    *energy_val = (1/ru[1].joules);
+
+    free(ru);
+    ru = NULL;
+    free(val);
+    val = NULL;
+    return 0;
+}
+
+int print_energy_data(FILE *writedest, off_t msr_rapl_unit,
+                     off_t msr_core_energy_status)
+{
+    static struct rapl_data *rapl = NULL;
+    static int init = 0;
+    int ncores = 0;
+    char hostname[1024];
+    int i, batchfd;
+    double val;
+
+    if ((batchfd = open(MSR_BATCH_DIR, O_RDWR)) < 0)
+    {
+        perror(MSR_BATCH_DIR);
+        return batchfd;
+    }
+
+    variorum_get_topology(NULL, &ncores, NULL);
+
+    read_rapl_data(msr_rapl_unit, msr_core_energy_status);
+
+    if (!init)
+    {
+        rapl_storage(&rapl);
+        init = 1;
+    }
+
+    get_rapl_unit(msr_rapl_unit, &val);
+
+    fprintf(stdout, " Core   | Energy (J)   |\n");
+    for (i = 0; i < ncores; i++) {
+        fprintf(stdout, "%6d  | %10f  |\n", i, (*rapl->core_bits[i]) * val);
+    }
+    return 0;
+}

--- a/src/variorum/AMD/energy_feature.h
+++ b/src/variorum/AMD/energy_feature.h
@@ -1,0 +1,28 @@
+#include <linux/types.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+struct rapl_units
+{
+    /// @brief Raw 64-bit value stored in MSR_RAPL_POWER_UNIT.
+    uint64_t msr_rapl_power_unit;
+    /// @brief Energy status units (ESU) based on the multiplier 1/(2^ESU) (in
+    /// Joules). ESU is encoded in bits 12:8 of MSR_RAPL_POWER_UNIT.
+    double joules;
+};
+
+struct EPYC_19h_offsets
+{
+    const off_t msr_rapl_power_unit;
+    const off_t msr_core_energy_stat;
+    const off_t msr_pkg_energy_stat;
+};
+
+struct rapl_data
+{
+    uint64_t **core_bits;
+    double *core_joules;
+};
+
+int print_energy_data(FILE *writedest, off_t msr_rapl_unit,
+                     off_t msr_core_energy_status);

--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -1,0 +1,206 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <config_architecture.h>
+#include <epyc.h>
+#include <variorum_error.h>
+#include <e_smi/e_smi.h>
+
+int epyc_get_power(int long_ver)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    int i, ret;
+    uint32_t current_power;
+
+    fprintf(stdout, "Socket | Power(Watts)    |\n");
+    for (i = 0; i < g_platform.num_sockets; i++)
+    {
+        current_power = 0;
+        ret = esmi_socket_power_get(i, &current_power);
+        if (ret != 0)
+        {
+            fprintf(stdout, "Failed to get socket[%d] _POWER, "
+                    "Err[%d]:%s\n", i, ret, esmi_get_err_msg(ret));
+            return ret;
+        }
+        else
+        {
+            fprintf(stdout, "%6d | %12.03f    |\n",
+                    i, (double)current_power/1000);
+        }
+    }
+    return 0;
+}
+
+int epyc_get_power_limits(int long_ver)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    int i, ret;
+    uint32_t power, pcap_current, pcap_max;
+
+    fprintf(stdout, "Socket | Power(Watts)    | PowerCap(Watts) | MaxPowerCap(Watts) |\n");
+    for (i = 0; i < g_platform.num_sockets; i++)
+    {
+        power = 0;
+        pcap_current = 0;
+        pcap_max = 0;
+        ret = esmi_socket_power_get(i, &power);
+        if (ret != 0)
+        {
+            fprintf(stdout, "Failed to get socket[%d] _POWER, Err[%d]:%s\n",
+                    i, ret, esmi_get_err_msg(ret));
+            return ret;
+        }
+        ret = esmi_socket_power_cap_get(i, &pcap_current);
+        if (ret != 0)
+        {
+            fprintf(stdout, "Failed to get socket[%d] _POWERCAP, Err[%d]:%s\n",
+                    i, ret, esmi_get_err_msg(ret));
+            return ret;
+        }
+        ret = esmi_socket_power_cap_max_get(i, &pcap_max);
+        if (ret != 0)
+        {
+            fprintf(stdout, "Failed to get socket[%d] _POWERCAPMAX, Err[%d]:%s\n",
+                    i, ret, esmi_get_err_msg(ret));
+            return ret;
+        }
+        fprintf(stdout, "%6d | %14.03f  | %14.03f  | %14.03f     |\n",
+                i, (double)power/1000, (double)pcap_current/1000,
+                (double)pcap_max/1000);
+    }
+
+    return 0;
+}
+
+int epyc_set_and_verify_node_power_limit(int pcap_new)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s with value %d\n", __FUNCTION__, pcap_new);
+#endif
+
+    int i, ret;
+    uint32_t pcap_test;
+    uint32_t max_power = 0;
+
+    /*
+     * Convert the pcap value to mWatt as library takes
+     * value in mWatt.
+     */
+    pcap_new = pcap_new * 1000;
+
+    for (i = 0; i < g_platform.num_sockets; i++)
+    {
+        pcap_test = 0;
+        ret = esmi_socket_power_cap_max_get(i, &max_power);
+        if ((ret == 0) && (pcap_new > max_power))
+        {
+            printf("Input power is more than max limit,"
+                   " So sets to default max %.3f Watts\n\n",
+                   (double)max_power/1000);
+            pcap_new = max_power;
+        }
+        ret = esmi_socket_power_cap_set(i, (uint32_t)pcap_new);
+        if (ret != 0)
+        {
+            fprintf(stdout, "Failed to set socket[%d] _POWERCAP, Err[%d]:%s\n",
+                    i, ret, esmi_get_err_msg(ret));
+            if (ret == ESMI_PERMISSION)
+            {
+                variorum_error_handler("Incorrect permissions",
+                                       VARIORUM_ERROR_INVAL, getenv("HOSTNAME"),
+                                       __FILE__, __FUNCTION__, __LINE__);
+                return -1;
+            }
+            return ret;
+        }
+        usleep(100000);
+
+        ret = esmi_socket_power_cap_get(i, &pcap_test);
+        if (ret != 0)
+        {
+            fprintf(stdout, "Failed to get socket[%d] _POWERCAP, Err[%d]:%s\n",
+                    i, ret, esmi_get_err_msg(ret));
+            return ret;
+        }
+
+#ifdef VARIORUM_DEBUG
+    fprintf(stdout, "Values are input:%2.03f, test=%2.03f\n",
+            (double)pcap_new/1000, (double)pcap_test/1000);
+#endif
+
+        if (pcap_new != pcap_test)
+        {
+            fprintf(stdout, "Could not verify if the power cap "
+                    "was set correctly.\n");
+            fprintf(stdout, "Verification check after 100ms failed.\n");
+            fprintf(stdout, "Please verify again with dump_power_limits.\n");
+            return -1;
+        }
+    }
+
+    fprintf(stdout, "Changed node power cap to %2.03f W.\n",
+            (double)pcap_new/1000);
+    return 0;
+}
+
+int epyc_set_socket_power_limit(int pcap_new)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    int i, ret;
+    uint32_t max_power = 0;
+
+    /*
+     * Convert the pcap value to mWatt as library takes
+     * value in mWatt.
+     */
+    pcap_new = pcap_new * 1000;
+
+    fprintf(stdout, "Socket |  Powercap(Watts)  |\n");
+    for (i = 0; i < g_platform.num_sockets; i++)
+    {
+        ret = esmi_socket_power_cap_max_get(i, &max_power);
+        if ((ret == 0) && (pcap_new > max_power))
+        {
+            printf("Input power is more than max limit,"
+                   " So sets to default max %.3f Watts\n\n",
+                   (double)max_power/1000);
+            pcap_new = max_power;
+        }
+        ret = esmi_socket_power_cap_set(i, (uint32_t)pcap_new);
+        if(ret != 0)
+        {
+            fprintf(stdout, "Failed to set socket[%d] _POWERCAP, Err[%d]:%s\n",
+                    i, ret, esmi_get_err_msg(ret));
+            if (ret == ESMI_PERMISSION)
+            {
+                variorum_error_handler("Incorrect permissions",
+                                       VARIORUM_ERROR_INVAL, getenv("HOSTNAME"),
+                                       __FILE__, __FUNCTION__, __LINE__);
+                return -1;
+            }
+            return ret;
+        }
+        else
+        {
+            fprintf(stdout, "%6d | %14.03f    | successfully set\n",
+                    i, (double)pcap_new/1000);
+        }
+    }
+    return 0;
+}

--- a/src/variorum/AMD/epyc.h
+++ b/src/variorum/AMD/epyc.h
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef EPYC_H_INCLUDE
+#define EPYC_H_INCLUDE
+
+int epyc_get_power(int long_ver);
+
+int epyc_get_power_limits(int long_ver);
+
+int epyc_set_socket_power_limit(int pcap_new);
+
+int epyc_set_and_verify_node_power_limit(int pcap_new);
+
+#endif

--- a/src/variorum/AMD/epyc.h
+++ b/src/variorum/AMD/epyc.h
@@ -14,4 +14,12 @@ int epyc_set_socket_power_limit(int pcap_new);
 
 int epyc_set_and_verify_node_power_limit(int pcap_new);
 
+int epyc_print_energy(void);
+
+int epyc_print_boostlimit(void);
+
+int epyc_set_and_verify_core_boostlimit(int core, unsigned int boostlimit);
+
+int epyc_set_socket_boostlimit(int socket, unsigned int boostlimit);
+
 #endif

--- a/src/variorum/AMD/msr_core.c
+++ b/src/variorum/AMD/msr_core.c
@@ -1,0 +1,690 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+// Necessary for pread & pwrite.
+#define _XOPEN_SOURCE 500
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/ioctl.h>
+#include <linux/types.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <msr_core.h>
+#include <config_architecture.h>
+#include <variorum_error.h>
+
+static uint64_t devidx(unsigned socket, unsigned core, unsigned thread)
+{
+    unsigned nsockets, ncores, nthreads;
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
+    return (thread * nsockets * (ncores / nsockets)) + (socket * ncores / nsockets)
+           + core;
+}
+
+static int batch_storage(struct msr_batch_array **batchsel, const int batchnum,
+                         unsigned **opssize)
+{
+    static struct msr_batch_array *batch = NULL;
+    static unsigned arrsize = 1;
+    static unsigned *size = NULL;
+    unsigned i;
+
+    if (batch == NULL)
+    {
+#ifdef BATCH_DEBUG
+        fprintf(stderr, "BATCH: initializing batch ops\n");
+#endif
+        arrsize = (batchnum + 1 > (int)arrsize ? batchnum + 1 : (int)arrsize);
+        //        printf("QQQ arrsize %d\n", arrsize);
+        batch = (struct msr_batch_array *) calloc(arrsize,
+                sizeof(struct msr_batch_array));
+        size = (unsigned *) calloc(arrsize, sizeof(unsigned));
+        for (i = 0; i < arrsize; i++)
+        {
+            size[i] = 0;
+            batch[i].ops = NULL;
+            batch[i].numops = 0;
+        }
+    }
+    else if (batchnum + 1 > (int)arrsize)
+    {
+#ifdef BATCH_DEBUG
+        fprintf(stderr, "BATCH: reallocating array of batches for batch %d\n",
+                batchnum);
+#endif
+        unsigned oldsize = arrsize;
+        arrsize = batchnum + 1;
+        batch = (struct msr_batch_array *) realloc(batch,
+                arrsize * sizeof(struct msr_batch_array));
+        size = (unsigned *) realloc(size, arrsize * sizeof(unsigned));
+        for (; oldsize < arrsize; oldsize++)
+        {
+            batch[oldsize].ops = NULL;
+            batch[oldsize].numops = 0;
+            size[oldsize] = 0;
+        }
+    }
+    if (batchsel == NULL)
+    {
+        variorum_error_handler("Loading uninitialized batch", VARIORUM_ERROR_MSR_BATCH,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+    }
+    *batchsel = &batch[batchnum];
+    if (opssize != NULL)
+    {
+        *opssize = &size[batchnum];
+        //        printf("opssize = %d\n", **opssize);
+    }
+    return 0;
+}
+
+static int compatibility_batch(int batchnum, int type)
+{
+    struct msr_batch_array *batch = NULL;
+    int i;
+
+    fprintf(stderr,
+            "Warning: <variorum> No /dev/cpu/msr_batch, using compatibility batch: compatibility_batch(): %s: %s:%s::%d\n",
+            strerror(errno), getenv("HOSTNAME"), __FILE__, __LINE__);
+    if (batch_storage(&batch, batchnum, NULL))
+    {
+        return -1;
+    }
+    for (i = 0; i < (int)batch->numops; i++)
+    {
+        if (type == BATCH_READ)
+        {
+            read_msr_by_idx(batch->ops[i].cpu, batch->ops[i].msr,
+                            (uint64_t *) &batch->ops[i].msrdata);
+        }
+        else
+        {
+            write_msr_by_idx(batch->ops[i].cpu, batch->ops[i].msr,
+                             (uint64_t)batch->ops[i].msrdata);
+        }
+    }
+    return 0;
+}
+
+/// @brief Retrieve file descriptor per logical processor.
+///
+/// @param [in] dev_idx Unique logical processor identifier.
+///
+/// @return Unique file descriptor, else NULL.
+static int *core_fd(const unsigned dev_idx)
+{
+    static int init_core_fd = 0;
+    static int *file_descriptors = NULL;
+    static unsigned nthreads;
+    char *variorum_error_msg = (char *) malloc(NAME_MAX * sizeof(char));
+
+    if (!init_core_fd)
+    {
+        init_core_fd = 1;
+        variorum_get_topology(NULL, NULL, &nthreads);
+        file_descriptors = (int *) malloc(nthreads * sizeof(int));
+    }
+    if (dev_idx < nthreads)
+    {
+        free(variorum_error_msg);
+        return &(file_descriptors[dev_idx]);
+    }
+    //    if (dev_idx == nthreads)
+    //    {
+    //        free(variorum_error_msg);
+    //        return file_descriptors;
+    //    }
+    sprintf(variorum_error_msg, "Array reference %d out of bounds (max: %d)",
+            dev_idx, nthreads);
+    variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_ARRAY_BOUNDS,
+                           getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+    free(variorum_error_msg);
+    return NULL;
+}
+
+static int do_batch_op(int batchnum, int type)
+{
+    static int batchfd = 0;
+    struct msr_batch_array *batch = NULL;
+    int res, i, j;
+
+    if (batchfd == 0)
+    {
+        if ((batchfd = open(MSR_BATCH_DIR, O_RDWR)) < 0)
+        {
+            perror(MSR_BATCH_DIR);
+            batchfd = -1;
+        }
+    }
+#ifdef USE_NO_BATCH
+    return compatibility_batch(batchnum, type);
+#endif
+    if (batchfd < 0)
+    {
+        return compatibility_batch(batchnum, type);
+    }
+    if (batch_storage(&batch, batchnum, NULL))
+    {
+        return -1;
+    }
+#ifdef BATCH_DEBUG
+    fprintf(stderr, "BATCH %d: %s MSRs, numops %u\n", batchnum,
+            (type == BATCH_READ ? "reading" : "writing"), batch->numops);
+#endif
+    if (batch->numops <= 0)
+    {
+        variorum_error_handler("Using empty batch", VARIORUM_ERROR_MSR_BATCH,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        return -1;
+    }
+
+    /* If current flag is the opposite type, switch the flags. */
+    if ((type == BATCH_WRITE && batch->ops[0].isrdmsr) || (type == BATCH_READ &&
+            !batch->ops[0].isrdmsr))
+    {
+        __u8 readflag = (__u8)(type == BATCH_READ ? 1 : 0);
+        for (j = 0; j < (int)batch->numops; j++)
+        {
+            batch->ops[j].isrdmsr = readflag;
+        }
+    }
+    res = ioctl(batchfd, X86_IOC_MSR_BATCH, batch);
+    if (res < 0)
+    {
+        variorum_error_handler("IOctl failed, does /dev/cpu/msr_batch exist?",
+                               VARIORUM_ERROR_MSR_BATCH, getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        for (i = 0; i < (int)batch->numops; i++)
+        {
+            if (batch->ops[i].err)
+            {
+                fprintf(stderr, "    CPU %3d, MSR 0x%x, ERR (%s)\n", batch->ops[i].cpu,
+                        batch->ops[i].msr, strerror(batch->ops[i].err));
+            }
+        }
+        return res;
+    }
+#ifdef BATCH_DEBUG
+    int k;
+    for (k = 0; k < batch->numops; k++)
+    {
+        fprintf(stderr, "BATCH %d: msr 0x%x cpu %u data 0x%lx (at %p)\n", batchnum,
+                batch->ops[k].msr, batch->ops[k].cpu, (uint64_t)batch->ops[k].msrdata,
+                &batch->ops[k].msrdata);
+    }
+#endif
+    return 0;
+}
+
+int sockets_assert(const unsigned *socket)
+{
+    char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
+    unsigned nsockets;
+    variorum_get_topology(&nsockets, NULL, NULL);
+
+    if (*socket > nsockets)
+    {
+        sprintf(variorum_error_msg, "Requested invalid socket %d (max: %d)", *socket,
+                nsockets);
+        variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_PLATFORM_ENV,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        free(variorum_error_msg);
+        return VARIORUM_ERROR_PLATFORM_ENV;
+    }
+    free(variorum_error_msg);
+    return 0;
+}
+
+int threads_assert(const unsigned *thread)
+{
+    char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
+    unsigned nthreads;
+    variorum_get_topology(NULL, NULL, &nthreads);
+
+    if (*thread > nthreads)
+    {
+        sprintf(variorum_error_msg, "Requested invalid thread %d (max: %d)", *thread,
+                nthreads);
+        variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_PLATFORM_ENV,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        free(variorum_error_msg);
+        return VARIORUM_ERROR_PLATFORM_ENV;
+    }
+    free(variorum_error_msg);
+    return 0;
+}
+
+int cores_assert(const unsigned *core)
+{
+    char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
+    unsigned ncores;
+    variorum_get_topology(NULL, &ncores, NULL);
+
+    if (*core > ncores)
+    {
+        sprintf(variorum_error_msg, "Requested invalid core %d (max: %d)", *core,
+                ncores);
+        variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_PLATFORM_ENV,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        free(variorum_error_msg);
+        return VARIORUM_ERROR_PLATFORM_ENV;
+    }
+    free(variorum_error_msg);
+    return 0;
+}
+
+int stat_module(char *filename, int *kerneltype, int *dev_idx)
+{
+    struct stat statbuf;
+    char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
+
+    if (*kerneltype == 3)
+    {
+        if (stat(filename, &statbuf))
+        {
+            fprintf(stderr,
+                    "Warning: <variorum> Could not stat %s: stat_module(): %s: %s:%s::%d\n",
+                    filename, strerror(errno), getenv("HOSTNAME"), __FILE__, __LINE__);
+            *kerneltype = 1;
+            free(variorum_error_msg);
+            return -1;
+        }
+        if (!(statbuf.st_mode & S_IRUSR) || !(statbuf.st_mode & S_IWUSR))
+        {
+            fprintf(stderr,
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
+                    "Warning: <variorum> Incorrect permissions on msr_whitelist: stat_module(): %s:%s::%d\n",
+#else
+                    "Warning: <variorum> Incorrect permissions on msr_allowlist: stat_module(): %s:%s::%d\n",
+#endif
+                    getenv("HOSTNAME"), __FILE__, __LINE__);
+            *kerneltype = 1;
+            free(variorum_error_msg);
+            return -1;
+        }
+        *kerneltype = 0;
+        free(variorum_error_msg);
+        return 0;
+    }
+    if (stat(filename, &statbuf))
+    {
+        fprintf(stderr,
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
+                "Warning: <variorum> Incorrect permissions on msr_whitelist: stat_module(): %s:%s::%d\n",
+#else
+                "Warning: <variorum> Incorrect permissions on msr_allowlist: stat_module(): %s:%s::%d\n",
+#endif
+                getenv("HOSTNAME"), __FILE__, __LINE__);
+        if (*kerneltype)
+        {
+            /* Could not find any msr module so exit. */
+            sprintf(variorum_error_msg, "Could not stat file %s on dev %d", filename,
+                    *dev_idx);
+            variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_MSR_MODULE,
+                                   getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+            free(variorum_error_msg);
+            return VARIORUM_ERROR_RAPL_INIT;
+        }
+        /* Could not find msr_safe module so try the msr module. */
+        sprintf(variorum_error_msg, "Could not stat file %s on dev %d", filename,
+                *dev_idx);
+        variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_MSR_MODULE,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        *kerneltype = 1;
+        /* Restart loading file descriptors for each device. */
+        *dev_idx = -1;
+        free(variorum_error_msg);
+        return 0;
+    }
+    if (!(statbuf.st_mode & S_IRUSR) || !(statbuf.st_mode & S_IWUSR))
+    {
+        sprintf(variorum_error_msg,
+                "Read/write permissions denied for file %s on dev %d", filename, *dev_idx);
+        variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_MSR_MODULE,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        *kerneltype = 1;
+        *dev_idx = -1;
+        if (kerneltype != NULL)
+        {
+            /* Could not find any msr module with RW permissions, so exit. */
+            variorum_error_handler("Could not find any valid MSR module with correct permissions",
+                                   VARIORUM_ERROR_MSR_MODULE, getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                                   __LINE__);
+            free(variorum_error_msg);
+            return VARIORUM_ERROR_MSR_MODULE;
+        }
+    }
+    free(variorum_error_msg);
+    return 0;
+}
+
+int finalize_msr(void)
+{
+    int ret = 0;
+    unsigned dev_idx;
+    int *file_descriptor = NULL;
+    char *variorum_error_msg = (char *) malloc(NAME_MAX * sizeof(char));
+    unsigned nthreads;
+    variorum_get_topology(NULL, NULL, &nthreads);
+
+    for (dev_idx = 0; dev_idx < nthreads; dev_idx++)
+    {
+        file_descriptor = core_fd(dev_idx);
+        if (file_descriptor != NULL)
+        {
+            ret = close(*file_descriptor);
+            if (ret)
+            {
+                sprintf(variorum_error_msg, "Could not close file for device %d", dev_idx);
+                variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_MSR_CLOSE,
+                                       getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+            }
+            else
+            {
+                *file_descriptor = 0;
+            }
+        }
+    }
+    //file_descriptor = core_fd(nthreads);
+    //free(file_descriptor);
+    free(variorum_error_msg);
+    return ret;
+}
+
+int init_msr(void)
+{
+    int dev_idx;
+    int ret;
+    int *file_descriptor = NULL;
+    char filename[FILENAME_SIZE];
+    int kerneltype = 3; // 0 is msr_safe, 1 is msr
+    char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
+    unsigned nsockets, ncores, nthreads;
+
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
+#ifdef USE_MSR_SAFE_BEFORE_1_5_0
+    snprintf(filename, FILENAME_SIZE, "/dev/cpu/msr_whitelist");
+#else
+    snprintf(filename, FILENAME_SIZE, "/dev/cpu/msr_allowlist");
+#endif
+    stat_module(filename, &kerneltype, 0);
+    /* Open the file descriptor for each device's msr interface. */
+    for (dev_idx = 0; dev_idx < (int)nthreads; dev_idx++)
+    {
+        /* Use the msr_safe module, or default to the msr module. */
+        if (kerneltype)
+        {
+            snprintf(filename, FILENAME_SIZE, "/dev/cpu/%d/msr", dev_idx);
+        }
+        else
+        {
+            snprintf(filename, FILENAME_SIZE, "/dev/cpu/%d/msr_safe", dev_idx);
+        }
+        if (stat_module(filename, &kerneltype, &dev_idx) < 0)
+        {
+            ret = -1;
+            free(variorum_error_msg);
+            //free(file_descriptor);
+            return ret;
+        }
+        /* Open the msr module, else return the appropriate error message. */
+        file_descriptor = core_fd(dev_idx);
+        *file_descriptor = open(filename, O_RDWR);
+        if (*file_descriptor == -1)
+        {
+            sprintf(variorum_error_msg, "Could not open file for device %d", dev_idx);
+            variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_RAPL_INIT,
+                                   getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+            if (kerneltype)
+            {
+                sprintf(variorum_error_msg, "Could not open any valid MSR module for device %d",
+                        dev_idx);
+                variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_RAPL_INIT,
+                                       getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+                /* Could not open any msr module, so exit. */
+                free(variorum_error_msg);
+                //free(file_descriptor);
+                return VARIORUM_ERROR_RAPL_INIT;
+            }
+            kerneltype = 1;
+            dev_idx--;
+        }
+    }
+    free(variorum_error_msg);
+    return 0;
+}
+
+int write_msr_by_coord(unsigned socket, unsigned core, unsigned thread,
+                       off_t msr, uint64_t val)
+{
+    sockets_assert(&socket);
+    cores_assert(&core);
+    threads_assert(&thread);
+
+    return write_msr_by_idx(devidx(socket, core, thread), msr, val);
+}
+
+int read_msr_by_coord(unsigned socket, unsigned core, unsigned thread,
+                      off_t msr, uint64_t *val)
+{
+#ifdef VARIORUM_DEBUG
+    fprintf(stderr,
+            "%s %s::%d (read_msr_by_coord) socket=%d core=%d thread=%d msr=%lu (0x%lx)\n",
+            getenv("HOSTNAME"), __FILE__, __LINE__, socket, core, thread, msr, msr);
+#endif
+    sockets_assert(&socket);
+    cores_assert(&core);
+    threads_assert(&thread);
+    if (val == NULL)
+    {
+        variorum_error_handler("Received NULL pointer for val", VARIORUM_ERROR_MSR_READ,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        return VARIORUM_ERROR_MSR_READ;
+    }
+    return read_msr_by_idx(devidx(socket, core, thread), msr, val);
+}
+
+int read_msr_by_idx(int dev_idx, off_t msr, uint64_t *val)
+{
+    int rc;
+    int *file_descriptor = NULL;
+    char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
+
+    file_descriptor = core_fd(dev_idx);
+    if (file_descriptor == NULL)
+    {
+        free(variorum_error_msg);
+        return -1;
+    }
+#ifdef VARIORUM_DEBUG
+    fprintf(stderr, "%s %s::%d (read_msr_by_idx) msr=%lu (0x%lx)\n",
+            getenv("HOSTNAME"), __FILE__, __LINE__, msr, msr);
+#endif
+    rc = pread(*file_descriptor, (void *)val, (size_t)sizeof(uint64_t), msr);
+    if (rc != sizeof(uint64_t))
+    {
+        sprintf(variorum_error_msg, "Pread failed on dev_idx %d", dev_idx);
+        variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_MSR_READ,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        free(variorum_error_msg);
+        return VARIORUM_ERROR_MSR_READ;
+    }
+    free(variorum_error_msg);
+    return 0;
+}
+
+int write_msr_by_idx(int dev_idx, off_t msr, uint64_t val)
+{
+    int rc;
+    int *file_descriptor = NULL;
+    char *variorum_error_msg = malloc(NAME_MAX * sizeof(char));
+
+    file_descriptor = core_fd(dev_idx);
+    if (file_descriptor == NULL)
+    {
+        free(variorum_error_msg);
+        return -1;
+    }
+#ifdef VARIORUM_DEBUG
+    fprintf(stderr, "%s %s::%d (write_msr_by_idx) msr=%lu (0x%lx)\n",
+            getenv("HOSTNAME"), __FILE__, __LINE__, msr, msr);
+#endif
+    rc = pwrite(*file_descriptor, &val, (size_t)sizeof(uint64_t), msr);
+    if (rc != sizeof(uint64_t))
+    {
+        sprintf(variorum_error_msg, "Pwrite failed on dev_idx %d", dev_idx);
+        variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_MSR_WRITE,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        free(variorum_error_msg);
+        return VARIORUM_ERROR_MSR_WRITE;
+    }
+    free(variorum_error_msg);
+    return 0;
+}
+
+int allocate_batch(int batchnum, size_t bsize)
+{
+    unsigned *size = NULL;
+    struct msr_batch_array *batch = NULL;
+    unsigned int i;
+
+#ifdef BATCH_DEBUG
+    fprintf(stderr, "BATCH: allocating batch %d\n", batchnum);
+#endif
+    //printf("First call to batch_storage\n");
+    if (batch_storage(&batch, batchnum, &size))
+    {
+        return -1;
+    }
+#ifdef BATCH_DEBUG
+    fprintf(stderr, "BATCH: batch %d is at %p\n", batchnum, batch);
+#endif
+    *size = bsize;
+#ifdef BATCH_DEBUG
+    printf("allocate_batch batchnum %d has %d ops\n", batchnum, *size);
+#endif
+    if (batch->ops != NULL)
+    {
+        variorum_error_handler("Conflicting batch pointers", VARIORUM_ERROR_MSR_BATCH,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+    }
+    batch->ops = (struct msr_batch_op *) calloc(*size, sizeof(struct msr_batch_op));
+    for (i = batch->numops; i < *size; i++)
+    {
+        batch->ops[i].err = 0;
+    }
+    return 0;
+}
+
+int load_socket_batch(off_t msr, uint64_t **val, int batchnum)
+{
+    unsigned dev_idx, val_idx;
+    unsigned nsockets, ncores, nthreads;
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
+
+    if (val == NULL)
+    {
+        variorum_error_handler("Given uninitialized array", VARIORUM_ERROR_MSR_BATCH,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        return VARIORUM_ERROR_MSR_BATCH;
+    }
+
+    for (dev_idx = 0, val_idx = 0; dev_idx < ncores;
+         dev_idx += ncores / nsockets, val_idx++)
+    {
+        create_batch_op(msr, dev_idx, &val[val_idx % (nsockets * (nthreads / ncores))],
+                        batchnum);
+    }
+    return 0;
+}
+
+int load_thread_batch(off_t msr, uint64_t **val, int batchnum)
+{
+    unsigned dev_idx, val_idx;
+    unsigned nsockets, ncores, nthreads;
+    variorum_get_topology(&nsockets, &ncores, &nthreads);
+
+    if (val == NULL)
+    {
+        variorum_error_handler("Given uninitialized array", VARIORUM_ERROR_MSR_BATCH,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        return VARIORUM_ERROR_MSR_BATCH;
+    }
+
+#ifdef VARIORUM_DEBUG
+    fprintf(stderr, "%s %s::%d (read_all_threads) msr=%lu (0x%lx)\n",
+            getenv("HOSTNAME"), __FILE__, __LINE__, msr, msr);
+#endif
+    for (dev_idx = 0, val_idx = 0; dev_idx < nthreads; dev_idx++, val_idx++)
+    {
+        create_batch_op(msr, dev_idx, &val[val_idx], batchnum);
+    }
+    return 0;
+}
+
+int read_batch(const int batchnum)
+{
+    int err = do_batch_op(batchnum, BATCH_READ);
+    return err;
+}
+
+int write_batch(const int batchnum)
+{
+    return do_batch_op(batchnum, BATCH_WRITE);
+}
+
+int create_batch_op(off_t msr, uint64_t cpu, uint64_t **dest,
+                    const int batchnum)
+{
+    struct msr_batch_array *batch = NULL;
+    unsigned *size = NULL;
+
+#ifdef BATCH_DEBUG
+    fprintf(stderr, "BATCH: creating new batch operation\n");
+#endif
+    if (batch_storage(&batch, batchnum, &size))
+    {
+        return -1;
+    }
+
+#ifdef BATCH_DEBUG
+    fprintf(stderr, "BATCH: batch %d is at %p\n", batchnum, batch);
+#endif
+    if (batch->numops > *size)
+    {
+        char *variorum_error_msg = (char *) malloc(NAME_MAX * sizeof(char));
+        sprintf(variorum_error_msg,
+                "Batch %d is full, you likely used the wrong size (max: %d)", batchnum,
+                batch->numops);
+        variorum_error_handler(variorum_error_msg, VARIORUM_ERROR_MSR_BATCH,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__, __LINE__);
+        free(variorum_error_msg);
+        return VARIORUM_ERROR_MSR_BATCH;
+    }
+
+    batch->numops++;
+#ifdef BATCH_DEBUG
+    printf("create_batch_op: batchnum = %d numops = %d size = %d\n", batchnum,
+           batch->numops, *size);
+#endif
+    batch->ops[batch->numops - 1].msr = msr;
+    batch->ops[batch->numops - 1].cpu = (__u16) cpu;
+    batch->ops[batch->numops - 1].isrdmsr = (__u8) 1;
+    batch->ops[batch->numops - 1].err = 0;
+    *dest = (uint64_t *) &batch->ops[batch->numops - 1].msrdata;
+#ifdef BATCH_DEBUG
+    fprintf(stderr, "BATCH: destination of msr %lx on core %lx (at %p) is %p\n",
+            msr, cpu, dest, &batch->ops[batch->numops - 1].msrdata);
+    fprintf(stderr, "\tbatch numops is %d\n", batch->numops);
+#endif
+    return 0;
+}

--- a/src/variorum/AMD/msr_core.h
+++ b/src/variorum/AMD/msr_core.h
@@ -1,0 +1,395 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef MSR_CORE_H_INCLUDE
+#define MSR_CORE_H_INCLUDE
+
+#include <linux/types.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#define X86_IOC_MSR_BATCH _IOWR('c', 0xA2, struct msr_batch_array)
+#define MSR_BATCH_DIR "/dev/cpu/msr_batch"
+#define FILENAME_SIZE 1024
+
+#ifndef NAME_MAX
+#define NAME_MAX 1024
+#endif
+
+/// @brief Enum encompassing type of data being read to/written from MSRs.
+enum variorum_data_type_e
+{
+    /// @brief Energy, time, and power measurements of various RAPL power
+    /// domains.
+    RAPL_DATA = 0,
+    /// @brief Units for energy, time, and power across all RAPL power domains.
+    RAPL_UNIT = 1,
+    /// @brief Fixed-function counter measurements (i.e., instructions retired,
+    /// reference clock cycles, CPU cycles).
+    FIXED_COUNTERS_DATA = 2,
+    /// @brief Controls for fixed-function counters (i.e., instructions retired,
+    /// reference clock cycles, CPU cycles).
+    FIXED_COUNTERS_CTRL_DATA = 3,
+    /// @brief General-purpose performance counter measurements.
+    COUNTERS_DATA = 4,
+    /// @brief Controls for general-purpose performance counters and
+    /// performance event select counter measurements.
+    COUNTERS_CTRL = 5,
+    /// @brief Clock cycle measurements based on fixed frequency and actual
+    /// frequency of the processor.
+    CLOCKS_DATA = 6,
+    /// @brief Instantaneous operating frequency of the core or socket.
+    PERF_DATA = 7,
+    /// @brief Thermal status of core.
+    THERM_STAT = 8,
+    /// @brief Interrupts by thermal monitor when thermal sensor on a core is
+    /// tripped.
+    THERM_INTERR = 9,
+    /// @brief Thermal status of package.
+    PKG_THERM_STAT = 10,
+    /// @brief Interrupts by thermal monitor when thermal sensor on the package
+    /// is tripped.
+    PKG_THERM_INTERR = 11,
+    /// @brief Current temperature of the package.
+    TEMP_TARGET = 12,
+    /// @brief Software desired operating frequency of the core or socket.
+    PERF_CTRL = 13,
+    /// @brief Measured time spent in C-states by the package.
+    PKG_CRESIDENCY = 14,
+    /// @brief Measured time spent in C-states by the core.
+    CORE_CRESIDENCY = 15,
+    /// @brief Uncore performance event select counter measurements.
+    UNCORE_EVTSEL = 16,
+    /// @brief Uncore general-performance counter measurements.
+    UNCORE_COUNT = 17,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH0 = 18,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH1 = 19,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH2 = 20,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH3 = 21,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH4 = 22,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH5 = 23,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH6 = 24,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH7 = 25,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH8 = 26,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH9 = 27,
+    /// @brief User-defined batch MSR data.
+    USR_BATCH10 = 28,
+    PLATFORM_INFO = 29,
+    MIN_OPERATING_RATIO = 30,
+    MAX_EFFICIENCY = 31,
+    TURBO_RATIO_LIMIT = 32,
+    TURBO_RATIO_LIMIT1 = 33,
+    TURBO_RATIO_LIMIT_CORES = 34,
+    TDP_DEFS = 35,
+    TDP_CONFIG = 36,
+};
+
+/// @brief Enum encompassing batch operations.
+enum variorum_batch_op_type_e
+{
+    /// @brief Load batch operation.
+    BATCH_LOAD,
+    /// @brief Write batch operation.
+    BATCH_WRITE,
+    /// @brief Read batch operation.
+    BATCH_READ,
+};
+
+/// @brief Structure holding multiple read/write operations to various MSRs.
+struct msr_batch_array
+{
+    /// @brief Number of operations to execute.
+    __u32 numops;
+    /// @brief Array of length numops of operations to execute.
+    struct msr_batch_op *ops;
+};
+
+/// @brief Structure holding information for a single read/write operation to
+/// an MSR.
+struct msr_batch_op
+{
+    /// @brief CPU where rdmsr/wrmsr will be executed.
+    __u16 cpu;
+    /// @brief Identify if operation is rdmsr (non-zero) or wrmsr (0).
+    __u16 isrdmsr;
+    /// @brief Stores error code.
+    __s32 err;
+    /// @brief Address of MSR to perform operation.
+    __u32 msr;
+    /// @brief Stores input to or result from operation.
+    __u64 msrdata;
+    /// @brief Write mask applied to wrmsr.
+    __u64 wmask;
+};
+
+// Depending on their scope, MSRs can be written to or read from at either the
+// socket (aka package/cpu) or core level, and possibly the hardware thread
+// level.
+//
+//  read/write_msr reads from core 0.
+//  read/write_msr_all_cores_v uses a vector of values.
+//  write_msr_all_cores writes all cores with a single value.
+//  read/write_msr_single_core contains all of the low-level logic.
+//  The rest of the functions are wrappers that call these two functions.
+
+/// @brief Validate specific socket exists in the platform configuration.
+///
+/// @param [in] socket Unique socket/package identifier.
+///
+/// @return 0 if successful, else -1 if socket requested is greater than number
+/// of sockets in the platform.
+int sockets_assert(const unsigned *socket);
+
+/// @brief Validate specific thread exists in the platform configuration.
+///
+/// @param [in] thread Unique thread identifier.
+///
+/// @return 0 if successful, else -1 if thread requested is greater than number
+/// of threads per core in the platform.
+int threads_assert(const unsigned *thread);
+
+/// @brief Validate specific core exists in the platform configuration.
+///
+/// @param [in] core Unique core identifier.
+///
+/// @return 0 if successful, else -1 if core requested is greater than number
+/// of cores per socket in the platform.
+int cores_assert(const unsigned *core);
+
+/// @brief Check status of a file.
+///
+/// @param [in] filename File to check status of.
+///
+/// @param [in] kerneltype OS privilege level (ring 0-ring 3).
+///
+/// @param [in] dev_idx Unique logical processor index.
+///
+/// @return 0 if successful, else -1 if can't find any msr module with RW
+/// permissions.
+int stat_module(char *filename,
+                int *kerneltype,
+                int *dev_idx);
+
+/// @brief Open the MSR module file descriptors exposed in the /dev filesystem.
+///
+/// @return 0 if initialization was a success, else -1 if could not stat file
+/// descriptors or open any msr module.
+int init_msr(void);
+
+/// @brief Close the MSR module file descriptors exposed in the /dev
+/// filesystem.
+///
+/// @return 0 if finalization was a success, else -1 if could not close file
+/// descriptors.
+int finalize_msr(void);
+
+/// @brief Write a new value to an MSR based on the coordinates of a core or
+/// thread.
+///
+/// A user can request to write to core 4 on socket 1, instead of having to map
+/// this core to a continuous value based on the the number of cores on socket
+/// 0. For a dual socket system with 8 cores, socket 0 would have cores 0-7,
+/// core 0 on socket 1 would be mapped to index 8.
+///
+/// @param [in] socket Unique socket/package identifier.
+///
+/// @param [in] core Unique core identifier.
+///
+/// @param [in] thread Unique thread identifier.
+///
+/// @param [in] msr Address of register to write.
+///
+/// @param [in] val Value to write to MSR.
+///
+/// @return 0 if write_msr_by_idx() was a success, else -1 if the file
+/// descriptor was NULL or if the number of bytes written was not the size of
+/// uint64_t.
+int write_msr_by_coord(unsigned socket,
+                       unsigned core,
+                       unsigned thread,
+                       off_t msr,
+                       uint64_t val);
+
+/// @brief Read current value of an MSR based on the coordinates of a core or
+/// thread.
+///
+/// A user can request to read from core 4 on socket 1, instead of having to map
+/// this core to a continuous value based on the the number of cores on socket
+/// 0. For a dual socket system with 8 cores, socket 0 would have cores 0-7,
+/// core 0 on socket 1 would be mapped to index 8.
+///
+/// @param [in] socket Unique socket/package identifier.
+///
+/// @param [in] core Unique core identifier.
+///
+/// @param [in] thread Unique thread identifier.
+///
+/// @param [in] msr Address of register to read.
+///
+/// @param [out] val Value read from MSR.
+///
+/// @return 0 if read_msr_by_idx() was a success, else -1 if the file
+/// descriptor was NULL or if the number of bytes read was not the size of
+/// uint64_t.
+int read_msr_by_coord(unsigned socket,
+                      unsigned core,
+                      unsigned thread,
+                      off_t msr,
+                      uint64_t *val);
+
+/// @brief Read current value of an MSR based on the index of a core or
+/// thread.
+///
+/// A user can request to read from index 8, which is core 0 on socket 1 in a
+/// dual socket system with 8 cores per socket.  This index is a continuous
+/// value based on the the number of cores on socket 0.
+///
+/// @param [in] dev_idx Unique device identifier.
+///
+/// @param [in] msr Address of register to read.
+///
+/// @param [out] val Value read from MSR.
+///
+/// @return 0 if successful, else -1 if file descriptor was NULL or if the
+/// number of bytes read was not the size of uint64_t.
+int read_msr_by_idx(int dev_idx,
+                    off_t msr,
+                    uint64_t *val);
+
+/// @brief Write new value to an MSR based on the continuous index of a core
+/// or thread.
+///
+/// A user can request to read from index 8, which is core 0 on socket 1 in a
+/// dual socket system with 8 cores per socket.  This index is a continuous
+/// value based on the the number of cores on socket 0.
+///
+/// @param [in] dev_idx Unique device identifier.
+///
+/// @param [in] msr Address of register to read.
+///
+/// @param [out] val Value read from MSR.
+///
+/// @return 0 if successful, else -1 if file descriptor was NULL or if the
+/// number of bytes read was not the size of uint64_t.
+int write_msr_by_idx(int dev_idx,
+                     off_t msr,
+                     uint64_t val);
+
+/// @brief Write new value to an MSR based on a tuple of socket, core, and
+/// thread.
+///
+/// A user can request to read from index 8, which is core 0 on socket 1 in a
+/// dual socket system with 8 cores per socket.  This index is a continuous
+/// value based on the the number of cores on socket 0.
+///
+/// @param [in] socket Socket identifier.
+///
+/// @param [in] core Core identifier.
+///
+/// @param [in] thread Thread identifier.
+///
+/// @param [in] msr Address of register to read.
+///
+/// @param [out] val Value read from MSR.
+///
+/// @return 0 if successful, else -1 if file descriptor was NULL or if the
+/// number of bytes read was not the size of uint64_t.
+int write_msr_by_coord(unsigned socket,
+                       unsigned core,
+                       unsigned thread,
+                       off_t msr,
+                       uint64_t val);
+
+/// @brief Create a batch for a thread-level MSR.
+///
+/// This function associates an existing allocated array (for the MSR values)
+/// with an existing batch handle. After this function call, issuing a read or
+/// write to the batched MSR can be done with read/write_batch.
+///
+/// @param [in] msr Address of register to read.
+///
+/// @param [out] val Array to store values for reading from or writing to
+///              batched MSR.
+///
+/// @param [in] batchnum Identify a unique batch.
+///
+/// @return 0 if successful, else -1 if val is NULL.
+int load_thread_batch(off_t msr,
+                      uint64_t **val,
+                      int batchnum);
+
+/// @brief Create a batch for a socket-level MSR.
+///
+/// This function associates an existing allocated array (for the MSR values)
+/// with an existing batch handle. After this function call, issuing a read or
+/// write to the batched MSR can be done with read/write_batch.
+///
+/// @param [in] msr Address of register to read.
+///
+/// @param [out] val Array to store values for reading from or writing to
+///              batched MSR.
+///
+/// @param [in] batchnum Identify a unique batch.
+///
+/// @return 0 if successful, else -1 if val is NULL.
+int load_socket_batch(off_t msr,
+                      uint64_t **val,
+                      int batchnum);
+
+/// @brief Allocate a batch handle.
+///
+/// This function initializes a batch handle with a given size.
+///
+/// @param [in] batchnum Identify a unique batch.
+///
+/// @param [in] bsize Length of array to allocate.
+///
+/// @return 0 if successful, else -1 if batch handle is NULL or if trying to
+/// reallocate an existing batch.
+int allocate_batch(int batchnum,
+                   size_t bsize);
+
+/// @brief Read from a batched set of MSRs.
+///
+/// @param [in] batchnum Identify a unique batch.
+///
+/// @return 0 if successful, else -1.
+int read_batch(const int batchnum);
+
+/// @brief Write to a batched set of MSRs.
+///
+/// @param [in] batchnum Identify a unique batch.
+///
+/// @return 0 if successful, else -1.
+int write_batch(const int batchnum);
+
+/// @brief Create a batch operation for a given CPU.
+///
+/// @param [in] msr Address of register to read.
+///
+/// @param [in] cpu Unique index on where to issue operation.
+///
+/// @param [out] dest Location to store batch operation.
+///
+/// @param [in] batchnum Identify a unique batch.
+///
+/// @return 0 if successful, else -1 if batch handle is NULL or if batched
+/// allocation size does not match.
+int create_batch_op(off_t msr,
+                    uint64_t cpu,
+                    uint64_t **dest,
+                    const int batchnum);
+
+#endif

--- a/src/variorum/CMakeLists.txt
+++ b/src/variorum/CMakeLists.txt
@@ -33,6 +33,7 @@ set(variorum_deps ""
 set(variorum_includes
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${HWLOC_INCLUDE_DIRS}
+    ${ESMI_INCLUDE_DIRS}
 )
 
 if(VARIORUM_WITH_INTEL)
@@ -67,6 +68,14 @@ if(VARIORUM_WITH_ARM)
     list(APPEND variorum_includes ${CMAKE_CURRENT_SOURCE_DIR}/ARM)
 endif()
 
+if(VARIORUM_WITH_AMD)
+    add_subdirectory(AMD)
+    list(APPEND variorum_headers AMD/config_amd.h ${variorum_amd_headers})
+    list(APPEND variorum_sources AMD/config_amd.c)
+    list(APPEND variorum_deps $<TARGET_OBJECTS:variorum_amd>)
+    list(APPEND variorum_includes ${CMAKE_CURRENT_SOURCE_DIR}/AMD)
+endif()
+
 if(FORTRAN_FOUND)
     add_library(variorum_fortran OBJECT variorum.f90)
     list(APPEND variorum_sources $<TARGET_OBJECTS:variorum_fortran>)
@@ -94,6 +103,9 @@ endif()
 target_link_libraries(variorum PUBLIC ${HWLOC_LIBRARY})
 target_link_libraries(variorum PUBLIC ${JANSSON_LIBRARY})
 target_link_libraries(variorum PUBLIC m)
+if(VARIORUM_WITH_AMD)
+target_link_libraries(variorum PUBLIC ${ESMI_LIBRARY})
+endif()
 
 install(TARGETS variorum
         EXPORT  variorum

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -308,6 +308,10 @@ void variorum_init_func_ptrs()
     g_platform.variorum_monitoring = NULL;
     g_platform.variorum_get_node_power_json = NULL;
     g_platform.variorum_print_available_frequencies = NULL;
+    g_platform.variorum_print_energy = NULL;
+    g_platform.variorum_print_boostlimit = NULL;
+    g_platform.variorum_set_and_verify_core_boostlimit = NULL;
+    g_platform.variorum_set_socket_boostlimit = NULL;
 }
 
 int variorum_set_func_ptrs()

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -31,6 +31,10 @@
 #include <config_arm.h>
 #endif
 
+#ifdef VARIORUM_WITH_AMD
+#include <config_amd.h>
+#endif
+
 #ifdef VARIORUM_LOG
 int variorum_enter(const char *filename, const char *func_name, int line_num)
 #else
@@ -87,9 +91,6 @@ int variorum_exit()
 #ifdef VARIORUM_WITH_INTEL
     free(g_platform.intel_arch);
 #endif
-#ifdef VARIORUM_WITH_AMD
-    free(g_platform.amd_arch);
-#endif
 #ifdef VARIORUM_WITH_IBM
     free(g_platform.ibm_arch);
 #endif
@@ -98,6 +99,10 @@ int variorum_exit()
 #endif
 #ifdef VARIORUM_WITH_ARM
     free(g_platform.arm_arch);
+#endif
+#ifdef VARIORUM_WITH_AMD
+    esmi_exit();
+    free(g_platform.amd_arch);
 #endif
 
     return err;
@@ -108,9 +113,6 @@ int variorum_detect_arch(void)
 #ifdef VARIORUM_WITH_INTEL
     g_platform.intel_arch = detect_intel_arch();
 #endif
-#ifdef VARIORUM_WITH_AMD
-    //g_platform.amd_arch = detect_amd_arch();
-#endif
 #ifdef VARIORUM_WITH_IBM
     g_platform.ibm_arch = detect_ibm_arch();
 #endif
@@ -120,6 +122,9 @@ int variorum_detect_arch(void)
 #ifdef VARIORUM_WITH_ARM
     g_platform.arm_arch = detect_arm_arch();
 #endif
+#ifdef VARIORUM_WITH_AMD
+    g_platform.amd_arch = detect_amd_arch();
+#endif
 
 #if defined(VARIORUM_LOG) && defined(VARIORUM_WITH_INTEL)
     printf("Intel Model: 0x%lx\n", *g_platform.intel_arch);
@@ -127,12 +132,16 @@ int variorum_detect_arch(void)
 #if defined(VARIORUM_LOG) && defined(VARIORUM_WITH_IBM)
     printf("IBM Model: 0x%lx\n", *g_platform.ibm_arch);
 #endif
+#if defined(VARIORUM_LOG) && defined(VARIORUM_WITH_AMD)
+    printf("AMD Family: 0x%lx, Model: 0x%lx\n",
+            (*g_platform.amd_arch >> 8) & 0xFF, *g_platform.amd_arch & 0xFF);
+#endif
 
     if (g_platform.intel_arch   == NULL &&
-        g_platform.amd_arch     == NULL &&
         g_platform.ibm_arch     == NULL &&
         g_platform.nvidia_arch  == NULL &&
-        g_platform.arm_arch     == NULL)
+        g_platform.arm_arch     == NULL &&
+        g_platform.amd_arch     == NULL)
     {
         variorum_error_handler("No architectures detected", VARIORUM_ERROR_RUNTIME,
                                getenv("HOSTNAME"), __FILE__, __FUNCTION__,
@@ -322,7 +331,11 @@ int variorum_set_func_ptrs()
 #ifdef VARIORUM_WITH_ARM
     err = set_arm_func_ptrs();
 #endif
+#ifdef VARIORUM_WITH_AMD
+    err = set_amd_func_ptrs();
+#endif
     return err;
+
 }
 
 ////setfixedcounters = fixed_ctr0,

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -210,6 +210,26 @@ struct platform
     /// @return Error code.
     int (*variorum_print_available_frequencies)(void);
 
+    /// @brief Function pointer to print energy for all cores and sockets.
+    ///
+    /// @return Error code.
+    int (*variorum_print_energy)(void);
+
+    /// @brief Function pointer to print boostlimit of all cores.
+    ///
+    /// @return Error code.
+    int (*variorum_print_boostlimit)(void);
+
+    /// @brief Function pointer to set and verify per core boostlimit.
+    ///
+    /// @return Error code.
+    int (*variorum_set_and_verify_core_boostlimit)(int core, unsigned int boostlimit);
+
+    /// @brief Function pointer to set per socket boostlimit.
+    ///
+    /// @return Error code.
+    int (*variorum_set_socket_boostlimit)(int socket, unsigned int boostlimit);
+
     /******************************/
     /* Platform-Specific Topology */
     /******************************/

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1100,3 +1100,115 @@ int variorum_print_available_frequencies(void)
     }
     return err;
 }
+
+int variorum_print_energy(void)
+{
+    int err = 0;
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    if (g_platform.variorum_print_energy == NULL)
+    {
+        variorum_error_handler("Feature not yet implemented or is not supported",
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               __FUNCTION__, __LINE__);
+        return 0;
+    }
+    err = g_platform.variorum_print_energy();
+    if (err)
+    {
+        return -1;
+    }
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
+
+int variorum_print_boostlimit(void)
+{
+    int err = 0;
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    if (g_platform.variorum_print_boostlimit == NULL)
+    {
+        variorum_error_handler("Feature not yet implemented or is not supported",
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               __FUNCTION__, __LINE__);
+        return 0;
+    }
+    err = g_platform.variorum_print_boostlimit();
+    if (err)
+    {
+        return -1;
+    }
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
+
+int variorum_set_and_verify_core_boostlimit(int core, unsigned int boostlimit)
+{
+    int err = 0;
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    if (g_platform.variorum_set_and_verify_core_boostlimit == NULL)
+    {
+        variorum_error_handler("Feature not yet implemented or is not supported",
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               __FUNCTION__, __LINE__);
+        return 0;
+    }
+    err = g_platform.variorum_set_and_verify_core_boostlimit(core, boostlimit);
+    if (err)
+    {
+        return -1;
+    }
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
+
+int variorum_set_socket_boostlimit(int socket, unsigned int boostlimit)
+{
+    int err = 0;
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    if (g_platform.variorum_set_socket_boostlimit == NULL)
+    {
+        variorum_error_handler("Feature not yet implemented or is not supported",
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                               __FUNCTION__, __LINE__);
+        return 0;
+    }
+    err = g_platform.variorum_set_socket_boostlimit(socket, boostlimit);
+    if (err)
+    {
+        return -1;
+    }
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -171,6 +171,26 @@ int variorum_print_gpu_utilization(void);
 /// @return Error code.
 int variorum_print_available_frequencies(void);
 
+/// @brief Print if core and socket energy is available.
+///
+/// @return Error code.
+int variorum_print_energy(void);
+
+/// @brief Print boostlimit(in MHz) of a all cores.
+///
+/// @return Error code.
+int variorum_print_boostlimit(void);
+
+/// @brief Set and Verify the specific core boostlimit
+///
+/// @return Error code.
+int variorum_set_and_verify_core_boostlimit(int core, unsigned int boostlimit);
+
+/// @brief Set the boostlimit of specific socket
+///
+/// @return Error code.
+int variorum_set_socket_boostlimit(int socket, unsigned int boostlimit);
+
 /***************************/
 /* Enable/Disable Features */
 /***************************/


### PR DESCRIPTION
This patch set is based on AMD's open-sourced E-SMI library
support AMD Family 19h, models 0~fh and 30~3fh

    * Provides function pointers for power sensors
    * Add function pointers for boostlimit and energy reporting
    * Add support for batch read for core energy counters using msr-safe
    * Added AMD documentation
