### PR TITLE
Json query API other architectures. 

### DIFF
--- a/src/variorum/AMD/config_amd.c
+++ b/src/variorum/AMD/config_amd.c
@@ -72,6 +72,9 @@ int set_amd_func_ptrs(void)
             g_platform.variorum_cap_each_core_frequency_limit =
                 epyc_set_each_core_boostlimit;
             g_platform.variorum_cap_socket_frequency_limit = epyc_set_socket_boostlimit;
+            g_platform.variorum_get_node_power_json = epyc_get_node_power_json;
+            g_platform.variorum_get_node_power_domain_info_json =
+                epyc_get_node_power_domain_info_json;
             break;
         default:
             fprintf(stdout, "ESMI not initialized, drivers not found. "

--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -497,58 +497,58 @@ int epyc_get_node_power_json(json_t *get_power_obj)
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-       unsigned nsockets;
-       char hostname[1024];
-       struct timeval tv;
-       uint64_t ts;
-       /* AMD authors declared this as uint32_t and typecast it to double, 
-        * not sure why. Just following their lead from the get_power function*/ 
-       uint32_t current_power;
+    unsigned nsockets;
+    char hostname[1024];
+    struct timeval tv;
+    uint64_t ts;
+    /* AMD authors declared this as uint32_t and typecast it to double,
+     * not sure why. Just following their lead from the get_power function*/
+    uint32_t current_power;
 
-        gethostname(hostname, 1024);
-        gettimeofday(&tv, NULL);
-        ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
-        json_object_set_new(get_power_obj, "host", json_string(hostname));
-        json_object_set_new(get_power_obj, "timestamp", json_integer(ts));
+    gethostname(hostname, 1024);
+    gettimeofday(&tv, NULL);
+    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
+    json_object_set_new(get_power_obj, "host", json_string(hostname));
+    json_object_set_new(get_power_obj, "timestamp", json_integer(ts));
 
-        for (i = 0; i < g_platform.num_sockets; i++)
+    for (i = 0; i < g_platform.num_sockets; i++)
+    {
+        char cpu_str[36] = "power_cpu_watts_socket_";
+        char mem_str[36] = "power_mem_watts_socket_";
+        char gpu_str[36] = "power_gpu_watts_socket_";
+
+        snprintf(sockID, sockID_len, "%d", i);
+        strcat(cpu_str, sockID);
+        strcat(mem_str, sockID);
+        strcat(gpu_str, sockID);
+
+        current_power = 0;
+        ret = esmi_socket_power_get(i, &current_power);
+        if (ret != 0)
         {
-            char cpu_str[36] = "power_cpu_watts_socket_";
-            char mem_str[36] = "power_mem_watts_socket_";
-            char gpu_str[36] = "power_gpu_watts_socket_";
-
-            snprintf(sockID, sockID_len, "%d", i);
-            strcat(cpu_str, sockID);
-            strcat(mem_str, sockID);
-            strcat(gpu_str, sockID);
-
-            current_power = 0;
-            ret = esmi_socket_power_get(i, &current_power);
-            if (ret != 0)
-            {
-                fprintf(stdout, "Failed to get socket[%d] _POWER, "
-                     "Err[%d]:%s\n", i, ret, esmi_get_err_msg(ret));
-                return ret;
-            }
-            else
-            { 
-                json_object_set_new(get_power_obj, cpu_str, 
-                                        json_real((double)current_power/1000);
-            }
-
-            // GPU power set to -1.0 for vendor neutrality and first cut, as we
-            // don't have a way to measure this yet.
-            json_object_set_new(get_power_obj, gpu_str, json_real(-1.0));
-
-            // Memory power set to -1.0 as this platform does not expose
-            // memory power yet.
-            json_object_set_new(get_power_obj, mem_str, json_real(-1.0));
-
-            node_power += (double)current_power/1000;
+            fprintf(stdout, "Failed to get socket[%d] _POWER, "
+                    "Err[%d]:%s\n", i, ret, esmi_get_err_msg(ret));
+            return ret;
+        }
+        else
+        {
+            json_object_set_new(get_power_obj, cpu_str,
+                                json_real((double)current_power / 1000);
         }
 
-        // Set the node power key with pwrnode value.
-        json_object_set_new(get_power_obj, "power_node_watts", json_real(node_power));
+        // GPU power set to -1.0 for vendor neutrality and first cut, as we
+        // don't have a way to measure this yet.
+        json_object_set_new(get_power_obj, gpu_str, json_real(-1.0));
+
+        // Memory power set to -1.0 as this platform does not expose
+        // memory power yet.
+        json_object_set_new(get_power_obj, mem_str, json_real(-1.0));
+
+        node_power += (double)current_power / 1000;
+    }
+
+    // Set the node power key with pwrnode value.
+    json_object_set_new(get_power_obj, "power_node_watts", json_real(node_power));
     return 0;
 }
 

--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -511,8 +511,34 @@ int epyc_get_node_power_json(json_t *get_power_obj)
         ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
         json_object_set_new(get_power_obj, "host", json_string(hostname));
         json_object_set_new(get_power_obj, "timestamp", json_integer(ts));
-    */
 
+        for (i = 0; i < nsockets; i++)
+        {
+            char cpu_str[36] = "power_cpu_watts_socket_";
+            char mem_str[36] = "power_mem_watts_socket_";
+            char gpu_str[36] = "power_gpu_watts_socket_";
+
+            snprintf(sockID, sockID_len, "%d", i);
+            strcat(cpu_str, sockID);
+            strcat(mem_str, sockID);
+            strcat(gpu_str, sockID);
+
+            get_package_rapl_limit(i, &l1, &l2, msr_power_limit, msr_rapl_unit);
+
+            json_object_set_new(get_power_obj, cpu_str, json_real(rapl->pkg_watts[i]));
+            json_object_set_new(get_power_obj, mem_str, json_real(rapl->dram_watts[i]));
+
+            // GPU power set to -1.0 for vendor neutrality and first cut, as we
+            // don't have a way to measure this yet.
+            json_object_set_new(get_power_obj, gpu_str, json_real(-1.0));
+
+
+            node_power += rapl->pkg_watts[i] + rapl->dram_watts[i];
+        }
+
+        // Set the node power key with pwrnode value.
+        json_object_set_new(get_power_obj, "power_node_watts", json_real(node_power));
+    */
     return 0;
 }
 
@@ -526,25 +552,38 @@ int epyc_get_node_power_domain_info_json(json_t *get_domain_obj)
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
+    int ret = 0;
+    uint32_t max_power = 0;
+    char range_str[100];
+
+    //Get max power from E-SMI from socket 0, same for both sockets.
+    //E-SMI doesn't expose minimum yet, something we need AMD to help with.
+    //Assuming minimum is 50 W.
+    ret = esmi_socket_power_cap_max_get(0, &max_power);
+
+    snprintf(range_str, sizeof range_str, "%s%d",
+             "[{min: ", 50,
+             ", max: ", max_power, "}]");
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);
     ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
+
     json_object_set_new(get_domain_obj, "host", json_string(hostname));
     json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));
 
     json_object_set_new(get_domain_obj, "measurement",
-                        json_string("[power_node, power_cpu, power_mem, power_gpu]"));
+                        json_string("[power_cpu]"));
     json_object_set_new(get_domain_obj, "control",
-                        json_string("[power_node, power_gpu]"));
+                        json_string("[power_cpu]"));
     json_object_set_new(get_domain_obj, "unsupported",
-                        json_string("[]"));
+                        json_string("[power_node, power_mem]"));
     json_object_set_new(get_domain_obj, "measurement_units",
-                        json_string("[Watts, Watts, Watts, Watts]"));
+                        json_string("[Watts]"));
     json_object_set_new(get_domain_obj, "control_units",
-                        json_string("[Watts, Percentage]"));
+                        json_string("[Watts]"));
     json_object_set_new(get_domain_obj, "control_range",
-                        json_string("[{min: 500, max: 3050}, {min: 0, max: 100}]"));
+                        json_string(range_str));
 
     return 0;
 }

--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -491,3 +491,60 @@ int epyc_set_socket_boostlimit(int socket, int boostlimit)
     }
     return ret;
 }
