### PR TITLE
Reporting power domain information through JSON

### DIFF
--- a/src/docs/sphinx/VariorumAPI.rst
+++ b/src/docs/sphinx/VariorumAPI.rst
@@ -29,8 +29,8 @@ CPU, memory, GPU (when available), and total node power. The total node power
 is estimated as a summation of available domains if it is not directly reported
 by the underlying architecture (such as Intel).
 
-The ``variorum_get_node_power_json(json_t *)`` includes 
-the JSON object with the following keys:
+The ``variorum_get_node_power_json(json_t *)`` includes the JSON object with
+the following keys:
 
 * hostname (string value)
 * timestamp (integer value)
@@ -65,8 +65,8 @@ The API for querying power domains allows users to query Variorum to obtain
 information about domains that can be measured and controlled on a certain
 architecture. It also includes information on the units of measurement
 and control, as well as information on the minimum and maximum values for
-setting the controls (control_range). If a certain domain is unsupported, 
-it is marked as such. 
+setting the controls (control_range). If a certain domain is unsupported, it is
+marked as such.
 
 The query API, ``variorum_get_node_power_domain_info_json(json_t *)``, accepts
 a JSON object by reference and  includes the following vendor-neutral keys:
@@ -75,10 +75,10 @@ a JSON object by reference and  includes the following vendor-neutral keys:
 * timestamp (integer value)
 * measurement (comma-separated string value)
 * control (comma-separated string value)
-* unsupported (comma-separated string value)   
+* unsupported (comma-separated string value)
 * measurement_units (comma-separated string value)
-* control_units (comma-separated string value)  
-* control_range (comma-separated string value)  
+* control_units (comma-separated string value)
+* control_range (comma-separated string value)
 
 ***************************
  Best Effort Power Capping

--- a/src/docs/sphinx/VariorumAPI.rst
+++ b/src/docs/sphinx/VariorumAPI.rst
@@ -18,21 +18,26 @@ The top-level API for Variorum consists of the following calls:
 
 The current JSON API depends on the JANSSON-C library and has a vendor-neutral
 format. The API has been tested on Intel Broadwell and IBM Witherspoon
-architectures. The API to obtain node power has the following format. It takes
+architectures, and will be supported on other platforms shortly.
+
+
+Obtaining Power Consumption:
+
+The API to obtain node power has the following format. It takes
 a ``json_t`` object by reference as input, and populates this JSON object with
 CPU, memory, GPU (when available), and total node power. The total node power
 is estimated as a summation of available domains if it is not directly reported
 by the underlying architecture (such as Intel).
 
-Currently, only ``variorum_get_node_power_json(json_t *)`` is supported, and
-the JSON object has the following keys:
+The ``variorum_get_node_power_json(json_t *)`` includes 
+the JSON object with the following keys:
 
 * hostname (string value)
 * timestamp (integer value)
 * power_node (real value)
-* power_cpu_socket_* (real value)
-* power_mem_socket_* (real value)
-* power_gpu_socket_* (real value)
+* power_cpu_watts_socket* (real value)
+* power_mem_watts_socket* (real value)
+* power_gpu_watts_socket* (real value)
 
 The "*" here refers to Socket ID. While more than one socket is supported, our
 test systems had only 2 sockets. Note that on IBM Witherspoon platform, only
@@ -52,6 +57,28 @@ integration in the JSON object will allow for this information to report
 individual GPU power as well as total GPU power per socket with a
 cross-architectural build, similar to Variorum's ``variorum_get_node_power()``
 API.
