### PR TITLE
Implement variorum_get_node_power_json() for skylake

### DIFF
--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -335,6 +335,19 @@ int fm_06_55_monitoring(FILE *output)
     return 0;
 }
 
+int fm_06_55_get_node_power_json(json_t *get_power_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
+                        msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                        msrs.msr_dram_energy_status);
+
+    return 0;
+}
+
 int fm_06_55_cap_frequency(int core_freq_mhz)
 {
     unsigned nsockets, ncores, nthreads;

--- a/src/variorum/Intel/Skylake_55.h
+++ b/src/variorum/Intel/Skylake_55.h
@@ -7,6 +7,7 @@
 #define SKYLAKE_55_H_INCLUDE
 
 #include <sys/types.h>
+#include <jansson.h>
 
 /// @brief List of unique addresses for Skylake Family/Model 55H.
 struct skylake_55_offsets
@@ -97,6 +98,8 @@ int fm_06_55_get_power(int long_ver);
 int fm_06_55_poll_power(FILE *output);
 
 int fm_06_55_monitoring(FILE *output);
+
+int fm_06_55_get_node_power_json(json_t *get_power_obj);
 
 int fm_06_55_cap_frequency(int core_freq_mhz);
 

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -188,6 +188,7 @@ int set_intel_func_ptrs(void)
         //g_platform.variorum_print_turbo = fm_06_55_get_turbo_status;
         //g_platform.variorum_enable_turbo = fm_06_55_enable_turbo;
         //g_platform.variorum_disable_turbo = fm_06_55_disable_turbo;
+        g_platform.variorum_get_node_power_json = fm_06_55_get_node_power_json;
         g_platform.variorum_poll_power = fm_06_55_poll_power;
         g_platform.variorum_monitoring = fm_06_55_monitoring;
         g_platform.variorum_cap_each_core_frequency_limit = fm_06_55_cap_frequency;

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -961,9 +961,9 @@ void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit,
     {
         /* Defined here so as to reset the string for each socket
          * and append correctly */
-        char cpu_str[24] = "power_cpu_watts_socket_";
-        char mem_str[24] = "power_mem_watts_socket_";
-        char gpu_str[24] = "power_gpu_watts_socket_";
+        char cpu_str[36] = "power_cpu_watts_socket_";
+        char mem_str[36] = "power_mem_watts_socket_";
+        char gpu_str[36] = "power_gpu_watts_socket_";
 
         snprintf(sockID, sockID_len, "%d", i);
         strcat(cpu_str, sockID);

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -970,7 +970,9 @@ void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit,
         strcat(mem_str, sockID);
         strcat(gpu_str, sockID);
 
+        // TODO: Check here
         get_package_rapl_limit(i, &l1, &l2, msr_power_limit, msr_rapl_unit);
+        printf("%s %d %f\n", cpu_str, i,  rapl->pkg_watts[i]);
 
         json_object_set_new(get_power_obj, cpu_str, json_real(rapl->pkg_watts[i]));
         json_object_set_new(get_power_obj, mem_str, json_real(rapl->dram_watts[i]));

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -970,9 +970,7 @@ void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit,
         strcat(mem_str, sockID);
         strcat(gpu_str, sockID);
 
-        // TODO: Check here
         get_package_rapl_limit(i, &l1, &l2, msr_power_limit, msr_rapl_unit);
-        printf("%s %d %f\n", cpu_str, i,  rapl->pkg_watts[i]);
 
         json_object_set_new(get_power_obj, cpu_str, json_real(rapl->pkg_watts[i]));
         json_object_set_new(get_power_obj, mem_str, json_real(rapl->dram_watts[i]));


### PR DESCRIPTION
Myself and @Perarnau have been experimenting with Variorum on a Skylake machine, but to use ``variorum_get_node_power_json()`` we had to copy the function and its declaration into the relevant files.

We've also included a small fix in ``power_features.c`` to resolve a segmentation fault.

Looks like this also helps resolve #182 and #202 

Thanks!