+
+int epyc_get_node_power_json(json_t *get_power_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    /*
+       unsigned nsockets;
+        char hostname[1024];
+        struct timeval tv;
+        uint64_t ts;
+
+        variorum_get_topology(&nsockets, NULL, NULL);
+
+        gethostname(hostname, 1024);
+        gettimeofday(&tv, NULL);
+        ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
+        json_object_set_new(get_power_obj, "host", json_string(hostname));
+        json_object_set_new(get_power_obj, "timestamp", json_integer(ts));
+    */
+
+    return 0;
+}
+
+// TBD 6/2/2022
+int epyc_get_node_power_domain_info_json(json_t *get_domain_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    char hostname[1024];
+    struct timeval tv;
+    uint64_t ts;
+
+    gethostname(hostname, 1024);
+    gettimeofday(&tv, NULL);
+    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
+    json_object_set_new(get_domain_obj, "host", json_string(hostname));
+    json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));
+
+    json_object_set_new(get_domain_obj, "measurement",
+                        json_string("[power_node, power_cpu, power_mem, power_gpu]"));
+    json_object_set_new(get_domain_obj, "control",
+                        json_string("[power_node, power_gpu]"));
+    json_object_set_new(get_domain_obj, "unsupported",
+                        json_string("[]"));
+    json_object_set_new(get_domain_obj, "measurement_units",
+                        json_string("[Watts, Watts, Watts, Watts]"));
+    json_object_set_new(get_domain_obj, "control_units",
+                        json_string("[Watts, Percentage]"));
+    json_object_set_new(get_domain_obj, "control_range",
+                        json_string("[{min: 500, max: 3050}, {min: 0, max: 100}]"));
+
+    return 0;
+}

--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -492,6 +492,12 @@ int epyc_set_socket_boostlimit(int socket, int boostlimit)
     return ret;
 }
 
+/* NOTE, June 8, 2022. The build and run of the two JSON APIs below has not been
+ * tested because we don't have access to a node with the right drivers and
+ * micro-architecture. Please use with caution and report any bugs or fixes to
+ * the variorum development team.
+ * We expect to test and update these two functions when access is made available.
+ * */
 int epyc_get_node_power_json(json_t *get_power_obj)
 {
 #ifdef VARIORUM_LOG

--- a/src/variorum/AMD/epyc.h
+++ b/src/variorum/AMD/epyc.h
@@ -6,6 +6,8 @@
 #ifndef EPYC_H_INCLUDE
 #define EPYC_H_INCLUDE
 
+#include <jansson.h>
+
 int epyc_get_power(int long_ver);
 
 int epyc_get_power_limits(int long_ver);

--- a/src/variorum/AMD/epyc.h
+++ b/src/variorum/AMD/epyc.h
@@ -24,4 +24,8 @@ int epyc_set_each_core_boostlimit(int boostlimit);
 
 int epyc_set_socket_boostlimit(int socket, int boostlimit);
 
+int epyc_get_node_power_json(json_t *get_power_obj);
+
+int epyc_get_node_power_domain_info_json(json_t *get_domain_obj);
+
 #endif

--- a/src/variorum/ARM/ARM.c
+++ b/src/variorum/ARM/ARM.c
@@ -94,3 +94,13 @@ int arm_get_power_json(json_t *get_power_obj)
     ret = json_get_power_data(get_power_obj);
     return ret;
 }
+
+int arm_get_power_domain_info_json(json_t *get_power_domain_obj)
+{
+    int ret;
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+    ret = json_get_power_domain_info(get_power_domain_obj);
+    return ret;
+}

--- a/src/variorum/ARM/ARM.h
+++ b/src/variorum/ARM/ARM.h
@@ -20,4 +20,6 @@ int arm_cap_socket_frequency(int cpuid, int freq);
 
 int arm_get_power_json(json_t *get_power_obj);
 
+int arm_get_power_domain_info_json(json_t *get_power_domain_obj);
+
 #endif

--- a/src/variorum/ARM/config_arm.c
+++ b/src/variorum/ARM/config_arm.c
@@ -31,9 +31,10 @@ int set_arm_func_ptrs(void)
         g_platform.variorum_print_thermals              = arm_get_thermals;
         g_platform.variorum_print_frequency             = arm_get_clocks;
         g_platform.variorum_print_available_frequencies = arm_get_frequencies;
-
         g_platform.variorum_cap_socket_frequency_limit  = arm_cap_socket_frequency;
         g_platform.variorum_get_node_power_json = arm_get_power_json;
+        g_platform.variorum_get_node_power_domain_info_json =
+            arm_get_power_domain_info_json;
     }
     else
     {

--- a/src/variorum/ARM/power_features.c
+++ b/src/variorum/ARM/power_features.c
@@ -455,34 +455,34 @@ int json_get_power_data(json_t *get_power_obj)
 
 int json_get_power_domain_info(json_t *get_domain_obj)
 {
-#ifdef VARIORUM_LOG                                                                
-    printf("Running %s\n", __FUNCTION__);                                          
-#endif                                                                             
-                                                                                   
-    char hostname[1024];                                                           
-    struct timeval tv;                                                             
-    uint64_t ts;                                                                   
-                                                                                   
-    gethostname(hostname, 1024);                                                   
-    gettimeofday(&tv, NULL);                                                       
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
 
-    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;                               
+    char hostname[1024];
+    struct timeval tv;
+    uint64_t ts;
 
-    json_object_set_new(get_domain_obj, "host", json_string(hostname));            
-    json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));            
-                                                                                   
-    json_object_set_new(get_domain_obj, "measurement",                             
+    gethostname(hostname, 1024);
+    gettimeofday(&tv, NULL);
+
+    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
+
+    json_object_set_new(get_domain_obj, "host", json_string(hostname));
+    json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));
+
+    json_object_set_new(get_domain_obj, "measurement",
                         json_string("[power_cpu, power_gpu]"));
-    json_object_set_new(get_domain_obj, "control",                                 
-                        json_string("[]"));                   
-    json_object_set_new(get_domain_obj, "unsupported",                             
-                        json_string("[power_node, power_mem]"));                                        
-    json_object_set_new(get_domain_obj, "measurement_units",                       
-                        json_string("[Watts, Watts]"));              
-    json_object_set_new(get_domain_obj, "control_units",                           
-                        json_string("[]"));                       
-    json_object_set_new(get_domain_obj, "control_range",                           
+    json_object_set_new(get_domain_obj, "control",
                         json_string("[]"));
-                                                                                   
-    return 0;                                                                      
+    json_object_set_new(get_domain_obj, "unsupported",
+                        json_string("[power_node, power_mem]"));
+    json_object_set_new(get_domain_obj, "measurement_units",
+                        json_string("[Watts, Watts]"));
+    json_object_set_new(get_domain_obj, "control_units",
+                        json_string("[]"));
+    json_object_set_new(get_domain_obj, "control_range",
+                        json_string("[]"));
+
+    return 0;
 }

--- a/src/variorum/ARM/power_features.c
+++ b/src/variorum/ARM/power_features.c
@@ -455,4 +455,34 @@ int json_get_power_data(json_t *get_power_obj)
 
 int json_get_power_domain_info(json_t *get_power_domain_obj)
 {
+#ifdef VARIORUM_LOG                                                                
+    printf("Running %s\n", __FUNCTION__);                                          
+#endif                                                                             
+                                                                                   
+    char hostname[1024];                                                           
+    struct timeval tv;                                                             
+    uint64_t ts;                                                                   
+                                                                                   
+    gethostname(hostname, 1024);                                                   
+    gettimeofday(&tv, NULL);                                                       
+
+    ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;                               
+
+    json_object_set_new(get_domain_obj, "host", json_string(hostname));            
+    json_object_set_new(get_domain_obj, "timestamp", json_integer(ts));            
+                                                                                   
+    json_object_set_new(get_domain_obj, "measurement",                             
+                        json_string("[power_cpu, power_gpu]"));
+    json_object_set_new(get_domain_obj, "control",                                 
+                        json_string("[]"));                   
+    json_object_set_new(get_domain_obj, "unsupported",                             
+                        json_string("[power_node, power_mem]"));                                        
+    json_object_set_new(get_domain_obj, "measurement_units",                       
+                        json_string("[Watts, Watts]"));              
+    json_object_set_new(get_domain_obj, "control_units",                           
+                        json_string("[]"));                       
+    json_object_set_new(get_domain_obj, "control_range",                           
+                        json_string("[]"));
+                                                                                   
+    return 0;                                                                      
 }