+
+
+Querying Power Domains:
+
+The API for querying power domains allows users to query Variorum to obtain
+information about domains that can be measured and controlled on a certain
+architecture. It also includes information on the units of measurement
+and control, as well as information on the minimum and maximum values for
+setting the controls (control_range). If a certain domain is unsupported, 
+it is marked as such. 
+
+The query API, ``variorum_get_node_power_domain_info_json(json_t *)``, accepts
+a JSON object by reference and  includes the following vendor-neutral keys:
+
+* hostname (string value)
+* timestamp (integer value)
+* measurement (comma-separated string value)
+* control (comma-separated string value)
+* unsupported (comma-separated string value)   
+* measurement_units (comma-separated string value)
+* control_units (comma-separated string value)  
+* control_range (comma-separated string value)  
 
 ***************************
  Best Effort Power Capping

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -17,6 +17,7 @@ set(BASIC_EXAMPLES
     variorum-disable-turbo-example
     variorum-enable-turbo-example
     variorum-get-node-power-json-example
+    variorum-get-node-power-domain-info-json-example
     variorum-monitoring-to-file-example
     variorum-poll-power-to-file-example
     variorum-poll-power-to-stdout-example

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -1,4 +1,4 @@
-// Copyright 2019 Lawrence Livermore National Security, LLC and other
+// Copyright 2021 Lawrence Livermore National Security, LLC and other
 // Variorum Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: MIT
@@ -14,8 +14,8 @@ int main(void)
     json_t *my_domain_obj = NULL;
     char *s = NULL;
 
-    my_domain_obj =
-        json_object(); // Create JSON object and pass to variorum API as reference.
+    // Create JSON object and pass to variorum API as reference.
+    my_domain_obj = json_object();
     ret = variorum_get_node_power_domain_info_json(my_domain_obj);
     if (ret != 0)
     {

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -1,0 +1,29 @@
+// Copyright 2019 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+
+#include <variorum.h>
+#include <jansson.h>
+
+int main(void)
+{
+    int ret;
+    json_t *my_domain_obj = NULL;
+    char *s = NULL;
+
+    my_domain_obj =
+        json_object(); // Create JSON object and pass to variorum API as reference.
+    ret = variorum_get_node_power_domain_info_json(my_domain_obj);
+    if (ret != 0)
+    {
+        printf("First run: JSON get node power domain information failed!\n");
+    }
+    s = json_dumps(my_domain_obj, 0);
+    puts(s);
+
+    json_decref(my_domain_obj);
+    return ret;
+}

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -458,12 +458,9 @@ int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    unsigned nsockets;
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
-
-    variorum_get_topology(&nsockets, NULL, NULL);
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -454,5 +454,5 @@ int p9_get_node_power_json(json_t *get_power_obj)
 
 int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
 {
-    
+
 }

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -454,5 +454,27 @@ int p9_get_node_power_json(json_t *get_power_obj)
 
 int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
 {
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
 
+    unsigned nsockets;
+    char hostname[1024];
+    struct timeval tv;
+    uint64_t ts;
+
+    variorum_get_topology(&nsockets, NULL, NULL);
+
+    gethostname(hostname, 1024);
+    gettimeofday(&tv, NULL);
+    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
+    json_object_set_new(get_domain_obj, "host", json_string(hostname));
+    json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));
+
+    json_object_set_new(get_domain_obj, "power_node", json_string("C (Min 500 W, Max 3050 W)"));
+    json_object_set_new(get_domain_obj, "power_cpu", json_string("M"));
+    json_object_set_new(get_domain_obj, "power_mem", json_string("M"));
+    json_object_set_new(get_domain_obj, "power_gpu", json_string("C (Shifting Ratio 0-100%"));
+
+    return 0;
 }

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -479,7 +479,7 @@ int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "control_units",
                         json_string("[Watts, Percentage]"));
     json_object_set_new(get_domain_obj, "control_range",
-                        json_string("[(500,3050), (0-100)]")); 
+                        json_string("[(500,3050), (0-100)]"));
 
     return 0;
 }

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -468,12 +468,18 @@ int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "host", json_string(hostname));
     json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));
 
