### PR TITLE
Documentation Edits. 

### DIFF
--- a/README
+++ b/README
@@ -76,7 +76,7 @@ installs. These can be used as follows:
 Variorum has support for an increasing number of platforms and
 microarchitectures:
 
-Platforms supported: Intel, IBM, NVIDIA, ARM
+Platforms supported: Intel, IBM, AMD, NVIDIA, ARM
 
 Supported Intel Microarchitectures:
 
@@ -90,6 +90,11 @@ Supported Intel Microarchitectures:
 
 If you are unsure of your architecture number, check the "model" field in `lscpu`
 or `/proc/cpuinfo` (note that it will not be in hexadecimal).
+
+
+Supported AMD Microrchitectures:
+
+    Family 19h, Models 0~Fh and 30h ~ 3Fh (EPYC Milan) 
 
 Supported IBM Microrchitectures:
 
@@ -118,15 +123,6 @@ Please report any failed tests to the project team at
 For sample code, see the `examples/` directory.
 
 
-## Support Additional Intel Platforms
-1. Under `Intel/` directory, create a `.h` and `.c` header and source file for
-the respective platform. This will contain features specific to that platform,
-which may or may not exist in previous generations.
-2. Modify `Intel/config_intel.c` to set the function pointers for the
-respective platform.
-3. Include the new header file in `Intel/config_architecture.h`.
-
-
 ## System Environment Requirements
 This software has certain system requirements depending on what hardware you
 are running on.