--- a/src/variorum/ARM/power_features.c
+++ b/src/variorum/ARM/power_features.c
@@ -452,3 +452,7 @@ int json_get_power_data(json_t *get_power_obj)
     return 0;
 }
 
+
+int json_get_power_domain_info(json_t *get_power_domain_obj)
+{
+}

--- a/src/variorum/ARM/power_features.c
+++ b/src/variorum/ARM/power_features.c
@@ -453,7 +453,7 @@ int json_get_power_data(json_t *get_power_obj)
 }
 
 
-int json_get_power_domain_info(json_t *get_power_domain_obj)
+int json_get_power_domain_info(json_t *get_domain_obj)
 {
 #ifdef VARIORUM_LOG                                                                
     printf("Running %s\n", __FUNCTION__);                                          

--- a/src/variorum/ARM/power_features.h
+++ b/src/variorum/ARM/power_features.h
@@ -29,7 +29,7 @@ int cap_socket_frequency(int socketid, int new_freq);
 
 int json_get_power_data(json_t *get_power_obj);
 
-int json_get_power_domain_info(json_t *get_power_domain_obj);
+int json_get_power_domain_info(json_t *get_domain_obj);
 
 
 #endif

--- a/src/variorum/ARM/power_features.h
+++ b/src/variorum/ARM/power_features.h
@@ -29,4 +29,7 @@ int cap_socket_frequency(int socketid, int new_freq);
 
 int json_get_power_data(json_t *get_power_obj);
 
+int json_get_power_domain_info(json_t *get_power_domain_obj);
+
+
 #endif

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -445,7 +445,7 @@ int fm_06_4f_get_node_power_domain_info_json(json_t *get_domain_obj)
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
                                msrs.msr_dram_power_info,
-msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
+                               msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
     return 0;
 }

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -46,6 +46,7 @@ static struct broadwell_4f_offsets msrs =
     .msr_dram_power_limit         = 0x618,
     .msr_dram_energy_status       = 0x619,
     .msr_dram_perf_status         = 0x61B,
+    .msr_dram_power_info          = 0x61C,
     .msr_turbo_activation_ratio   = 0x64C,
     .ia32_mperf                   = 0xE7,
     .ia32_aperf                   = 0xE8,
@@ -118,6 +119,18 @@ int fm_06_4f_get_power_limits(int long_ver)
         else if (long_ver == 1)
         {
             print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        if (long_ver == 0)
+        {
+            print_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
         }
     }
 
@@ -212,6 +225,8 @@ int fm_06_4f_get_features(void)
             msrs.msr_dram_energy_status);
     fprintf(stdout, "msr_dram_perf_status         = 0x%lx\n",
             msrs.msr_dram_perf_status);
+    fprintf(stdout, "msr_dram_power_info           = 0x%lx\n",
+            msrs.msr_dram_power_info);
     fprintf(stdout, "msr_turbo_activation_ratio   = 0x%lx\n",
             msrs.msr_turbo_activation_ratio);
     fprintf(stdout, "ia32_mperf                   = 0x%lx\n", msrs.ia32_mperf);

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -444,7 +444,8 @@ int fm_06_4f_get_node_power_domain_info_json(json_t *get_domain_obj)
 #endif
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info);
+                               msrs.msr_dram_power_info,
+msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
     return 0;
 }

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -443,7 +443,8 @@ int fm_06_4f_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info(get_domain_obj);
+    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
+                                msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -443,8 +443,8 @@ int fm_06_4f_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
-                                msrs.msr_dram_power_info);
+    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -56,6 +56,8 @@ struct broadwell_4f_offsets
     off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
     off_t msr_pkg_power_info;
+    /// @brief Address for DRAM_POWER_INFO.
+    off_t msr_dram_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
     off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -419,8 +419,8 @@ int fm_06_3f_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
-                                msrs.msr_dram_power_info);
+    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -420,7 +420,7 @@ int fm_06_3f_get_node_power_domain_info_json(json_t *get_domain_obj)
 #endif
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info);
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
     return 0;
 }

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -45,6 +45,7 @@ static struct haswell_3f_offsets msrs =
     .msr_dram_power_limit         = 0x618,
     .msr_dram_energy_status       = 0x619,
     .msr_dram_perf_status         = 0x61B,
+    .msr_dram_power_info          = 0x61C,
     .msr_turbo_activation_ratio   = 0x64C,
     .ia32_mperf                   = 0xE7,
     .ia32_aperf                   = 0xE8,
@@ -113,6 +114,18 @@ int fm_06_3f_get_power_limits(int long_ver)
         else if (long_ver == 1)
         {
             print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        if (long_ver == 0)
+        {
+            print_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
         }
     }
 
@@ -205,6 +218,8 @@ int fm_06_3f_get_features(void)
             msrs.msr_dram_energy_status);
     fprintf(stdout, "msr_dram_perf_status         = 0x%lx\n",
             msrs.msr_dram_perf_status);
+    fprintf(stdout, "msr_dram_power_info           = 0x%lx\n",
+            msrs.msr_dram_power_info);
     fprintf(stdout, "msr_turbo_activation_ratio   = 0x%lx\n",
             msrs.msr_turbo_activation_ratio);
     fprintf(stdout, "ia32_mperf                   = 0x%lx\n", msrs.ia32_mperf);

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -398,6 +398,17 @@ int fm_06_3f_get_node_power_json(json_t *get_power_obj)
     return 0;
 }
 
+int fm_06_3f_get_node_power_domain_info_json(json_t *get_domain_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_get_power_domain_info(get_domain_obj);
+
+    return 0;
+}
+
 int fm_06_3f_cap_best_effort_node_power_limit(int node_limit)
 {
 #ifdef VARIORUM_LOG

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -419,7 +419,8 @@ int fm_06_3f_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info(get_domain_obj);
+    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
+                                msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/Haswell_3F.h
+++ b/src/variorum/Intel/Haswell_3F.h
@@ -56,6 +56,8 @@ struct haswell_3f_offsets
     off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
     off_t msr_pkg_power_info;
+    /// @brief Address for DRAM_POWER_INFO.
+    off_t msr_dram_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
     off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.

--- a/src/variorum/Intel/Haswell_3F.h
+++ b/src/variorum/Intel/Haswell_3F.h
@@ -107,6 +107,8 @@ int fm_06_3f_monitoring(FILE *output);
 
 int fm_06_3f_get_node_power_json(json_t *get_power_obj);
 
+int fm_06_3f_get_node_power_domain_info_json(json_t *get_domain_obj);
+
 int fm_06_3f_cap_best_effort_node_power_limit(int node_power_limit);
 
 int fm_06_3f_get_frequencies(void);

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -433,8 +433,8 @@ int fm_06_3e_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
-                                msrs.msr_dram_power_info);
+    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -433,7 +433,8 @@ int fm_06_3e_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info(get_domain_obj);
+    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
+                                msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -412,6 +412,17 @@ int fm_06_3e_get_node_power_json(json_t *get_power_obj)
     return 0;
 }
 
+int fm_06_3e_get_node_power_domain_info_json(json_t *get_domain_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_get_power_domain_info(get_domain_obj);
+
+    return 0;
+}
+
 int fm_06_3e_cap_best_effort_node_power_limit(int node_limit)
 {
 #ifdef VARIORUM_LOG

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -434,7 +434,7 @@ int fm_06_3e_get_node_power_domain_info_json(json_t *get_domain_obj)
 #endif
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info);
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
     return 0;
 }

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -45,6 +45,7 @@ static struct ivybridge_3e_offsets msrs =
     .msr_dram_power_limit         = 0x618,
     .msr_dram_energy_status       = 0x619,
     .msr_dram_perf_status         = 0x61B,
+    .msr_dram_power_info          = 0x61C,
     .msr_turbo_activation_ratio   = 0x64C,
     .ia32_mperf                   = 0xE7,
     .ia32_aperf                   = 0xE8,
@@ -117,6 +118,18 @@ int fm_06_3e_get_power_limits(int long_ver)
         else if (long_ver == 1)
         {
             print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        if (long_ver == 0)
+        {
+            print_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
         }
     }
 