-    json_object_set_new(get_domain_obj, "power_node",
-                        json_string("C (Min 500 W, Max 3050 W)"));
-    json_object_set_new(get_domain_obj, "power_cpu", json_string("M"));
-    json_object_set_new(get_domain_obj, "power_mem", json_string("M"));
-    json_object_set_new(get_domain_obj, "power_gpu",
-                        json_string("C (Shifting Ratio 0-100%"));
+    json_object_set_new(get_domain_obj, "measurement",
+                        json_string("[power_node, power_cpu, power_mem, power_gpu]"));
+    json_object_set_new(get_domain_obj, "control",
+                        json_string("[power_node, power_gpu]"));
+    json_object_set_new(get_domain_obj, "unsupported",
+                        json_string("[]"));
+    json_object_set_new(get_domain_obj, "measurement_units",
+                        json_string("[Watts, Watts, Watts, Watts]"));
+    json_object_set_new(get_domain_obj, "control_units",
+                        json_string("[Watts, Percentage]"));
+    json_object_set_new(get_domain_obj, "control_range",
+                        json_string("[(500,3050), (0-100)]")); 
 
     return 0;
 }

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -479,7 +479,7 @@ int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "control_units",
                         json_string("[Watts, Percentage]"));
     json_object_set_new(get_domain_obj, "control_range",
-                        json_string("[(500,3050), (0-100)]"));
+                        json_string("[{"min": 500, "max": 3050}, {"min": 0, "max": 100}]"));
 
     return 0;
 }

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -451,3 +451,8 @@ int p9_get_node_power_json(json_t *get_power_obj)
     close(fd);
     return 0;
 }
+
+int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
+{
+    
+}

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -479,7 +479,7 @@ int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "control_units",
                         json_string("[Watts, Percentage]"));
     json_object_set_new(get_domain_obj, "control_range",
-                        json_string("[{"min": 500, "max": 3050}, {"min": 0, "max": 100}]"));
+                        json_string("[{min: 500, max: 3050}, {min: 0, max: 100}]"));
 
     return 0;
 }

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -471,10 +471,12 @@ int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "host", json_string(hostname));
     json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));
 
-    json_object_set_new(get_domain_obj, "power_node", json_string("C (Min 500 W, Max 3050 W)"));
+    json_object_set_new(get_domain_obj, "power_node",
+                        json_string("C (Min 500 W, Max 3050 W)"));
     json_object_set_new(get_domain_obj, "power_cpu", json_string("M"));
     json_object_set_new(get_domain_obj, "power_mem", json_string("M"));
-    json_object_set_new(get_domain_obj, "power_gpu", json_string("C (Shifting Ratio 0-100%"));
+    json_object_set_new(get_domain_obj, "power_gpu",
+                        json_string("C (Shifting Ratio 0-100%"));
 
     return 0;
 }

--- a/src/variorum/IBM/Power9.h
+++ b/src/variorum/IBM/Power9.h
@@ -24,4 +24,6 @@ int p9_monitoring(FILE *output);
 
 int p9_get_node_power_json(json_t *get_power_obj);
 
+int p9_get_node_power_domain_info_json(json_t *get_domain_obj);
+
 #endif

--- a/src/variorum/IBM/config_ibm.c
+++ b/src/variorum/IBM/config_ibm.c
@@ -36,7 +36,7 @@ int set_ibm_func_ptrs(void)
             p9_cap_and_verify_node_power_limit;
         g_platform.variorum_monitoring = p9_monitoring;
         g_platform.variorum_get_node_power_json = p9_get_node_power_json;
-        g_platform.variorum_get_node_power_domain_info_json = 
+        g_platform.variorum_get_node_power_domain_info_json =
             p9_get_node_power_domain_info_json;
     }
     else

--- a/src/variorum/IBM/config_ibm.c
+++ b/src/variorum/IBM/config_ibm.c
@@ -36,6 +36,8 @@ int set_ibm_func_ptrs(void)
             p9_cap_and_verify_node_power_limit;
         g_platform.variorum_monitoring = p9_monitoring;
         g_platform.variorum_get_node_power_json = p9_get_node_power_json;
+        g_platform.variorum_get_node_power_domain_info_json = 
+            p9_get_node_power_domain_info_json;
     }
     else
     {

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -422,6 +422,17 @@ int fm_06_4f_get_node_power_json(json_t *get_power_obj)
     return 0;
 }
 
