### PR TITLE
Add getopt to examples

### DIFF
--- a/src/examples/variorum-cap-and-verify-node-power-limit-example.c
+++ b/src/examples/variorum-cap-and-verify-node-power-limit-example.c
@@ -3,27 +3,48 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
-    /* 500 W is based on minimum power on IBM Witherspoon */
-    int node_pow_lim_watts = 500;
+    int node_pow_lim_watts;
 
-    if (argc == 1)
+    const char *usage = "%s [--help | -h] -l power_lim_watts\n";
+
+    if (argc == 1 || (argc > 1 && (
+                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
+                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
     {
-        printf("No power limit specified...using default limit of 500W.\n");
-        node_pow_lim_watts = 500;
+        printf(usage, argv[0]);
+        return 0;
     }
-    else if (argc == 2)
+    if (argc <= 2)
     {
-        node_pow_lim_watts = atoi(argv[1]);
-        printf("Capping node to %dW.\n", node_pow_lim_watts);
+        printf(usage, argv[0]);
+        return 1;
     }
+
+    int opt;
+    while ((opt = getopt(argc, argv, "l:")) != -1)
+    {
+        switch (opt)
+        {
+            case 'l':
+                node_pow_lim_watts = atoi(optarg);
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
+
+    printf("Capping node to %dW.\n", node_pow_lim_watts);
 
     ret = variorum_cap_and_verify_node_power_limit(node_pow_lim_watts);
     if (ret != 0)

--- a/src/examples/variorum-cap-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-cap-best-effort-node-power-limit-example.c
@@ -3,8 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <variorum.h>
 
@@ -14,17 +16,36 @@ int main(int argc, char **argv)
     // 500W is based on minimum power on IBM Witherspoon
     int node_pow_lim_watts = 500;
 
-    if (argc == 1)
+    const char *usage = "%s [--help | -h] -l power_lim_watts\n";
+
+    if (argc == 1 || (argc > 1 && (
+                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
+                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
     {
-        printf("Please specify an input value in Watts for correctness.\n");
-        printf("Cannot set defaults due to architecture dependence.\n");
+        printf(usage, argv[0]);
         return 0;
     }
-    else if (argc == 2)
+    if (argc <= 2)
     {
-        node_pow_lim_watts = atoi(argv[1]);
-        printf("Capping node to %dW.\n", node_pow_lim_watts);
+        printf(usage, argv[0]);
+        return 1;
     }
+
+    int opt;
+    while ((opt = getopt(argc, argv, "l:")) != -1)
+    {
+        switch (opt)
+        {
+            case 'l':
+                node_pow_lim_watts = atoi(optarg);
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
+
+    printf("Capping node to %dW.\n", node_pow_lim_watts);
 
     ret = variorum_cap_best_effort_node_power_limit(node_pow_lim_watts);
     if (ret != 0)

--- a/src/examples/variorum-cap-each-core-frequency-limit-example.c
+++ b/src/examples/variorum-cap-each-core-frequency-limit-example.c
@@ -3,8 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <variorum.h>
 
@@ -13,13 +15,35 @@ int main(int argc, char **argv)
     int ret;
     int cpu_freq_mhz;
 
-    if (argc == 1)
+    const char *usage = "%s [--help | -h] -f cpu_freq_mhz\n";
+
+    if (argc == 1 || (argc > 1 && (
+                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
+                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
     {
-        printf("%s <cpu_freq_mhz>\n", argv[0]);
+        printf(usage, argv[0]);
+        return 0;
+    }
+    if (argc <= 2)
+    {
+        printf(usage, argv[0]);
         return 1;
     }
 
-    cpu_freq_mhz = atoi(argv[1]);
+    int opt;
+    while ((opt = getopt(argc, argv, "f:")) != -1)
+    {
+        switch (opt)
+        {
+            case 'f':
+                cpu_freq_mhz = atoi(optarg);
+                break;
+            default:
+                printf(usage, argv[0]);
+                return -1;
+        }
+    }
+
     printf("Capping each CPU to %d MHz.\n", cpu_freq_mhz);
 
     ret = variorum_cap_each_core_frequency_limit(cpu_freq_mhz);

--- a/src/examples/variorum-cap-gpu-power-ratio-example.c
+++ b/src/examples/variorum-cap-gpu-power-ratio-example.c
@@ -3,26 +3,48 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
-    /*100 % is based on IBM Witherspoon default */
-    int gpu_power_ratio_pct = 100;
+    int gpu_power_ratio_pct;
 
-    if (argc == 1)
+    const char *usage = "%s [--help | -h] -r gpu_power_ratio_pct\n";
+
+    if (argc == 1 || (argc > 1 && (
+                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
+                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
     {
-        printf("No GPU power ratio specified...using default ratio of 100 percent.\n");
+        printf(usage, argv[0]);
+        return 0;
     }
-    else if (argc == 2)
+    if (argc <= 2)
     {
-        gpu_power_ratio_pct = atoi(argv[1]);
-        printf("Capping GPU power ratio to %d percent.\n", gpu_power_ratio_pct);
+        printf(usage, argv[0]);
+        return 1;
     }
+
+    int opt;
+    while ((opt = getopt(argc, argv, "r:")) != -1)
+    {
+        switch (opt)
+        {
+            case 'r':
+                gpu_power_ratio_pct = atoi(optarg);
+                break;
+            default:
+                printf(usage, argv[0]);
+                return -1;
+        }
+    }
+
+    printf("Capping GPU power ratio to %d percent.\n", gpu_power_ratio_pct);
 
     ret = variorum_cap_gpu_power_ratio(gpu_power_ratio_pct);
     if (ret != 0)

--- a/src/examples/variorum-cap-socket-clock-speed-example.c
+++ b/src/examples/variorum-cap-socket-clock-speed-example.c
@@ -3,8 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <variorum.h>
 
@@ -14,14 +16,38 @@ int main(int argc, char **argv)
     int cpu_id;
     int cpu_freq_mhz;
 
-    if (argc != 3)
+    const char *usage = "%s [--help | -h] -i socket_id -f cpu_freq_mhz\n";
+
+    if (argc == 1 || (argc > 1 && (
+                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
+                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
     {
-        printf("%s <socket_id> <cpu_freq_mhz>\n", argv[0]);
+        printf(usage, argv[0]);
+        return 0;
+    }
+    if (argc <= 2)
+    {
+        printf(usage, argv[0]);
         return 1;
     }
 
-    cpu_id = atoi(argv[1]);
-    cpu_freq_mhz = atoi(argv[2]);
+    int opt;
+    while ((opt = getopt(argc, argv, "i:f:")) != -1)
+    {
+        switch (opt)
+        {
+            case 'i':
+                cpu_id = atoi(optarg);
+                break;
+            case 'f':
+                cpu_freq_mhz = atoi(optarg);
+                break;
+            default:
+                printf(usage, argv[0]);
+                return -1;
+        }
+    }
+
     printf("Capping CPU %d to %d MHz.\n", cpu_id, cpu_freq_mhz);
 
     ret = variorum_cap_socket_frequency(cpu_id, cpu_freq_mhz);

--- a/src/examples/variorum-cap-socket-power-limits-example.c
+++ b/src/examples/variorum-cap-socket-power-limits-example.c
@@ -3,30 +3,48 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
-    int pkg_pow_lim_watts = 100;
+    int pkg_pow_lim_watts;
 
-    if (argc == 1)
+    const char *usage = "%s [--help | -h] -l power_lim_watts\n";
+
+    if (argc == 1 || (argc > 1 && (
+                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
+                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
     {
-        printf("No power limit specified...using default limit of 100W.\n");
+        printf(usage, argv[0]);
+        return 0;
     }
-    else if (argc == 2)
+    if (argc <= 2)
     {
-        pkg_pow_lim_watts = atoi(argv[1]);
-        printf("Capping each socket to %dW.\n", pkg_pow_lim_watts);
+        printf(usage, argv[0]);
+        return 1;
     }
-    else
+
+    int opt;
+    while ((opt = getopt(argc, argv, "l:")) != -1)
     {
-        printf("Usage: variorum_cap_socket_power_limit [limit in watts]\n");
-        exit(0);
+        switch (opt)
+        {
+            case 'l':
+                pkg_pow_lim_watts = atoi(optarg);
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
     }
+
+    printf("Capping each socket to %dW.\n", pkg_pow_lim_watts);
 
     ret = variorum_cap_each_socket_power_limit(pkg_pow_lim_watts);
     if (ret != 0)


### PR DESCRIPTION
Use getopt to better parse arguments passed to some of the examples.