@@ -210,6 +223,8 @@ int fm_06_3e_get_features(void)
             msrs.msr_dram_energy_status);
     fprintf(stdout, "msr_dram_perf_status         = 0x%lx\n",
             msrs.msr_dram_perf_status);
+    fprintf(stdout, "msr_dram_power_info           = 0x%lx\n",
+            msrs.msr_dram_power_info);
     fprintf(stdout, "msr_turbo_activation_ratio   = 0x%lx\n",
             msrs.msr_turbo_activation_ratio);
     fprintf(stdout, "ia32_mperf                   = 0x%lx\n", msrs.ia32_mperf);

--- a/src/variorum/Intel/IvyBridge_3E.h
+++ b/src/variorum/Intel/IvyBridge_3E.h
@@ -56,6 +56,8 @@ struct ivybridge_3e_offsets
     off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
     off_t msr_pkg_power_info;
+    /// @brief Address for DRAM_POWER_INFO.
+    off_t msr_dram_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
     off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.

--- a/src/variorum/Intel/IvyBridge_3E.h
+++ b/src/variorum/Intel/IvyBridge_3E.h
@@ -105,6 +105,8 @@ int fm_06_3e_monitoring(FILE *output);
 
 int fm_06_3e_get_node_power_json(json_t *get_power_obj);
 
+int fm_06_3e_get_node_power_domain_info_json(json_t *get_domain_obj);
+
 int fm_06_3e_cap_best_effort_node_power_limit(int node_power_limit);
 
 int fm_06_3e_get_frequencies(void);

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -45,6 +45,7 @@ static struct kabylake_9e_offsets msrs =
     .msr_dram_power_limit         = 0x618,
     .msr_dram_energy_status       = 0x619,
     .msr_dram_perf_status         = 0x61B,
+    .msr_dram_power_info          = 0x61C,
     .msr_turbo_activation_ratio   = 0x64C,
     .ia32_mperf                   = 0xE7,
     .ia32_aperf                   = 0xE8,
@@ -99,6 +100,18 @@ int fm_06_9e_get_power_limits(int long_ver)
         else if (long_ver == 1)
         {
             print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        if (long_ver == 0)
+        {
+            print_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
         }
     }
 
@@ -192,6 +205,8 @@ int fm_06_9e_get_features(void)
             msrs.msr_dram_energy_status);
     fprintf(stdout, "msr_dram_perf_status         = 0x%lx\n",
             msrs.msr_dram_perf_status);
+    fprintf(stdout, "msr_dram_power_info           = 0x%lx\n",
+            msrs.msr_dram_power_info);
     fprintf(stdout, "msr_turbo_activation_ratio   = 0x%lx\n",
             msrs.msr_turbo_activation_ratio);
     fprintf(stdout, "ia32_mperf                   = 0x%lx\n", msrs.ia32_mperf);

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -371,7 +371,8 @@ int fm_06_9e_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info(get_domain_obj);
+    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
+                                msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -350,6 +350,17 @@ int fm_06_9e_get_node_power_json(json_t *get_power_obj)
     return 0;
 }
 
+int fm_06_9e_get_node_power_domain_info_json(json_t *get_domain_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_get_power_domain_info(get_domain_obj);
+
+    return 0;
+}
+
 int fm_06_9e_cap_best_effort_node_power_limit(int node_limit)
 {
 #ifdef VARIORUM_LOG

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -371,8 +371,8 @@ int fm_06_9e_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
-                                msrs.msr_dram_power_info);
+    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -372,7 +372,7 @@ int fm_06_9e_get_node_power_domain_info_json(json_t *get_domain_obj)
 #endif
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info);
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
     return 0;
 }

--- a/src/variorum/Intel/KabyLake_9E.h
+++ b/src/variorum/Intel/KabyLake_9E.h
@@ -101,6 +101,8 @@ int fm_06_9e_monitoring(FILE *output);
 
 int fm_06_9e_get_node_power_json(json_t *get_power_obj);
 
+int fm_06_9e_get_node_power_domain_info_json(json_t *get_domain_obj);
+
 int fm_06_9e_cap_best_effort_node_power_limit(int node_power_limit);
 
 int fm_06_9e_get_frequencies(void);

--- a/src/variorum/Intel/KabyLake_9E.h
+++ b/src/variorum/Intel/KabyLake_9E.h
@@ -56,6 +56,8 @@ struct kabylake_9e_offsets
     off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
     off_t msr_pkg_power_info;
+    /// @brief Address for DRAM_POWER_INFO.
+    off_t msr_dram_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
     off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -401,8 +401,8 @@ int fm_06_2a_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
-                                msrs.msr_dram_power_info);
+    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -401,7 +401,8 @@ int fm_06_2a_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info(get_domain_obj);
+    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
+                                msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -39,6 +39,7 @@ static struct sandybridge_2a_offsets msrs =
     .msr_pkg_power_limit          = 0x610,
     .msr_pkg_energy_status        = 0x611,
     .msr_pkg_power_info           = 0x614,
+    .msr_dram_power_info          = 0x61C,
     .ia32_mperf                   = 0xE7,
     .ia32_aperf                   = 0xE8,
     .ia32_perfmon_counters[0]     = 0xC1,
@@ -106,6 +107,18 @@ int fm_06_2a_get_power_limits(int long_ver)
         else if (long_ver == 1)
         {
             print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        if (long_ver == 0)
+        {
+            print_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
         }
     }
 
@@ -188,6 +201,8 @@ int fm_06_2a_get_features(void)
             msrs.msr_pkg_energy_status);
     fprintf(stdout, "msr_pkg_power_info           = 0x%lx\n",
             msrs.msr_pkg_power_info);
+    fprintf(stdout, "msr_dram_power_info           = 0x%lx\n",
+            msrs.msr_dram_power_info);
     fprintf(stdout, "ia32_mperf                   = 0x%lx\n", msrs.ia32_mperf);
     fprintf(stdout, "ia32_aperf                   = 0x%lx\n", msrs.ia32_aperf);
     fprintf(stdout, "ia32_perfmon_counters[0]     = 0x%lx\n",

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -402,7 +402,7 @@ int fm_06_2a_get_node_power_domain_info_json(json_t *get_domain_obj)
 #endif
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info);
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -380,6 +380,17 @@ int fm_06_2a_get_node_power_json(json_t *get_power_obj)
     return 0;
 }
 
+int fm_06_2a_get_node_power_domain_info_json(json_t *get_domain_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_get_power_domain_info(get_domain_obj);
+
+    return 0;
+}
+
 int fm_06_2a_cap_best_effort_node_power_limit(int node_limit)
 {
 #ifdef VARIORUM_LOG

--- a/src/variorum/Intel/SandyBridge_2A.h
+++ b/src/variorum/Intel/SandyBridge_2A.h
@@ -102,6 +102,8 @@ int fm_06_2a_monitoring(FILE *output);
 
 int fm_06_2a_get_node_power_json(json_t *get_power_obj);
 
+int fm_06_2a_get_node_power_domain_info_json(json_t *get_domain_obj);
+
 int fm_06_2a_cap_best_effort_node_power_limit(int node_power_limit);
 
 int fm_06_2a_get_frequencies(void);

--- a/src/variorum/Intel/SandyBridge_2A.h
+++ b/src/variorum/Intel/SandyBridge_2A.h
@@ -54,6 +54,8 @@ struct sandybridge_2a_offsets
     off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
     off_t msr_pkg_power_info;
+    /// @brief Address for DRAM_POWER_INFO.
+    off_t msr_dram_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
     off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -405,7 +405,7 @@ int fm_06_2d_get_node_power_domain_info_json(json_t *get_domain_obj)
 #endif
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info);
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -404,7 +404,8 @@ int fm_06_2d_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info(get_domain_obj);
+    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
+                                msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -40,6 +40,7 @@ static struct sandybridge_2d_offsets msrs =
     .msr_pkg_power_limit          = 0x610,
     .msr_pkg_energy_status        = 0x611,
     .msr_pkg_power_info           = 0x614,
+    .msr_dram_power_info          = 0x61C,
     .ia32_mperf                   = 0xE7,
     .ia32_aperf                   = 0xE8,
     .ia32_perfmon_counters[0]     = 0xC1,