+int fm_06_4f_get_node_power_domain_info_json(json_t *get_domain_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_get_power_domain_info(get_domain_obj);
+
+    return 0;
+}
+
 int fm_06_4f_cap_best_effort_node_power_limit(int node_limit)
 {
 #ifdef VARIORUM_LOG

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -107,6 +107,8 @@ int fm_06_4f_monitoring(FILE *output);
 
 int fm_06_4f_get_node_power_json(json_t *get_power_obj);
 
+int fm_06_4f_get_node_power_domain_info_json(json_t *get_domain_obj);
+
 int fm_06_4f_cap_best_effort_node_power_limit(int node_power_limit);
 
 int fm_06_4f_get_frequencies(void);

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -167,6 +167,8 @@ int set_intel_func_ptrs(void)
         //    fm_06_4f_cap_frequency;
         g_platform.variorum_get_node_power_json =
             fm_06_4f_get_node_power_json;
+        g_platform.variorum_get_node_power_domain_info_json =
+            fm_06_4f_get_node_power_domain_info_json;
         g_platform.variorum_cap_best_effort_node_power_limit =
             fm_06_4f_cap_best_effort_node_power_limit;
         g_platform.variorum_print_available_frequencies =

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1026,8 +1026,8 @@ void json_get_power_domain_info(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "control_units",
                         json_string("[Watts, Watts]"));
     json_object_set_new(get_domain_obj, "control_range",
-                        json_string("[(65,135), (15,30)]")); 
-  
+                        json_string("[(65,135), (15,30)]"));
+
     // Need to figure out a way to specify capping limits by reading MSRs.
     // If we have an NVIDIA + Intel build, the GPU info should be updated.
 

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1015,13 +1015,21 @@ void json_get_power_domain_info(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "host", json_string(hostname));
     json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));
 
-    json_object_set_new(get_domain_obj, "power_node", json_string("N"));
-
-    // Need to figure out a way to specify capping limits.
-    json_object_set_new(get_domain_obj, "power_cpu", json_string("C"));
-    json_object_set_new(get_domain_obj, "power_mem", json_string("C"));
-    // If we have an NVIDIA + Intel build, the following should be updated.
-    json_object_set_new(get_domain_obj, "power_gpu", json_string("N"));
+    json_object_set_new(get_domain_obj, "measurement",
+                        json_string("[power_cpu, power_mem]"));
+    json_object_set_new(get_domain_obj, "control",
+                        json_string("[power_cpu, power_mem]"));
+    json_object_set_new(get_domain_obj, "unsupported",
+                        json_string("[]"));
+    json_object_set_new(get_domain_obj, "measurement_units",
+                        json_string("[Watts, Watts]"));
+    json_object_set_new(get_domain_obj, "control_units",
+                        json_string("[Watts, Watts]"));
+    json_object_set_new(get_domain_obj, "control_range",
+                        json_string("[(65,135), (15,30)]")); 
+  
+    // Need to figure out a way to specify capping limits by reading MSRs.
+    // If we have an NVIDIA + Intel build, the GPU info should be updated.
 
     return 0;
 }

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1002,6 +1002,31 @@ void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit,
 }
 
 