@@ -137,6 +133,9 @@ additional capabilities. We have found it easier to use our own
 [msr-safe](https://github.com/LLNL/msr-safe) kernel module, but running as root
 (or going through the bother of adding the capabilities to the binaries) is
 another option.
+
+AMD: Running this software on AMD platforms depends on the AMD Energy Driver, 
+AMD HSMP driver, and AMD E-SMI library being available with the correct permissions. 
 
 IBM: Running this software on IBM platforms depends on the OPAL files being
 present with R/W permissions.

--- a/README
+++ b/README
@@ -76,7 +76,7 @@ installs. These can be used as follows:
 Variorum has support for an increasing number of platforms and
 microarchitectures:
 
-Platforms supported: AMD,ARM, IBM, Intel, NVIDIA
+Platforms supported: AMD, ARM, IBM, Intel, NVIDIA
 
 If you are unsure of your architecture number, check the "model" field in `lscpu`
 or `/proc/cpuinfo` (note that it will not be in hexadecimal).

--- a/README
+++ b/README
@@ -76,7 +76,23 @@ installs. These can be used as follows:
 Variorum has support for an increasing number of platforms and
 microarchitectures:
 
-Platforms supported: Intel, IBM, AMD, NVIDIA, ARM
+Platforms supported: AMD,ARM, IBM, Intel, NVIDIA
+
+If you are unsure of your architecture number, check the "model" field in `lscpu`
+or `/proc/cpuinfo` (note that it will not be in hexadecimal).
+
+
+Supported AMD Microrchitectures:
+
+    Family 19h, Models 0~Fh and 30h ~ 3Fh (EPYC Milan) 
+
+Supported ARM Microrchitectures:
+
+    Juno r2
+
+Supported IBM Microrchitectures:
+
+    Power9
 
 Supported Intel Microarchitectures:
 
@@ -88,25 +104,10 @@ Supported Intel Microarchitectures:
     0x9E (Kaby Lake)
     0x55 (Skylake)
 
-If you are unsure of your architecture number, check the "model" field in `lscpu`
-or `/proc/cpuinfo` (note that it will not be in hexadecimal).
-
-
-Supported AMD Microrchitectures:
-
-    Family 19h, Models 0~Fh and 30h ~ 3Fh (EPYC Milan) 
-
-Supported IBM Microrchitectures:
-
-    Power9
-
 Supported Nvidia Microrchitectures:
 
     Volta (requires [CUDA Toolkit[(https://developer.nvidia.com/cuda-downloads))
 
-Supported ARM Microrchitectures:
-
-    Juno r2
 
 ## Testing
 
@@ -127,6 +128,16 @@ For sample code, see the `examples/` directory.
 This software has certain system requirements depending on what hardware you
 are running on.
 
+AMD: Running this software on AMD platforms depends on the AMD Energy Driver, 
+AMD HSMP driver, and AMD E-SMI library being available with the correct permissions. 
+
+ARM: Running this software on ARM platforms depends on the Linux Hardware
+Monitoring (hwmon) subsystem for access to the monitoring and control
+interfaces.
+
+IBM: Running this software on IBM platforms depends on the OPAL files being
+present with R/W permissions.
+
 Intel: Running this software on Intel platforms depends on the files
 `/dev/cpu/*/msr` being present with R/W permissions. Recent kernels require
 additional capabilities. We have found it easier to use our own
@@ -134,17 +145,8 @@ additional capabilities. We have found it easier to use our own
 (or going through the bother of adding the capabilities to the binaries) is
 another option.
 
-AMD: Running this software on AMD platforms depends on the AMD Energy Driver, 
-AMD HSMP driver, and AMD E-SMI library being available with the correct permissions. 
-
-IBM: Running this software on IBM platforms depends on the OPAL files being
-present with R/W permissions.
-
 Nvidia: Running this software on Nvidia platforms depends on CUDA being loaded.
 
-ARM: Running this software on ARM platforms depends on the Linux Hardware
-Monitoring (hwmon) subsystem for access to the monitoring and control
-interfaces.
 
 
 ## Bug Tracker

--- a/src/docs/sphinx/AMD.rst
+++ b/src/docs/sphinx/AMD.rst
@@ -75,13 +75,13 @@ the SMU FW. All registers are updated every 1 millisecond.
  Power telemetry
 =================
 
-esmi_socket_power_get()
+`esmi_socket_power_get()`
 - Instantaneous power is reported in milliwatts
 
-esmi_socket_power_cap_get() and esmi_socket_power_cap_set()
+`esmi_socket_power_cap_get()` and `esmi_socket_power_cap_set()`
 - Get and Set power limit of the socket in milliwatts
 
-esmi_socket_power_cap_max_get()
+`esmi_socket_power_cap_max_get()`
 - Maximum Power limit of the socket in milliwatts
 
  Boostlimit telemetry
@@ -89,19 +89,19 @@ esmi_socket_power_cap_max_get()
 
 Boostlimit is a maximum frequency a CPU can run at.
 
-esmi_core_boostlimit_get() and esmi_core_boostlimit_set()
+`esmi_core_boostlimit_get()` and `esmi_core_boostlimit_set()`
 - Get and set the current boostlimit for a given core
 
-esmi_socket_boostlimit_set()
+`esmi_socket_boostlimit_set()`
 - Set boostlimit for all the cores in the socket
 
  Energy telemetry
 ==================
 
-esmi_socket_energy_get()
+`esmi_socket_energy_get()`
 - Get software accumulated 64-bit energy counter for a given socket
 
-esmi_core_energy_get()
+`esmi_core_energy_get()`
 - Get software accumulated 64-bit energy counter for a given core
 
 ************

--- a/src/docs/sphinx/AMD.rst
+++ b/src/docs/sphinx/AMD.rst
@@ -7,41 +7,73 @@
  AMD Overview
 ##############
 
-This implementation of the AMD port of Variorum supports the AMD processors
-for family support refer to dependencie section. We have tested the AMD
-functionality of Variorum on SLES15 and Ubuntu 18.04.
-
-**************
- Dependencies
-**************
-
-The following software stack is supported on family 19h model 0~Fh and 30h ~ 3Fh
-processors from AMD, as of April 2021.
-
-This version of the AMD port of Variorum depends on the AMD open-sourced
+The current AMD port of Variorum supports the AMD processors
+from the AMD EPYC Milan family 19h, models 0~Fh and 30h~3Fh. 
+This functionality has been tested on SLES15 and Ubuntu 18.04.
+This version of depends on the AMD open-sourced software stack components 
+listed below:
 
 1. EPYC™ System Management Interface In-band Library (E-SMI library) available at
    https://github.com/amd/esmi_ib_library
 
-2. HSMP driver for power metrics
+2. AMD Energy Driver
+   https://github.com/amd/amd_energy
+
+3. HSMP driver for power metrics
    https://github.com/amd/amd_hsmp
 
-2. amd_energy driver for core and socket energy counters
-   https://github.com/amd/amd_energy
+The E-SMI library provides the C API for user space application 
+of the AMD Energy Driver and the AMD HSMP modules.
+
+The AMD Energy Driver is an out of kernel module that allows for 
+core and socket energy counter access through MSRs and RAPL via `hwmon` sys entries. 
+These registers are updated every 1 millisecond and cleared on reset of the system.
+Some registers of interest include:
+* Power, Energy and Time Units 
+    - ``MSR_RAPL_POWER_UNIT/ C001_0299``: shared with all cores in the socket
+* Energy consumed by each core 
+    - ``MSR_CORE_ENERGY_STATUS/ C001_029A``: 32-bitRO, Accumulator, core-level
+power reporting
+* Energy consumed by Socket 
+    - ``MSR_PACKAGE_ENERGY_STATUS/ C001_029B``: 32-bitRO, Accumulator, socket-level
+power reporting, shared with all cores in socket
+
+The Host System Management Port (HSMP) kernel module allows for *setting* of 
+power caps, boostlimits and PCIe access. It provides user level access to the 
+HSMP mailboxes implemented by the firmware in the System Management Unit (SMU).
+AMD Power Control Knobs are exposed through HSMP via sysfs.
+
+* ``amd_hsmp/cpuX/`` : Directory for each possible CPU
+    - boost_limit (RW): HSMP boost limit for the core in MHz
+
+* ``amd_hsmp/socketX/`` :  Directory for each possible socket
+    - boost_limit (WO): Set HSMP boost limit for the socket in MHz
+    - c0_residency (RO): Average % all cores are in C0 state
+    - cclk_limit (RO): Most restrictive core clock (CCLK) limit in MHz
+    - fabric_clocks (RO): Data fabric (FCLK) and memory (MCLK) in MHz
+    - fabric_pstate (WO): Set data fabric P-state, -1 for autonomous
+    - power (RO): Average socket power in milliwatts
+    - power_limit (RW): Socket power limit in milliwatts
+    - power_limit_max (RO): Maximum possible value for power limit in mW
+    - proc_hot (RO): Socket PROC_HOT status (1 = active, 0 = inactive)
+    - tctl (RO): Thermal Control value (not temperature) 
+ 
+We expect a similar software stack to be available on the upcoming El Capitan 
+supercomputer at Lawrence Livermore National Laboratory.  
 
 ******************************************
  Monitoring and Control Through E-SMI API
 ******************************************
 
-The built-in monitoring interface on the AMD EPYC™ processors is implemented by
-the SMU FW. The following subsections provide the specific metrics:
+Variorum interfaces with AMD's E-SMI library for obtaining power and energy 
+information. These E-SMI APIs are described below. 
 
-All registers are updated every 1 milli second.
+The built-in monitoring interface on the AMD EPYC™ processors is implemented by
+the SMU FW. All registers are updated every 1 millisecond.
+
 
  Power telemetry
 =================
-
-The following E-SMI APIs are used in this version of AMD port
 
 esmi_socket_power_get()
 - Instantaneous power is reported in milliwatts
@@ -52,13 +84,10 @@ esmi_socket_power_cap_get() and esmi_socket_power_cap_set()
 esmi_socket_power_cap_max_get()
 - Maximum Power limit of the socket in milliwatts
 
-To improve readability of the verbose output Variorum converts power into
-watts before logging.
-
  Boostlimit telemetry
 ======================
 
-Boostlimit is a maximum frequency a CPU can run at
+Boostlimit is a maximum frequency a CPU can run at.
 
 esmi_core_boostlimit_get() and esmi_core_boostlimit_set()
 - Get and set the current boostlimit for a given core
@@ -80,4 +109,4 @@ esmi_core_energy_get()
 ************
 
 -  `AMD EPYC™ processors Fam19h technical reference
-   <https://www.amd.com/system/files/TechDocs/55898_pub.zip>`_
+   <https://www.amd.com/system/files/TechDocs/55898_B1_pub_0.50.zip>`_

--- a/src/docs/sphinx/AMD.rst
+++ b/src/docs/sphinx/AMD.rst
@@ -26,7 +26,7 @@ The E-SMI library provides the C API for user space application
 of the AMD Energy Driver and the AMD HSMP modules.
 
 The AMD Energy Driver is an out of kernel module that allows for 
-core and socket energy counter access through MSRs and RAPL via `hwmon` sys entries.
+core and socket energy counter access through MSRs and RAPL via ``hwmon`` sys entries.
 These registers are updated every 1 millisecond and cleared on reset of the system.
 Some registers of interest include:
 
@@ -45,19 +45,19 @@ HSMP mailboxes implemented by the firmware in the System Management Unit (SMU).
 AMD Power Control Knobs are exposed through HSMP via sysfs.
 
 * ``amd_hsmp/cpuX/``: Directory for each possible CPU
-    - boost_limit (RW): HSMP boost limit for the core in MHz
+    - ``boost_limit`` (RW): HSMP boost limit for the core in MHz
 
 * ``amd_hsmp/socketX/``:  Directory for each possible socket
-    - boost_limit (WO): Set HSMP boost limit for the socket in MHz
-    - c0_residency (RO): Average % all cores are in C0 state
-    - cclk_limit (RO): Most restrictive core clock (CCLK) limit in MHz
-    - fabric_clocks (RO): Data fabric (FCLK) and memory (MCLK) in MHz
-    - fabric_pstate (WO): Set data fabric P-state, -1 for autonomous
-    - power (RO): Average socket power in milliwatts
-    - power_limit (RW): Socket power limit in milliwatts
-    - power_limit_max (RO): Maximum possible value for power limit in mW
-    - proc_hot (RO): Socket PROC_HOT status (1 = active, 0 = inactive)
-    - tctl (RO): Thermal Control value (not temperature)
+    - ``boost_limit`` (WO): Set HSMP boost limit for the socket in MHz
+    - ``c0_residency`` (RO): Average % all cores are in C0 state
+    - ``cclk_limit`` (RO): Most restrictive core clock (CCLK) limit in MHz
+    - ``fabric_clocks`` (RO): Data fabric (FCLK) and memory (MCLK) in MHz
+    - ``fabric_pstate`` (WO): Set data fabric P-state, -1 for autonomous
+    - ``power`` (RO): Average socket power in milliwatts
+    - ``power_limit`` (RW): Socket power limit in milliwatts
+    - ``power_limit_max`` (RO): Maximum possible value for power limit in mW
+    - ``proc_hot`` (RO): Socket PROC_HOT status (1 = active, 0 = inactive)
+    - ``tctl`` (RO): Thermal Control value (not temperature)
 
 We expect a similar software stack to be available on the upcoming El Capitan
 supercomputer at Lawrence Livermore National Laboratory.
@@ -76,27 +76,27 @@ the SMU FW. All registers are updated every 1 millisecond.
 Power telemetry
 =================
 
-* `esmi_socket_power_get()`: Instantaneous power is reported in milliwatts
+* ``esmi_socket_power_get()``: Instantaneous power is reported in milliwatts
 
-* `esmi_socket_power_cap_get()` and `esmi_socket_power_cap_set()`: Get and Set power limit of the socket in milliwatts
+* ``esmi_socket_power_cap_get()`` and ``esmi_socket_power_cap_set()``: Get and Set power limit of the socket in milliwatts
 
-* `esmi_socket_power_cap_max_get()`: Maximum Power limit of the socket in milliwatts
+* ``esmi_socket_power_cap_max_get()``: Maximum Power limit of the socket in milliwatts
 
 Boostlimit telemetry
 ======================
 
 Boostlimit is a maximum frequency a CPU can run at.
 
-* `esmi_core_boostlimit_get()` and `esmi_core_boostlimit_set()`: Get and set the current boostlimit for a given core
+* ``esmi_core_boostlimit_get()`` and ``esmi_core_boostlimit_set()``: Get and set the current boostlimit for a given core
 
-* `esmi_socket_boostlimit_set()`: Set boostlimit for all the cores in the socket
+* ``esmi_socket_boostlimit_set()``: Set boostlimit for all the cores in the socket
 
 Energy telemetry
 ==================
 
-* `esmi_socket_energy_get()`: Get software accumulated 64-bit energy counter for a given socket
+* ``esmi_socket_energy_get()``: Get software accumulated 64-bit energy counter for a given socket
 
-* `esmi_core_energy_get()`: Get software accumulated 64-bit energy counter for a given core
+* ``esmi_core_energy_get()``: Get software accumulated 64-bit energy counter for a given core
 
 ************
  References

--- a/src/docs/sphinx/AMD.rst
+++ b/src/docs/sphinx/AMD.rst
@@ -8,9 +8,9 @@
 ##############
 
 The current AMD port of Variorum supports the AMD processors
-from the AMD EPYC Milan family 19h, models 0~Fh and 30h~3Fh. 
+from the AMD EPYC Milan family 19h, models 0~Fh and 30h~3Fh.
 This functionality has been tested on SLES15 and Ubuntu 18.04.
-This version of depends on the AMD open-sourced software stack components 
+This version of depends on the AMD open-sourced software stack components
 listed below:
 
 1. EPYC™ System Management Interface In-band Library (E-SMI library) available at
@@ -22,31 +22,32 @@ listed below:
 3. HSMP driver for power metrics
    https://github.com/amd/amd_hsmp
 
-The E-SMI library provides the C API for user space application 
+The E-SMI library provides the C API for user space application
 of the AMD Energy Driver and the AMD HSMP modules.
 
 The AMD Energy Driver is an out of kernel module that allows for 
-core and socket energy counter access through MSRs and RAPL via `hwmon` sys entries. 
+core and socket energy counter access through MSRs and RAPL via `hwmon` sys entries.
 These registers are updated every 1 millisecond and cleared on reset of the system.
 Some registers of interest include:
-* Power, Energy and Time Units 
-    - ``MSR_RAPL_POWER_UNIT/ C001_0299``: shared with all cores in the socket
-* Energy consumed by each core 
-    - ``MSR_CORE_ENERGY_STATUS/ C001_029A``: 32-bitRO, Accumulator, core-level
-power reporting
-* Energy consumed by Socket 
-    - ``MSR_PACKAGE_ENERGY_STATUS/ C001_029B``: 32-bitRO, Accumulator, socket-level
-power reporting, shared with all cores in socket
 
-The Host System Management Port (HSMP) kernel module allows for *setting* of 
-power caps, boostlimits and PCIe access. It provides user level access to the 
+* Power, Energy and Time Units
+    - ``MSR_RAPL_POWER_UNIT/ C001_0299``: shared with all cores in the socket
+
+* Energy consumed by each core
+    - ``MSR_CORE_ENERGY_STATUS/ C001_029A``: 32-bitRO, Accumulator, core-level power reporting
+
+* Energy consumed by Socket
+    - ``MSR_PACKAGE_ENERGY_STATUS/ C001_029B``: 32-bitRO, Accumulator, socket-level power reporting, shared with all cores in socket
+
+The Host System Management Port (HSMP) kernel module allows for *setting* of
+power caps, boostlimits and PCIe access. It provides user level access to the
 HSMP mailboxes implemented by the firmware in the System Management Unit (SMU).
 AMD Power Control Knobs are exposed through HSMP via sysfs.
 
-* ``amd_hsmp/cpuX/`` : Directory for each possible CPU
+* ``amd_hsmp/cpuX/``: Directory for each possible CPU
     - boost_limit (RW): HSMP boost limit for the core in MHz
 
-* ``amd_hsmp/socketX/`` :  Directory for each possible socket
+* ``amd_hsmp/socketX/``:  Directory for each possible socket
     - boost_limit (WO): Set HSMP boost limit for the socket in MHz
     - c0_residency (RO): Average % all cores are in C0 state
     - cclk_limit (RO): Most restrictive core clock (CCLK) limit in MHz
@@ -56,53 +57,46 @@ AMD Power Control Knobs are exposed through HSMP via sysfs.
     - power_limit (RW): Socket power limit in milliwatts
     - power_limit_max (RO): Maximum possible value for power limit in mW
     - proc_hot (RO): Socket PROC_HOT status (1 = active, 0 = inactive)
-    - tctl (RO): Thermal Control value (not temperature) 
- 
-We expect a similar software stack to be available on the upcoming El Capitan 
-supercomputer at Lawrence Livermore National Laboratory.  
+    - tctl (RO): Thermal Control value (not temperature)
+
+We expect a similar software stack to be available on the upcoming El Capitan
+supercomputer at Lawrence Livermore National Laboratory.
 
 ******************************************
  Monitoring and Control Through E-SMI API
 ******************************************
 
-Variorum interfaces with AMD's E-SMI library for obtaining power and energy 
-information. These E-SMI APIs are described below. 
+Variorum interfaces with AMD's E-SMI library for obtaining power and energy
+information. These E-SMI APIs are described below.
 
 The built-in monitoring interface on the AMD EPYC™ processors is implemented by
 the SMU FW. All registers are updated every 1 millisecond.
 
 
- Power telemetry
+Power telemetry
 =================
 
-esmi_socket_power_get()
-- Instantaneous power is reported in milliwatts
+* esmi_socket_power_get(): Instantaneous power is reported in milliwatts
 
-esmi_socket_power_cap_get() and esmi_socket_power_cap_set()
-- Get and Set power limit of the socket in milliwatts
+* esmi_socket_power_cap_get() and esmi_socket_power_cap_set(): Get and Set power limit of the socket in milliwatts
 
-esmi_socket_power_cap_max_get()
-- Maximum Power limit of the socket in milliwatts
+* esmi_socket_power_cap_max_get(): Maximum Power limit of the socket in milliwatts
 
- Boostlimit telemetry
+Boostlimit telemetry
 ======================
 
 Boostlimit is a maximum frequency a CPU can run at.
 
-esmi_core_boostlimit_get() and esmi_core_boostlimit_set()
-- Get and set the current boostlimit for a given core
+* esmi_core_boostlimit_get() and esmi_core_boostlimit_set(): Get and set the current boostlimit for a given core
 
-esmi_socket_boostlimit_set()
-- Set boostlimit for all the cores in the socket
+* esmi_socket_boostlimit_set(): Set boostlimit for all the cores in the socket
 
- Energy telemetry
+Energy telemetry
 ==================
 
-esmi_socket_energy_get()
-- Get software accumulated 64-bit energy counter for a given socket
+* esmi_socket_energy_get(): Get software accumulated 64-bit energy counter for a given socket
 
-esmi_core_energy_get()
-- Get software accumulated 64-bit energy counter for a given core
+* esmi_core_energy_get(): Get software accumulated 64-bit energy counter for a given core
 
 ************
  References

--- a/src/docs/sphinx/AMD.rst
+++ b/src/docs/sphinx/AMD.rst
@@ -25,7 +25,7 @@ listed below:
 The E-SMI library provides the C API for user space application
 of the AMD Energy Driver and the AMD HSMP modules.
 
-The AMD Energy Driver is an out of kernel module that allows for 
+The AMD Energy Driver is an out of kernel module that allows for
 core and socket energy counter access through MSRs and RAPL via ``hwmon`` sys entries.
 These registers are updated every 1 millisecond and cleared on reset of the system.
 Some registers of interest include:

--- a/src/docs/sphinx/HWArchitectures.rst
+++ b/src/docs/sphinx/HWArchitectures.rst
@@ -12,8 +12,8 @@ These are the currently supported platforms in Variorum.
 .. toctree::
    :maxdepth: 2
 
+   AMD
    ARM
    IBM
    Intel
    Nvidia
-   AMD

--- a/src/docs/sphinx/Intel.rst
+++ b/src/docs/sphinx/Intel.rst
@@ -52,7 +52,7 @@ These are the most common mistakes we have seen when using these registers.
       -  Naming conventions will vary across and within documents, even to the
          naming of particular MSRs. While these are trivial to the eye (CTL
          versus CONTROL, PKG versus PACKAGE) it does make grepping documents
-         more challenging that it should be. We have tried to follow a
+         more challenging than it should be. We have tried to follow a
          consistent scheme for MSRs, PCI addresses and CPUID queries. Where
          there is a conflict in MSR names, we have chosen what seems most
          sensible.

--- a/src/docs/sphinx/VariorumAPI.rst
+++ b/src/docs/sphinx/VariorumAPI.rst
@@ -7,7 +7,14 @@
  Variorum API
 ##############
 
-The top-level API for Variorum consists of the following calls:
+Variorum supports vendor-neutral power and energy management through its
+rich API. Please refer to the top-level API, as well as the specific descritptions of the JSON API and the Best Effort Power Capping API. The JSON API allows system software interacting with Variorum to obtain data in a portable, vendor-neutral manner. 
+
+*************
+Top-level API
+*************
+
+The top-level API for Variorum consists of the following calls, as shown in the `variorum.h` header file.:
 
 .. literalinclude:: ../../variorum/variorum.h
    :language: c
@@ -17,9 +24,8 @@ The top-level API for Variorum consists of the following calls:
 **********
 
 The current JSON API depends on the JANSSON-C library and has a vendor-neutral
-format. The API has been tested on Intel Broadwell and IBM Witherspoon
-architectures, and will be supported on other platforms shortly.
-
+format. The API has been tested on Intel, IBM and ARM
+architectures.
 
 Obtaining Power Consumption
 ===========================

--- a/src/docs/sphinx/VariorumAPI.rst
+++ b/src/docs/sphinx/VariorumAPI.rst
@@ -21,7 +21,8 @@ format. The API has been tested on Intel Broadwell and IBM Witherspoon
 architectures, and will be supported on other platforms shortly.
 
 
-Obtaining Power Consumption:
+Obtaining Power Consumption
+===========================
 
 The API to obtain node power has the following format. It takes
 a ``json_t`` object by reference as input, and populates this JSON object with
@@ -59,7 +60,8 @@ cross-architectural build, similar to Variorum's ``variorum_get_node_power()``
 API.
 
 
-Querying Power Domains:
+Querying Power Domains
+======================
 
 The API for querying power domains allows users to query Variorum to obtain
 information about domains that can be measured and controlled on a certain

--- a/src/docs/sphinx/VariorumAPI.rst
+++ b/src/docs/sphinx/VariorumAPI.rst
@@ -14,7 +14,7 @@ rich API. Please refer to the top-level API, as well as the specific descritptio
 Top-level API
 *************
 
-The top-level API for Variorum consists of the following calls, as shown in the `variorum.h` header file.:
+The top-level API for Variorum is shown in the `variorum.h` header file:
 
 .. literalinclude:: ../../variorum/variorum.h
    :language: c

--- a/src/docs/sphinx/VariorumDevel.rst
+++ b/src/docs/sphinx/VariorumDevel.rst
@@ -53,3 +53,20 @@ Power9 for IBM Power processors.
    MSRs, OPAL, IPMI, etc. If applicable, these can be re-used across
    microarchitectures (i.e., the same implementation is used for many
    microarchitectures).
+
+
+*************************************************************
+Example 
+*************************************************************
+
+As an example, to support additional Intel microarchitectures:
+1. Under `Intel/` directory, create a `.h` and `.c` header and source file for
+the respective microarchitecture. 
+This will contain features specific to that microarchitecture,
+which may or may not exist in previous generations.
+
+2. Modify `Intel/config_intel.c` to set the function pointers for the
+respective microarchitecture.
+
+3. Include the new header file in `Intel/config_architecture.h`.
+

--- a/src/docs/sphinx/VariorumDevel.rst
+++ b/src/docs/sphinx/VariorumDevel.rst
@@ -55,9 +55,9 @@ Power9 for IBM Power processors.
    microarchitectures).
 
 
-*************************************************************
+*******
 Example 
-*************************************************************
+*******
 
 As an example, to support additional Intel microarchitectures:
 1. Under `Intel/` directory, create a `.h` and `.c` header and source file for

--- a/src/docs/sphinx/VariorumTools.rst
+++ b/src/docs/sphinx/VariorumTools.rst
@@ -4,21 +4,24 @@
    # SPDX-License-Identifier: MIT
 
 ###########################
- Using Tools with Variorum
+ Integrating with Variorum
 ###########################
 
 The JSON API enables Variorum to interface with higher-level system software.
-Current integration efforts include a Kokkos connector for power monitoring and
-a Flux power management module.
+Current integration efforts include a Kokkos connector for power monitoring , a Caliper service for method-level power data, and
+a Flux power management module for scheduling.
 
 Links to each of these frameworks can be found below. Note that these
 integrations with Variorum are in early development stages and are expected to
 be updated to support more features and tests. Upcoming integration also
-includes developing a Variorum service for Caliper.
+includes developing a Variorum interface for Intel's GEOPM.
 
    -  Kokkos connector:
       https://github.com/kokkos/kokkos-tools/tree/develop/profiling/variorum-connector
-   -  Flux Power Manager Module: https://github.com/rountree/flux-power-mgr
+   -  Caliper service:
+      https://github.com/LLNL/Caliper/tree/master/src/services/variorum     
+   -  Flux Power Manager Module: 
+      https://github.com/rountree/flux-power-mgr
 
 In order for tools to interact with Variorum, a simple JANSSON based parser is
 sufficient. The format of the JSON object has been documented, and includes


### PR DESCRIPTION
Add AMD documentation, edit README to reflect support for AMD. Move the Intel developer example from README to VariorumDevel.rst as it makes more sense to put it there. Minor typo fix for Intel documentation, and minor fix for JSON API documentation (indentation).