@@ -107,6 +108,18 @@ int fm_06_2d_get_power_limits(int long_ver)
         else if (long_ver == 1)
         {
             print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        if (long_ver == 0)
+        {
+            print_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
         }
     }
 
@@ -191,6 +204,8 @@ int fm_06_2d_get_features(void)
             msrs.msr_pkg_energy_status);
     fprintf(stdout, "msr_pkg_power_info           = 0x%lx\n",
             msrs.msr_pkg_power_info);
+    fprintf(stdout, "msr_dram_power_info           = 0x%lx\n",
+            msrs.msr_dram_power_info);
     fprintf(stdout, "ia32_mperf                   = 0x%lx\n", msrs.ia32_mperf);
     fprintf(stdout, "ia32_aperf                   = 0x%lx\n", msrs.ia32_aperf);
     fprintf(stdout, "ia32_perfmon_counters[0]     = 0x%lx\n",

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -404,8 +404,8 @@ int fm_06_2d_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
-                                msrs.msr_dram_power_info);
+    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -383,6 +383,17 @@ int fm_06_2d_get_node_power_json(json_t *get_power_obj)
     return 0;
 }
 
+int fm_06_2d_get_node_power_domain_info_json(json_t *get_domain_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_get_power_domain_info(get_domain_obj);
+
+    return 0;
+}
+
 int fm_06_2d_cap_best_effort_node_power_limit(int node_limit)
 {
 #ifdef VARIORUM_LOG

--- a/src/variorum/Intel/SandyBridge_2D.h
+++ b/src/variorum/Intel/SandyBridge_2D.h
@@ -56,6 +56,8 @@ struct sandybridge_2d_offsets
     off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
     off_t msr_pkg_power_info;
+    /// @brief Address for DRAM_POWER_INFO.
+    off_t msr_dram_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
     off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.

--- a/src/variorum/Intel/SandyBridge_2D.h
+++ b/src/variorum/Intel/SandyBridge_2D.h
@@ -104,6 +104,8 @@ int fm_06_2d_monitoring(FILE *output);
 
 int fm_06_2d_get_node_power_json(json_t *get_power_obj);
 
+int fm_06_2d_get_node_power_domain_info_json(json_t *get_domain_obj);
+
 int fm_06_2d_cap_best_effort_node_power_limit(int node_power_limit);
 
 int fm_06_2d_get_frequencies(void);

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -369,8 +369,8 @@ int fm_06_55_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
-                                msrs.msr_dram_power_info);
+    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -348,6 +348,17 @@ int fm_06_55_get_node_power_json(json_t *get_power_obj)
     return 0;
 }
 
+int fm_06_55_get_node_power_domain_info_json(json_t *get_domain_obj)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_get_power_domain_info(get_domain_obj);
+
+    return 0;
+}
+
 int fm_06_55_cap_best_effort_node_power_limit(int node_limit)
 {
 #ifdef VARIORUM_LOG

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -369,7 +369,8 @@ int fm_06_55_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info(get_domain_obj);
+    json_get_power_domain_info (get_domain_obj, msrs.msr_pkg_power_info,
+                                msrs.msr_dram_power_info);
 
     return 0;
 }

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -44,6 +44,7 @@ static struct skylake_55_offsets msrs =
     .msr_dram_power_limit         = 0x618,
     .msr_dram_energy_status       = 0x619,
     .msr_dram_perf_status         = 0x61B,
+    .msr_dram_power_info          = 0x61C,
     .msr_turbo_activation_ratio   = 0x64C,
     .ia32_mperf                   = 0xE7,
     .ia32_aperf                   = 0xE8,
@@ -98,6 +99,18 @@ int fm_06_55_get_power_limits(int long_ver)
         else if (long_ver == 1)
         {
             print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        if (long_ver == 0)
+        {
+            print_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
         }
     }
 
@@ -190,6 +203,8 @@ int fm_06_55_get_features(void)
             msrs.msr_dram_energy_status);
     fprintf(stdout, "msr_dram_perf_status         = 0x%lx\n",
             msrs.msr_dram_perf_status);
+    fprintf(stdout, "msr_dram_power_info           = 0x%lx\n",
+            msrs.msr_dram_power_info);
     fprintf(stdout, "msr_turbo_activation_ratio   = 0x%lx\n",
             msrs.msr_turbo_activation_ratio);
     fprintf(stdout, "ia32_mperf                   = 0x%lx\n", msrs.ia32_mperf);

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -370,7 +370,7 @@ int fm_06_55_get_node_power_domain_info_json(json_t *get_domain_obj)
 #endif
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info);
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
     return 0;
 }

--- a/src/variorum/Intel/Skylake_55.h
+++ b/src/variorum/Intel/Skylake_55.h
@@ -103,6 +103,8 @@ int fm_06_55_get_node_power_json(json_t *get_power_obj);
 
 int fm_06_55_cap_best_effort_node_power_limit(int node_power_limit);
 
+int fm_06_55_get_node_power_domain_info_json(json_t *get_domain_obj);
+
 int fm_06_55_cap_frequency(int core_freq_mhz);
 
 int fm_06_55_get_frequencies(void);

--- a/src/variorum/Intel/Skylake_55.h
+++ b/src/variorum/Intel/Skylake_55.h
@@ -56,6 +56,8 @@ struct skylake_55_offsets
     off_t msr_pkg_perf_status;
     /// @brief Address for PKG_POWER_INFO.
     off_t msr_pkg_power_info;
+    /// @brief Address for DRAM_POWER_INFO.
+    off_t msr_dram_power_info;
     /// @brief Address for DRAM_POWER_LIMIT.
     off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -86,6 +86,8 @@ int set_intel_func_ptrs(void)
         //    fm_06_2a_cap_frequency;
         g_platform.variorum_get_node_power_json =
             fm_06_2a_get_node_power_json;
+        g_platform.variorum_get_node_power_domain_info_json =
+            fm_06_2a_get_node_power_domain_info_json;
         g_platform.variorum_cap_best_effort_node_power_limit =
             fm_06_2a_cap_best_effort_node_power_limit;
         g_platform.variorum_print_available_frequencies =
@@ -109,6 +111,8 @@ int set_intel_func_ptrs(void)
         //    fm_06_2d_cap_frequency;
         g_platform.variorum_get_node_power_json =
             fm_06_2d_get_node_power_json;
+        g_platform.variorum_get_node_power_domain_info_json =
+            fm_06_2d_get_node_power_domain_info_json;
         g_platform.variorum_cap_best_effort_node_power_limit =
             fm_06_2d_cap_best_effort_node_power_limit;
         g_platform.variorum_print_available_frequencies =
@@ -134,6 +138,8 @@ int set_intel_func_ptrs(void)
         //    fm_06_3e_cap_frequency;
         g_platform.variorum_get_node_power_json =
             fm_06_3e_get_node_power_json;
+        g_platform.variorum_get_node_power_domain_info_json =
+            fm_06_3e_get_node_power_domain_info_json;
         g_platform.variorum_cap_best_effort_node_power_limit =
             fm_06_3e_cap_best_effort_node_power_limit;
         g_platform.variorum_print_available_frequencies =
@@ -159,6 +165,8 @@ int set_intel_func_ptrs(void)
         //    fm_06_3f_cap_frequency;
         g_platform.variorum_get_node_power_json =
             fm_06_3f_get_node_power_json;
+        g_platform.variorum_get_node_power_domain_info_json =
+            fm_06_3f_get_node_power_domain_info_json;
         g_platform.variorum_cap_best_effort_node_power_limit =
             fm_06_3f_cap_best_effort_node_power_limit;
         g_platform.variorum_print_available_frequencies =
@@ -209,6 +217,8 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_monitoring = fm_06_55_monitoring;
         g_platform.variorum_get_node_power_json =
             fm_06_55_get_node_power_json;
+        g_platform.variorum_get_node_power_domain_info_json =
+            fm_06_55_get_node_power_domain_info_json;
         g_platform.variorum_cap_best_effort_node_power_limit =
             fm_06_55_cap_best_effort_node_power_limit;
         g_platform.variorum_cap_each_core_frequency_limit = fm_06_55_cap_frequency;