+void json_get_power_domain_info(json_t *get_domain_obj)
+{
+
+   char hostname[1024];                                                           
+    struct timeval tv;                                                             
+    uint64_t ts;                                                                   
+                                                                                   
+    gethostname(hostname, 1024);                                                   
+    gettimeofday(&tv, NULL);                                                       
+    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;                               
+    json_object_set_new(get_domain_obj, "host", json_string(hostname));            
+    json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));            
+                                                                                   
+    json_object_set_new(get_domain_obj, "power_node",                              
+                        json_string("N"));                 
+   
+    // Need to figure out a way to specify capping limits.
+    json_object_set_new(get_domain_obj, "power_cpu", json_string("C"));            
+    json_object_set_new(get_domain_obj, "power_mem", json_string("C"));
+    // If we have an NVIDIA + Intel build, the following should be updated.            
+    json_object_set_new(get_domain_obj, "power_gpu", json_string("N");                  
+                                                                                   
+    return 0;                                                                       
+} 
+
 //int print_rapl_data(FILE *writedest)
 //{
 //    static int init = 0;

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1005,27 +1005,27 @@ void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit,
 void json_get_power_domain_info(json_t *get_domain_obj)
 {
 
-   char hostname[1024];                                                           
-    struct timeval tv;                                                             
-    uint64_t ts;                                                                   
-                                                                                   
-    gethostname(hostname, 1024);                                                   
-    gettimeofday(&tv, NULL);                                                       
-    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;                               
-    json_object_set_new(get_domain_obj, "host", json_string(hostname));            
-    json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));            
-                                                                                   
-    json_object_set_new(get_domain_obj, "power_node",                              
-                        json_string("N"));                 
-   
+    char hostname[1024];
+    struct timeval tv;
+    uint64_t ts;
+
+    gethostname(hostname, 1024);
+    gettimeofday(&tv, NULL);
+    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
+    json_object_set_new(get_domain_obj, "host", json_string(hostname));
+    json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));
+
+    json_object_set_new(get_domain_obj, "power_node",
+                        json_string("N"));
+
     // Need to figure out a way to specify capping limits.
-    json_object_set_new(get_domain_obj, "power_cpu", json_string("C"));            
+    json_object_set_new(get_domain_obj, "power_cpu", json_string("C"));
     json_object_set_new(get_domain_obj, "power_mem", json_string("C"));
-    // If we have an NVIDIA + Intel build, the following should be updated.            
-    json_object_set_new(get_domain_obj, "power_gpu", json_string("N");                  
-                                                                                   
-    return 0;                                                                       
-} 
+    // If we have an NVIDIA + Intel build, the following should be updated.
+    json_object_set_new(get_domain_obj, "power_gpu", json_string("N");
+
+                        return 0;
+}
 
 //int print_rapl_data(FILE *writedest)
 //{

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1026,7 +1026,7 @@ void json_get_power_domain_info(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "control_units",
                         json_string("[Watts, Watts]"));
     json_object_set_new(get_domain_obj, "control_range",
-                        json_string("[{"min": 65, "max": 135}, {"min": 15, "max": 30}]");
+                        json_string("[{min: 65, max: 135}, {min: 15, max: 30}]");
 
                         // Need to figure out a way to specify capping limits by reading MSRs.
                         // If we have an NVIDIA + Intel build, the GPU info should be updated.

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1015,16 +1015,15 @@ void json_get_power_domain_info(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "host", json_string(hostname));
     json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));
 
-    json_object_set_new(get_domain_obj, "power_node",
-                        json_string("N"));
+    json_object_set_new(get_domain_obj, "power_node", json_string("N"));
 
     // Need to figure out a way to specify capping limits.
     json_object_set_new(get_domain_obj, "power_cpu", json_string("C"));
     json_object_set_new(get_domain_obj, "power_mem", json_string("C"));
     // If we have an NVIDIA + Intel build, the following should be updated.
-    json_object_set_new(get_domain_obj, "power_gpu", json_string("N");
+    json_object_set_new(get_domain_obj, "power_gpu", json_string("N"));
 
-                        return 0;
+    return 0;
 }
 
 //int print_rapl_data(FILE *writedest)

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1026,7 +1026,7 @@ void json_get_power_domain_info(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "control_units",
                         json_string("[Watts, Watts]"));
     json_object_set_new(get_domain_obj, "control_range",
-                        json_string("[{min: 65, max: 135}, {min: 15, max: 30}]");
+                        json_string("[{min: 65, max: 135}, {min: 15, max: 30}]"));
 
                         // Need to figure out a way to specify capping limits by reading MSRs.
                         // If we have an NVIDIA + Intel build, the GPU info should be updated.

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1004,7 +1004,6 @@ void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit,
 
 void json_get_power_domain_info(json_t *get_domain_obj)
 {
-
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1026,10 +1026,10 @@ void json_get_power_domain_info(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "control_units",
                         json_string("[Watts, Watts]"));
     json_object_set_new(get_domain_obj, "control_range",
-                        json_string("[{"min": 65, "max": 135}, {"min": 15, "max": 30}]"));
+                        json_string("[{"min": 65, "max": 135}, {"min": 15, "max": 30}]");
 
-    // Need to figure out a way to specify capping limits by reading MSRs.
-    // If we have an NVIDIA + Intel build, the GPU info should be updated.
+                        // Need to figure out a way to specify capping limits by reading MSRs.
+                        // If we have an NVIDIA + Intel build, the GPU info should be updated.
 }
 
 //int print_rapl_data(FILE *writedest)

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1028,8 +1028,8 @@ void json_get_power_domain_info(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "control_range",
                         json_string("[{min: 65, max: 135}, {min: 15, max: 30}]"));
 
