### PR TITLE
Closes #216: Fix duplicate definition of g_platform

### DIFF
--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -31,6 +31,8 @@
 #include <config_arm.h>
 #endif
 
+struct platform g_platform;
+
 #ifdef VARIORUM_LOG
 int variorum_enter(const char *filename, const char *func_name, int line_num)
 #else

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -249,7 +249,7 @@ struct platform
 //    void (*set_performance_counters)();
 #endif
 
-struct platform g_platform;
+extern struct platform g_platform;
 
 #ifdef VARIORUM_LOG
 int variorum_enter(const char *filename,


### PR DESCRIPTION
Extern the initial definition and add storage in corresponding source file.