@@ -233,6 +243,8 @@ int set_intel_func_ptrs(void)
         g_platform.variorum_monitoring = fm_06_9e_monitoring;
         g_platform.variorum_get_node_power_json =
             fm_06_9e_get_node_power_json;
+        g_platform.variorum_get_node_power_domain_info_json =
+            fm_06_9e_get_node_power_domain_info_json;
         g_platform.variorum_cap_best_effort_node_power_limit =
             fm_06_9e_cap_best_effort_node_power_limit;
         g_platform.variorum_print_available_frequencies =

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1080,9 +1080,27 @@ void json_get_power_domain_info(json_t *get_domain_obj,
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
-
+    struct pkg_power_info pkg_info;
+    struct dram_power_info dram_info;
+    char range_str[36] = "[{min: ";
     double pkg_max, pkg_min, dram_max, dram_min;
 
+    get_rapl_pkg_power_info(socket, &pkg_info, msr_pkg_power_info);
+    get_rapl_pkg_power_info(socket, &dram_info, msr_dram_power_info);
+
+    pkg_min = pkg_info.pkg_min_power;
+    pkg_max = pkg_info.pkg_max_power;
+    dram_min = dram_info.dram_min_power;
+    dram_max = dram_info.dram_max_power;
+    
+    strcat(range_str, pkg_min);
+    strcat(range_str, ", max: ");
+    strcat(range_str, pkg_max);
+    strcat(range_str, "},{min: ");
+    strcat(range_str, dram_min);
+    strcat(range_str, ", max: ");
+    strcat(range_str, dram_max);
+    strcat(range_str, "}]");
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);
@@ -1101,7 +1119,7 @@ void json_get_power_domain_info(json_t *get_domain_obj,
     json_object_set_new(get_domain_obj, "control_units",
                         json_string("[Watts, Watts]"));
     json_object_set_new(get_domain_obj, "control_range",
-                        json_string("[{min: 65, max: 135}, {min: 15, max: 30}]"));
+                        json_string(range_str));
 
     // Need to figure out a way to specify capping limits by reading MSRs.
     // If we have an NVIDIA + Intel build, the GPU info should be updated.

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1076,7 +1076,7 @@ void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit,
 
 void json_get_power_domain_info(json_t *get_domain_obj,
                                 off_t msr_pkg_power_info, off_t
-msr_dram_power_info, off_t msr_rapl_unit, off_t msr_power_limit)
+                                msr_dram_power_info, off_t msr_rapl_unit, off_t msr_power_limit)
 {
     char hostname[1024];
     struct timeval tv;
@@ -1096,10 +1096,10 @@ msr_dram_power_info, off_t msr_rapl_unit, off_t msr_power_limit)
     get_rapl_dram_power_info(0, &dram_info, msr_dram_power_info);
 
     snprintf(range_str, sizeof range_str, "%s%lf%s%lf%s%lf%s%lf%s",
-		    "[{min: ", pkg_info.pkg_min_power,
-		    ", max: ", pkg_info.pkg_max_power,
-		    "}, {min: ", dram_info.dram_min_power,
-		    ", max: ", dram_info.dram_max_power, "}]");
+             "[{min: ", pkg_info.pkg_min_power,
+             ", max: ", pkg_info.pkg_max_power,
+             "}, {min: ", dram_info.dram_min_power,
+             ", max: ", dram_info.dram_max_power, "}]");
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1080,13 +1080,14 @@ void json_get_power_domain_info(json_t *get_domain_obj,
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
-    struct pkg_power_info pkg_info;
-    struct dram_power_info dram_info;
+    struct rapl_pkg_power_info pkg_info;
+    struct rapl_dram_power_info dram_info;
     char range_str[36] = "[{min: ";
     double pkg_max, pkg_min, dram_max, dram_min;
 
-    get_rapl_pkg_power_info(socket, &pkg_info, msr_pkg_power_info);
-    get_rapl_pkg_power_info(socket, &dram_info, msr_dram_power_info);
+    // First argument here is socket ID, both sockets have same info.
+    get_rapl_pkg_power_info(0, &pkg_info, msr_pkg_power_info);
+    get_rapl_pkg_power_info(0, &dram_info, msr_dram_power_info);
 
     pkg_min = pkg_info.pkg_min_power;
     pkg_max = pkg_info.pkg_max_power;
@@ -1100,7 +1101,7 @@ void json_get_power_domain_info(json_t *get_domain_obj,
     sprintf(range_str, "%f", dram_min);
     sprintf(range_str, "%s", ", max: ");
     sprintf(range_str, "%f", dram_max);
-    sprintf(range_str, "%s" "}]");
+    sprintf(range_str, "%s", "}]");
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -484,13 +484,13 @@ void print_dram_power_info(FILE *writedest, off_t msr, int socket)
 {
     struct rapl_dram_power_info info;
     char hostname[1024];
-    static int init_print_package_power_info = 0;
+    static int init_print_dram_power_info = 0;
 
     gethostname(hostname, 1024);
 
-    if (!init_print_package_power_info)
+    if (!init_print_dram_power_info)
     {
-        init_print_package_power_info = 1;
+        init_print_dram_power_info = 1;
         fprintf(writedest,
                 "_DRAM_POWER_INFO Offset Host Socket Bits MaxPower_W MinPower_W MaxTimeWindow_sec ThermPower_W\n");
     }
@@ -498,8 +498,8 @@ void print_dram_power_info(FILE *writedest, off_t msr, int socket)
     if (!get_rapl_dram_power_info(socket, &info, msr))
     {
         fprintf(writedest, "_DRAM_POWER_INFO 0x%lx %s %d 0x%lx %lf %lf %lf %lf\n",
-                msr, hostname, socket, info.msr_dram_power_info, info.pkg_max_power,
-                info.pkg_min_power, info.pkg_max_window, info.pkg_therm_power);
+                msr, hostname, socket, info.msr_dram_power_info, info.dram_max_power,
+                info.dram_min_power, info.dram_max_window, info.dram_therm_power);
     }
 }
 
@@ -514,8 +514,8 @@ void print_verbose_dram_power_info(FILE *writedest, off_t msr, int socket)
     {
         fprintf(writedest,
                 "_DRAM_POWER_INFO Offset: 0x%lx, Host: %s, Socket: %d, Bits: 0x%lx, MaxPower: %lf W, MinPower: %lf W, MaxTimeWindow: %lf sec, ThermPower: %lf W\n",
-                msr, hostname, socket, info.msr_dram_power_info, info.pkg_max_power,
-                info.pkg_min_power, info.pkg_max_window, info.pkg_therm_power);
+                msr, hostname, socket, info.msr_dram_power_info, info.dram_max_power,
+                info.dram_min_power, info.dram_max_window, info.dram_therm_power);
     }
 }
 

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1092,15 +1092,15 @@ void json_get_power_domain_info(json_t *get_domain_obj,
     pkg_max = pkg_info.pkg_max_power;
     dram_min = dram_info.dram_min_power;
     dram_max = dram_info.dram_max_power;
-    
-    strcat(range_str, pkg_min);
-    strcat(range_str, ", max: ");
-    strcat(range_str, pkg_max);
-    strcat(range_str, "},{min: ");
-    strcat(range_str, dram_min);
-    strcat(range_str, ", max: ");
-    strcat(range_str, dram_max);
-    strcat(range_str, "}]");
+   
+    sprintf(range_str, "%f", pkg_min); 
+    sprintf(range_str, "%s", ", max: "); 
+    sprintf(range_str, "%f", pkg_max); 
+    sprintf(range_str, "%s", "},{min: ");
+    sprintf(range_str, "%f", dram_min);
+    sprintf(range_str, "%s", ", max: ");
+    sprintf(range_str, "%f", dram_max);
+    sprintf(range_str, "%s" "}]");
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1075,7 +1075,7 @@ void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit,
 
 
 void json_get_power_domain_info(json_t *get_domain_obj,
-                         off_t msr_pkg_power_info, off_t msr_dram_power_info)
+                                off_t msr_pkg_power_info, off_t msr_dram_power_info)
 {
     char hostname[1024];
     struct timeval tv;

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -696,15 +696,17 @@ int cap_package_power_limit(const unsigned socket, int package_power_limit,
     return ret;
 }
 
-int get_rapl_pkg_power_info(const unsigned socket, struct rapl_pkg_power_info *info,
-                        off_t msr)
+int get_rapl_pkg_power_info(const unsigned socket,
+                            struct rapl_pkg_power_info *info,
+                            off_t msr)
 {
     uint64_t val = 0;
 
     sockets_assert(&socket);
 
 #ifdef VARIORUM_DEBUG
-    fprintf(stderr, "%s %s::%d DEBUG: (get_rapl_pkg_power_info)\n", getenv("HOSTNAME"),
+    fprintf(stderr, "%s %s::%d DEBUG: (get_rapl_pkg_power_info)\n",
+            getenv("HOSTNAME"),
             __FILE__, __LINE__);
 #endif
 
@@ -724,15 +726,17 @@ int get_rapl_pkg_power_info(const unsigned socket, struct rapl_pkg_power_info *i
     return 0;
 }
 
-int get_rapl_dram_power_info(const unsigned socket, struct rapl_dram_power_info *info,
-                        off_t msr)
+int get_rapl_dram_power_info(const unsigned socket,
+                             struct rapl_dram_power_info *info,
+                             off_t msr)
 {
     uint64_t val = 0;
 
     sockets_assert(&socket);
 
 #ifdef VARIORUM_DEBUG
-    fprintf(stderr, "%s %s::%d DEBUG: (get_rapl_dram_power_info)\n", getenv("HOSTNAME"),
+    fprintf(stderr, "%s %s::%d DEBUG: (get_rapl_dram_power_info)\n",
+            getenv("HOSTNAME"),
             __FILE__, __LINE__);
 #endif
 

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1087,16 +1087,16 @@ void json_get_power_domain_info(json_t *get_domain_obj,
 
     // First argument here is socket ID, both sockets have same info.
     get_rapl_pkg_power_info(0, &pkg_info, msr_pkg_power_info);
-    get_rapl_pkg_power_info(0, &dram_info, msr_dram_power_info);
+    get_rapl_dram_power_info(0, &dram_info, msr_dram_power_info);
 
     pkg_min = pkg_info.pkg_min_power;
     pkg_max = pkg_info.pkg_max_power;
     dram_min = dram_info.dram_min_power;
     dram_max = dram_info.dram_max_power;
-   
-    sprintf(range_str, "%f", pkg_min); 
-    sprintf(range_str, "%s", ", max: "); 
-    sprintf(range_str, "%f", pkg_max); 
+
+    sprintf(range_str, "%f", pkg_min);
+    sprintf(range_str, "%s", ", max: ");
+    sprintf(range_str, "%f", pkg_max);
     sprintf(range_str, "%s", "},{min: ");
     sprintf(range_str, "%f", dram_min);
     sprintf(range_str, "%s", ", max: ");

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -742,16 +742,16 @@ int get_rapl_dram_power_info(const unsigned socket,
 
     read_msr_by_coord(socket, 0, 0, msr, &(info->msr_dram_power_info));
     val = MASK_VAL(info->msr_dram_power_info, 54, 48);
-    translate(socket, &val, &(info->pkg_max_window), BITS_TO_SECONDS_STD, msr);
+    translate(socket, &val, &(info->dram_max_window), BITS_TO_SECONDS_STD, msr);
 
     val = MASK_VAL(info->msr_dram_power_info, 46, 32);
-    translate(socket, &val, &(info->pkg_max_power), BITS_TO_WATTS, msr);
+    translate(socket, &val, &(info->dram_max_power), BITS_TO_WATTS, msr);
 
     val = MASK_VAL(info->msr_dram_power_info, 30, 16);
-    translate(socket, &val, &(info->pkg_min_power), BITS_TO_WATTS, msr);
+    translate(socket, &val, &(info->dram_min_power), BITS_TO_WATTS, msr);
 
     val = MASK_VAL(info->msr_dram_power_info, 14, 0);
-    translate(socket, &val, &(info->pkg_therm_power), BITS_TO_WATTS, msr);
+    translate(socket, &val, &(info->dram_therm_power), BITS_TO_WATTS, msr);
 
     return 0;
 }

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1074,11 +1074,15 @@ void json_get_power_data(json_t *get_power_obj, off_t msr_power_limit,
 }
 
 
-void json_get_power_domain_info(json_t *get_domain_obj)
+void json_get_power_domain_info(json_t *get_domain_obj,
+                         off_t msr_pkg_power_info, off_t msr_dram_power_info)
 {
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
+
+    double pkg_max, pkg_min, dram_max, dram_min;
+
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -1082,26 +1082,17 @@ void json_get_power_domain_info(json_t *get_domain_obj,
     uint64_t ts;
     struct rapl_pkg_power_info pkg_info;
     struct rapl_dram_power_info dram_info;
-    char range_str[36] = "[{min: ";
-    double pkg_max, pkg_min, dram_max, dram_min;
+    char range_str[100];
 
     // First argument here is socket ID, both sockets have same info.
-    get_rapl_pkg_power_info(0, &pkg_info, msr_pkg_power_info);
-    get_rapl_dram_power_info(0, &dram_info, msr_dram_power_info);
+    get_rapl_pkg_power_info(1, &pkg_info, msr_pkg_power_info);
+    get_rapl_dram_power_info(1, &dram_info, msr_dram_power_info);
 
-    pkg_min = pkg_info.pkg_min_power;
-    pkg_max = pkg_info.pkg_max_power;
-    dram_min = dram_info.dram_min_power;
-    dram_max = dram_info.dram_max_power;
-
-    sprintf(range_str, "%f", pkg_min);
-    sprintf(range_str, "%s", ", max: ");
-    sprintf(range_str, "%f", pkg_max);
-    sprintf(range_str, "%s", "},{min: ");
-    sprintf(range_str, "%f", dram_min);
-    sprintf(range_str, "%s", ", max: ");
-    sprintf(range_str, "%f", dram_max);
-    sprintf(range_str, "%s", "}]");
+    snprintf(range_str, sizeof range_str, "%s%lf%s%lf%s%lf%s%lf%s", 
+		    "[{min: ", pkg_info.pkg_min_power, 
+		    ", max: ", pkg_info.pkg_max_power, 
+		    "}, {min: ", dram_info.dram_min_power,
+		    ", max: ", dram_info.dram_max_power, "}]");
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);

--- a/src/variorum/Intel/power_features.c
+++ b/src/variorum/Intel/power_features.c
@@ -443,7 +443,7 @@ void print_verbose_rapl_power_unit(FILE *writedest, off_t msr)
 
 void print_package_power_info(FILE *writedest, off_t msr, int socket)
 {
-    struct rapl_power_info info;
+    struct rapl_pkg_power_info info;
     char hostname[1024];
     static int init_print_package_power_info = 0;
 
@@ -456,7 +456,7 @@ void print_package_power_info(FILE *writedest, off_t msr, int socket)
                 "_PACKAGE_POWER_INFO Offset Host Socket Bits MaxPower_W MinPower_W MaxTimeWindow_sec ThermPower_W\n");
     }
 
-    if (!get_rapl_power_info(socket, &info, msr))
+    if (!get_rapl_pkg_power_info(socket, &info, msr))
     {
         fprintf(writedest, "_PACKAGE_POWER_INFO 0x%lx %s %d 0x%lx %lf %lf %lf %lf\n",
                 msr, hostname, socket, info.msr_pkg_power_info, info.pkg_max_power,
@@ -466,12 +466,12 @@ void print_package_power_info(FILE *writedest, off_t msr, int socket)
 
 void print_verbose_package_power_info(FILE *writedest, off_t msr, int socket)
 {
-    struct rapl_power_info info;
+    struct rapl_pkg_power_info info;
     char hostname[1024];
 
     gethostname(hostname, 1024);
 
-    if (!get_rapl_power_info(socket, &info, msr))
+    if (!get_rapl_pkg_power_info(socket, &info, msr))
     {
         fprintf(writedest,
                 "_PACKAGE_POWER_INFO Offset: 0x%lx, Host: %s, Socket: %d, Bits: 0x%lx, MaxPower: %lf W, MinPower: %lf W, MaxTimeWindow: %lf sec, ThermPower: %lf W\n",
@@ -656,7 +656,7 @@ int cap_package_power_limit(const unsigned socket, int package_power_limit,
     return ret;
 }
 
-int get_rapl_power_info(const unsigned socket, struct rapl_power_info *info,
+int get_rapl_pkg_power_info(const unsigned socket, struct rapl_pkg_power_info *info,
                         off_t msr)
 {
     uint64_t val = 0;
@@ -664,7 +664,7 @@ int get_rapl_power_info(const unsigned socket, struct rapl_power_info *info,
     sockets_assert(&socket);
 
 #ifdef VARIORUM_DEBUG
-    fprintf(stderr, "%s %s::%d DEBUG: (get_rapl_power_info)\n", getenv("HOSTNAME"),
+    fprintf(stderr, "%s %s::%d DEBUG: (get_rapl_pkg_power_info)\n", getenv("HOSTNAME"),
             __FILE__, __LINE__);
 #endif
 
@@ -1019,7 +1019,7 @@ void json_get_power_domain_info(json_t *get_domain_obj)
     json_object_set_new(get_domain_obj, "control",
                         json_string("[power_cpu, power_mem]"));
     json_object_set_new(get_domain_obj, "unsupported",
-                        json_string("[]"));
+                        json_string("[power_node]"));
     json_object_set_new(get_domain_obj, "measurement_units",
                         json_string("[Watts, Watts]"));
     json_object_set_new(get_domain_obj, "control_units",

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -65,7 +65,7 @@ struct rapl_limit
 };
 
 /// @brief Structure containing power range info for RAPL usage for various
-/// RAPL DRAM power domains.
+/// RAPL power domains.
 struct rapl_pkg_power_info
 {
     /**************************/

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -260,7 +260,9 @@ void json_get_power_data(json_t *get_power_obj,
 
 void json_get_power_domain_info(json_t *get_domain_obj,
                                 off_t msr_pkg_power_info,
-                                off_t msr_dram_power_info);
+                                off_t msr_dram_power_info,
+                                off_t msr_rapl_unit,
+                                off_t msr_power_limit);
 
 /// @brief Store the RAPL data on the heap.
 ///

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -258,7 +258,9 @@ void json_get_power_data(json_t *get_power_obj,
                          off_t msr_pkg_energy_status,
                          off_t msr_dram_energy_status);
 
-void json_get_power_domain_info(json_t *get_domain_obj);
+void json_get_power_domain_info(json_t *get_domain_obj
+                         off_t msr_pkg_power_info,
+                         off_t msr_dram_power_info);
 
 /// @brief Store the RAPL data on the heap.
 ///

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -258,7 +258,7 @@ void json_get_power_data(json_t *get_power_obj,
                          off_t msr_pkg_energy_status,
                          off_t msr_dram_energy_status);
 
-void json_get_power_domain_info(json_t *get_domain_obj
+void json_get_power_domain_info(json_t *get_domain_obj,
                                 off_t msr_pkg_power_info,
                                 off_t msr_dram_power_info);
 

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -206,20 +206,20 @@ void print_rapl_power_unit(FILE *writedest,
                            off_t msr);
 
 int get_rapl_pkg_power_info(const unsigned socket,
-                        struct rapl_pkg_power_info *info,
-                        off_t msr);
+                            struct rapl_pkg_power_info *info,
+                            off_t msr);
 
 int get_rapl_dram_power_info(const unsigned socket,
-                        struct rapl_dram_power_info *info,
-                        off_t msr);
+                             struct rapl_dram_power_info *info,
+                             off_t msr);
 
 void print_package_power_info(FILE *writedest,
                               off_t msr,
                               int socket);
 
 void print_dram_power_info(FILE *writedest,
-                              off_t msr,
-                              int socket);
+                           off_t msr,
+                           int socket);
 
 void print_verbose_rapl_power_unit(FILE *writedest,
                                    off_t msr);
@@ -234,8 +234,8 @@ void print_verbose_package_power_info(FILE *writedest,
                                       int socket);
 
 void print_verbose_dram_power_info(FILE *writedest,
-                                      off_t msr,
-                                      int socket);
+                                   off_t msr,
+                                   int socket);
 
 int cap_package_power_limit(const unsigned socket,
                             int package_power_limit,

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -259,8 +259,8 @@ void json_get_power_data(json_t *get_power_obj,
                          off_t msr_dram_energy_status);
 
 void json_get_power_domain_info(json_t *get_domain_obj
-                         off_t msr_pkg_power_info,
-                         off_t msr_dram_power_info);
+                                off_t msr_pkg_power_info,
+                                off_t msr_dram_power_info);
 
 /// @brief Store the RAPL data on the heap.
 ///

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -65,7 +65,7 @@ struct rapl_limit
 };
 
 /// @brief Structure containing power range info for RAPL usage for various
-/// RAPL power domains.
+/// RAPL DRAM power domains.
 struct rapl_pkg_power_info
 {
     /**************************/
@@ -84,6 +84,28 @@ struct rapl_pkg_power_info
     double pkg_max_window;
     /// @brief Thermal specification power (in Watts) of the package domain.
     double pkg_therm_power;
+};
+
+/// @brief Structure containing power range info for RAPL usage for various
+/// RAPL DRAM power domains.
+struct rapl_dram_power_info
+{
+    /**************************/
+    /* RAPL Power Domain: DRAM */
+    /**************************/
+    /// @brief Raw 64-bit value stored in MSR_DRAM_POWER_INFO.
+    uint64_t msr_dram_power_info;
+    /// @brief Max power (in Watts) derived from electrical specifications of
+    /// the dram domain.
+    double dram_max_power;
+    /// @brief Min power (in Watts) derived from electrical specifications of
+    /// the dram domain.
+    double dram_min_power;
+    /// @brief Max time (in seconds) that can be set in either time window field
+    /// of the dram domain.
+    double dram_max_window;
+    /// @brief Thermal specification power (in Watts) of the dram domain.
+    double dram_therm_power;
 };
 
 /// @brief Structure containing data from energy, time, and power measurements
@@ -187,7 +209,15 @@ int get_rapl_pkg_power_info(const unsigned socket,
                         struct rapl_pkg_power_info *info,
                         off_t msr);
 
+int get_rapl_dram_power_info(const unsigned socket,
+                        struct rapl_dram_power_info *info,
+                        off_t msr);
+
 void print_package_power_info(FILE *writedest,
+                              off_t msr,
+                              int socket);
+
+void print_dram_power_info(FILE *writedest,
                               off_t msr,
                               int socket);
 
@@ -200,6 +230,10 @@ void print_verbose_package_power_limit(FILE *writedest,
                                        int socket);
 
 void print_verbose_package_power_info(FILE *writedest,
+                                      off_t msr,
+                                      int socket);
+
+void print_verbose_dram_power_info(FILE *writedest,
                                       off_t msr,
                                       int socket);
 

--- a/src/variorum/Intel/power_features.h
+++ b/src/variorum/Intel/power_features.h
@@ -66,7 +66,7 @@ struct rapl_limit
 
 /// @brief Structure containing power range info for RAPL usage for various
 /// RAPL power domains.
-struct rapl_power_info
+struct rapl_pkg_power_info
 {
     /**************************/
     /* RAPL Power Domain: PKG */
@@ -183,8 +183,8 @@ int get_dram_rapl_limit(const unsigned socket,
 void print_rapl_power_unit(FILE *writedest,
                            off_t msr);
 
-int get_rapl_power_info(const unsigned socket,
-                        struct rapl_power_info *info,
+int get_rapl_pkg_power_info(const unsigned socket,
+                        struct rapl_pkg_power_info *info,
                         off_t msr);
 
 void print_package_power_info(FILE *writedest,


### PR DESCRIPTION
 - [x] Add support for `MSR_DRAM_POWER_INFO` for Intel
- [x]  Populate data in power_features.c from the appropriate MSR. 
- [x] Add support for AMD port (untested as we don't have a system to test on)
- [x] Add support for ARM port, test on Juno r2 
- [x] Add issue about new API for frequency domain info (setting/getting)
- [x] Test on power lab nodes: Comus (Broadwell), Thompson (Haswell), Alehouse (Power9)
- [x] Test on Rhetoric (Skylake) 

Will close https://github.com/LLNL/variorum/issues/202, #229, and update a task on https://github.com/LLNL/variorum/issues/224 when done. 