-                        // Need to figure out a way to specify capping limits by reading MSRs.
-                        // If we have an NVIDIA + Intel build, the GPU info should be updated.
+    // Need to figure out a way to specify capping limits by reading MSRs.
+    // If we have an NVIDIA + Intel build, the GPU info should be updated.
 }
 
 //int print_rapl_data(FILE *writedest)

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1026,12 +1026,10 @@ void json_get_power_domain_info(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "control_units",
                         json_string("[Watts, Watts]"));
     json_object_set_new(get_domain_obj, "control_range",
-                        json_string("[(65,135), (15,30)]"));
+                        json_string("[{"min": 65, "max": 135}, {"min": 15, "max": 30}]"));
 
     // Need to figure out a way to specify capping limits by reading MSRs.
     // If we have an NVIDIA + Intel build, the GPU info should be updated.
-
-    return 0;
 }
 
 //int print_rapl_data(FILE *writedest)

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -224,7 +224,7 @@ void json_get_power_data(json_t *get_power_obj,
                          off_t msr_pkg_energy_status,
                          off_t msr_dram_energy_status);
 
-void json_get_power_domain_info(json_t *get_domain_obj); 
+void json_get_power_domain_info(json_t *get_domain_obj);
 
 /// @brief Store the RAPL data on the heap.
 ///

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -224,6 +224,8 @@ void json_get_power_data(json_t *get_power_obj,
                          off_t msr_pkg_energy_status,
                          off_t msr_dram_energy_status);
 
+void json_get_power_domain_info(json_t *get_domain_obj); 
+
 /// @brief Store the RAPL data on the heap.
 ///
 /// @param [out] data Pointer to measurements of energy, time, and power data

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -298,6 +298,7 @@ void variorum_init_func_ptrs()
     g_platform.variorum_cap_each_core_frequency = NULL;
     g_platform.variorum_monitoring = NULL;
     g_platform.variorum_get_node_power_json = NULL;
+    g_platform.variorum_get_node_power_domain_info_json = NULL;
     g_platform.variorum_print_available_frequencies = NULL;
 }
 

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -205,6 +205,11 @@ struct platform
     /// @return Error code.
     int (*variorum_get_node_power_json)(json_t *get_power_obj);
 
+    /// @brief Function pointer to get JSON object for power domain information.
+    ///
+    /// @return Error code.
+    int (*variorum_get_node_power_domain_info_json)(json_t *get_domain_obj);
+
     /// @brief Function pointer to get list of available frequencies.
     ///
     /// @return Error code.

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1065,6 +1065,43 @@ int variorum_get_node_power_json(json_t *get_power_obj)
     return err;
 }
 
