### PR TITLE
Fixes "may be uninitialized" warning.

### DIFF
--- a/src/thirdparty_builtin/googletest/src/gtest-death-test.cc
+++ b/src/thirdparty_builtin/googletest/src/gtest-death-test.cc
@@ -996,14 +996,14 @@ static int ExecDeathTestChildMain(void* child_arg) {
 // correct answer.
 void StackLowerThanAddress(const void* ptr, bool* result) GTEST_NO_INLINE_;
 void StackLowerThanAddress(const void* ptr, bool* result) {
-  int dummy;
+  int dummy=0;
   *result = (&dummy < ptr);
 }
 
 // Make sure AddressSanitizer does not tamper with the stack here.
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 bool StackGrowsDown() {
-  int dummy;
+  int dummy=0;
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;


### PR DESCRIPTION
Spurious uninitialized variable warning in Google test code
silenced by initializing variable to zero.

Fixes #232 