+int variorum_get_node_power_domain_info_json(json_t *get_domain_obj)                             
+{                                                                                   
+    int err = 0;                                                                    
+#ifdef VARIORUM_LOG                                                                 
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);                         
+#else                                                                               
+    err = variorum_enter();                                                         
+#endif                                                                              
+    if (err)                                                                        
+    {                                                                               
+        return -1;                                                                  
+    }                                                                               
+    if (g_platform.variorum_get_node_power_domain_info_json == NULL)                            
+    {                                                                               
+        variorum_error_handler("Feature not yet implemented or is not supported",
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,              
+                               getenv("HOSTNAME"), __FILE__,                        
+                               __FUNCTION__, __LINE__);                             
+        return 0;                                                                   
+    }                                                                               
+    err = g_platform.variorum_get_node_power_domain_info_json(get_domain_obj);                   
+    if (err)                                                                        
+    {                                                                               
+        return -1;                                                                  
+    }                                                                               
+#ifdef VARIORUM_LOG                                                                 
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);                          
+#else                                                                               
+    err = variorum_exit();                                                          
+#endif                                                                              
+    if (err)                                                                        
+    {                                                                               
+        return -1;                                                                  
+    }                                                                               
+    return err;                                                                     
+}           
+
 int variorum_print_available_frequencies(void)
 {
     int err = 0;

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1065,42 +1065,42 @@ int variorum_get_node_power_json(json_t *get_power_obj)
     return err;
 }
 
-int variorum_get_node_power_domain_info_json(json_t *get_domain_obj)                             
-{                                                                                   
-    int err = 0;                                                                    
-#ifdef VARIORUM_LOG                                                                 
-    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);                         
-#else                                                                               
-    err = variorum_enter();                                                         
-#endif                                                                              
-    if (err)                                                                        
-    {                                                                               
-        return -1;                                                                  
-    }                                                                               
-    if (g_platform.variorum_get_node_power_domain_info_json == NULL)                            
-    {                                                                               
+int variorum_get_node_power_domain_info_json(json_t *get_domain_obj)
+{
+    int err = 0;
+#ifdef VARIORUM_LOG
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_enter();
+#endif
+    if (err)
+    {
+        return -1;
+    }
+    if (g_platform.variorum_get_node_power_domain_info_json == NULL)
+    {
         variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,              
-                               getenv("HOSTNAME"), __FILE__,                        
-                               __FUNCTION__, __LINE__);                             
-        return 0;                                                                   
-    }                                                                               
-    err = g_platform.variorum_get_node_power_domain_info_json(get_domain_obj);                   
-    if (err)                                                                        
-    {                                                                               
-        return -1;                                                                  
-    }                                                                               
-#ifdef VARIORUM_LOG                                                                 
-    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);                          
-#else                                                                               
-    err = variorum_exit();                                                          
-#endif                                                                              
-    if (err)                                                                        
-    {                                                                               
-        return -1;                                                                  
-    }                                                                               
-    return err;                                                                     
-}           
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
+                               __FUNCTION__, __LINE__);
+        return 0;
+    }
+    err = g_platform.variorum_get_node_power_domain_info_json(get_domain_obj);
+    if (err)
+    {
+        return -1;
+    }
+#ifdef VARIORUM_LOG
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+#else
+    err = variorum_exit();
+#endif
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
 
 int variorum_print_available_frequencies(void)
 {

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -192,6 +192,11 @@ int variorum_disable_turbo(void);
 /// @return Error code.
 int variorum_get_node_power_json(json_t *get_power_obj);
 
+/// @brief Populate json_t object parameter with measurable power domains.
+///
+/// @return Error code.
+int variorum_get_node_power_domain_info_json(json_t *get_domain_obj);
+
 /***********/
 /* Testing */
 /***********/


### PR DESCRIPTION
Work in progress, not ready for review. 


Sep 8, 2021. 
The following is old format: See comments for the new format.

=============
Simple interface for power domain info. Legend is as follows: 
- M = can be measured, 
- C = can be measured and capped (along with acceptable values/range?), 
- N = cannot be measured or capped (unsupported)

JSON object is similar to the previous one, power_cpu, power_gpu, power_mem, power_node. 

This doesn't capture other features such as thermals, frequencies, energy -- that should be its own JSON query API.
Current example on Lassen has the following format: 

```
./variorum-get-node-power-domain-info-json-example 
{"host": "lassen35", "timestamp": 1630532716890872, "power_node": "C (Min 500 W, Max 3050 W)", "power_cpu": "M", "power_mem": "M", "power_gpu": "C (Shifting Ratio 0-100%"}
```
=============