### PR TITLE
Adds -h and -v flags for all examples

### DIFF
--- a/src/docs/sphinx/api/print_functions.rst
+++ b/src/docs/sphinx/api/print_functions.rst
@@ -18,6 +18,8 @@ output formats supported by Variorum.
 
 Defined in ``variorum/variorum.h``.
 
+.. doxygenfunction:: variorum_get_current_version
+
 .. doxygenfunction:: variorum_print_verbose_power_limit
 
 .. doxygenfunction:: variorum_print_power_limit

--- a/src/docs/sphinx/api/print_functions.rst
+++ b/src/docs/sphinx/api/print_functions.rst
@@ -18,7 +18,9 @@ output formats supported by Variorum.
 
 Defined in ``variorum/variorum.h``.
 
-.. doxygenfunction:: variorum_get_current_version
+.. doxygenfunction:: variorum_print_verbose_power
+
+.. doxygenfunction:: variorum_print_power
 
 .. doxygenfunction:: variorum_print_verbose_power_limit
 
@@ -31,10 +33,6 @@ Defined in ``variorum/variorum.h``.
 .. doxygenfunction:: variorum_print_verbose_counters
 
 .. doxygenfunction:: variorum_print_counters
-
-.. doxygenfunction:: variorum_print_verbose_power
-
-.. doxygenfunction:: variorum_print_power
 
 .. doxygenfunction:: variorum_print_verbose_frequency
 
@@ -59,4 +57,6 @@ Defined in ``variorum/variorum.h``.
 .. doxygenfunction:: variorum_poll_power
 
 .. doxygenfunction:: variorum_monitoring
+
+.. doxygenfunction:: variorum_get_current_version
 

--- a/src/examples/mpi-examples/variorum-print-power-limit-mpi-example.c
+++ b/src/examples/mpi-examples/variorum-print-power-limit-mpi-example.c
@@ -3,14 +3,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
+#include <getopt.h>
 #include <mpi.h>
 #include <rankstr_mpi.h>
+#include <stdio.h>
 #include <unistd.h>
 
 #include <variorum.h>
 
-int main()
+int main(int argc, char **argv)
 {
     int ret = 0;
     int numprocs = 0, rank = 0;
@@ -32,6 +33,24 @@ int main()
     // we assume rank 0 on each node is responsible for monitor and control
     if (new_rank == 0)
     {
+        const char *usage = "Usage: %s [-h] [-v]\n";
+        int opt;
+        while ((opt = getopt(argc, argv, "hv")) != -1)
+        {
+            switch (opt)
+            {
+                case 'h':
+                    printf(usage, argv[0]);
+                    return 0;
+                case 'v':
+                    printf("%s\n", variorum_get_current_version());
+                    return 0;
+                default:
+                    fprintf(stderr, usage, argv[0]);
+                    return -1;
+            }
+        }
+
         ret = variorum_print_power_limit();
         if (ret != 0)
         {

--- a/src/examples/mpi-examples/variorum-print-power-mpi-example.c
+++ b/src/examples/mpi-examples/variorum-print-power-mpi-example.c
@@ -3,14 +3,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
+#include <getopt.h>
 #include <mpi.h>
 #include <rankstr_mpi.h>
+#include <stdio.h>
 #include <unistd.h>
 
 #include <variorum.h>
 
-int main()
+int main(int argc, char **argv)
 {
     int ret = 0;
     int numprocs = 0, rank = 0;
@@ -32,6 +33,24 @@ int main()
     // we assume rank 0 on each node is responsible for monitor and control
     if (new_rank == 0)
     {
+        const char *usage = "Usage: %s [-h] [-v]\n";
+        int opt;
+        while ((opt = getopt(argc, argv, "hv")) != -1)
+        {
+            switch (opt)
+            {
+                case 'h':
+                    printf(usage, argv[0]);
+                    return 0;
+                case 'v':
+                    printf("%s\n", variorum_get_current_version());
+                    return 0;
+                default:
+                    fprintf(stderr, usage, argv[0]);
+                    return -1;
+            }
+        }
+
         ret = variorum_print_power();
         if (ret != 0)
         {

--- a/src/examples/mpi-examples/variorum-print-verbose-power-limit-mpi-example.c
+++ b/src/examples/mpi-examples/variorum-print-verbose-power-limit-mpi-example.c
@@ -3,14 +3,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
+#include <getopt.h>
 #include <mpi.h>
 #include <rankstr_mpi.h>
+#include <stdio.h>
 #include <unistd.h>
 
 #include <variorum.h>
 
-int main()
+int main(int argc, char **argv)
 {
     int ret = 0;
     int numprocs = 0, rank = 0;
@@ -32,6 +33,24 @@ int main()
     // we assume rank 0 on each node is responsible for monitor and control
     if (new_rank == 0)
     {
+        const char *usage = "Usage: %s [-h] [-v]\n";
+        int opt;
+        while ((opt = getopt(argc, argv, "hv")) != -1)
+        {
+            switch (opt)
+            {
+                case 'h':
+                    printf(usage, argv[0]);
+                    return 0;
+                case 'v':
+                    printf("%s\n", variorum_get_current_version());
+                    return 0;
+                default:
+                    fprintf(stderr, usage, argv[0]);
+                    return -1;
+            }
+        }
+
         ret = variorum_print_verbose_power_limit();
         if (ret != 0)
         {

--- a/src/examples/mpi-examples/variorum-print-verbose-power-mpi-example.c
+++ b/src/examples/mpi-examples/variorum-print-verbose-power-mpi-example.c
@@ -3,9 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
+#include <getopt.h>
 #include <mpi.h>
 #include <rankstr_mpi.h>
+#include <stdio.h>
 #include <unistd.h>
 
 #include <variorum.h>
@@ -25,7 +26,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main()
+int main(int argc, char **argv)
 {
     int ret = 0;
     int numprocs = 0, rank = 0;
@@ -52,6 +53,24 @@ int main()
     // we assume rank 0 on each node is responsible for monitor and control
     if (new_rank == 0)
     {
+        const char *usage = "Usage: %s [-h] [-v]\n";
+        int opt;
+        while ((opt = getopt(argc, argv, "hv")) != -1)
+        {
+            switch (opt)
+            {
+                case 'h':
+                    printf(usage, argv[0]);
+                    return 0;
+                case 'v':
+                    printf("%s\n", variorum_get_current_version());
+                    return 0;
+                default:
+                    fprintf(stderr, usage, argv[0]);
+                    return -1;
+            }
+        }
+
         ret = variorum_print_verbose_power();
         if (ret != 0)
         {

--- a/src/examples/openmp-examples/variorum-cap-socket-power-limit-openmp-example.c
+++ b/src/examples/openmp-examples/variorum-cap-socket-power-limit-openmp-example.c
@@ -4,10 +4,9 @@
 // SPDX-License-Identifier: MIT
 
 #include <getopt.h>
+#include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <omp.h>
 
 #include <variorum.h>
 
@@ -17,26 +16,18 @@ int main(int argc, char **argv)
     int pkg_pow_lim_watts = 0;
     int tid = 0;
 
-    const char *usage = "%s [--help | -h] -l power_lim_watts\n";
-
-    if (argc == 1 || (argc > 1 && (
-                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
-                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
-    {
-        printf(usage, argv[0]);
-        return 0;
-    }
-    if (argc <= 2)
-    {
-        printf(usage, argv[0]);
-        return 1;
-    }
-
+    const char *usage = "Usage: %s [-h] [-v] -l watts\n";
     int opt;
-    while ((opt = getopt(argc, argv, "l:")) != -1)
+    while ((opt = getopt(argc, argv, "hvl:")) != -1)
     {
         switch (opt)
         {
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
+                return 0;
             case 'l':
                 pkg_pow_lim_watts = atoi(optarg);
                 break;

--- a/src/examples/openmp-examples/variorum-print-power-limit-openmp-example.c
+++ b/src/examples/openmp-examples/variorum-print-power-limit-openmp-example.c
@@ -3,15 +3,34 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
+#include <getopt.h>
 #include <omp.h>
+#include <stdio.h>
 
 #include <variorum.h>
 
-int main()
+int main(int argc, char **argv)
 {
     int ret;
     int tid;
+
+    const char *usage = "Usage: %s [-h] [-v]\n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
+                return 0;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
 
     #pragma omp parallel private(tid)
     {

--- a/src/examples/openmp-examples/variorum-print-power-openmp-example.c
+++ b/src/examples/openmp-examples/variorum-print-power-openmp-example.c
@@ -3,15 +3,34 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
+#include <getopt.h>
 #include <omp.h>
+#include <stdio.h>
 
 #include <variorum.h>
 
-int main()
+int main(int argc, char **argv)
 {
     int ret;
     int tid;
+
+    const char *usage = "Usage: %s [-h] [-v]\n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
+                return 0;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
 
     #pragma omp parallel private(tid)
     {

--- a/src/examples/openmp-examples/variorum-print-verbose-power-limit-openmp-example.c
+++ b/src/examples/openmp-examples/variorum-print-verbose-power-limit-openmp-example.c
@@ -3,15 +3,34 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
+#include <getopt.h>
 #include <omp.h>
+#include <stdio.h>
 
 #include <variorum.h>
 
-int main()
+int main(int argc, char **argv)
 {
     int ret;
     int tid;
+
+    const char *usage = "Usage: %s [-h] [-v]\n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
+                return 0;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
 
     #pragma omp parallel private(tid)
     {

--- a/src/examples/openmp-examples/variorum-print-verbose-power-openmp-example.c
+++ b/src/examples/openmp-examples/variorum-print-verbose-power-openmp-example.c
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
+#include <getopt.h>
 #include <omp.h>
+#include <stdio.h>
 
 #include <variorum.h>
 
@@ -23,7 +24,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main()
+int main(int argc, char **argv)
 {
     int ret;
     int tid;
@@ -32,6 +33,24 @@ int main()
     int size = 1E3;
     double x = 0.0;
 #endif
+
+    const char *usage = "Usage: %s [-h] [-v]\n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
+                return 0;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
 
     #pragma omp parallel private(tid)
     {

--- a/src/examples/variorum-cap-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-cap-best-effort-node-power-limit-example.c
@@ -15,9 +15,9 @@ int main(int argc, char **argv)
     // 500W is based on minimum power on IBM Witherspoon
     int node_pow_lim_watts = 500;
 
-    const char *usage = "Usage: %s [-hvl] -l power_lim_watts\n";
+    const char *usage = "Usage: %s [-hvl] power_lim_watts\n";
     int opt;
-    while ((opt = getopt(argc, argv, "lhv")) != -1)
+    while ((opt = getopt(argc, argv, "hvl")) != -1)
     {
         switch (opt)
         {

--- a/src/examples/variorum-cap-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-cap-best-effort-node-power-limit-example.c
@@ -6,7 +6,6 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-cap-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-cap-best-effort-node-power-limit-example.c
@@ -15,17 +15,17 @@ int main(int argc, char **argv)
     // 500W is based on minimum power on IBM Witherspoon
     int node_pow_lim_watts = 500;
 
-    const char *usage = "Usage: %s [-hv] -l Watts\n";
+    const char *usage = "Usage: %s [-h] [-v] -l watts\n";
     int opt;
     while ((opt = getopt(argc, argv, "hvl:")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             case 'l':
                 node_pow_lim_watts = atoi(optarg);

--- a/src/examples/variorum-cap-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-cap-best-effort-node-power-limit-example.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
+#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -16,26 +16,20 @@ int main(int argc, char **argv)
     // 500W is based on minimum power on IBM Witherspoon
     int node_pow_lim_watts = 500;
 
-    const char *usage = "%s [--help | -h] -l power_lim_watts\n";
-
-    if (argc == 1 || (argc > 1 && (
-                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
-                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
-    {
-        printf(usage, argv[0]);
-        return 0;
-    }
-    if (argc <= 2)
-    {
-        printf(usage, argv[0]);
-        return 1;
-    }
-
+    const char *usage = "%s [-hv] -l power_lim_watts\n";
     int opt;
-    while ((opt = getopt(argc, argv, "l:")) != -1)
+    while ((opt = getopt(argc, argv, "lhv")) != -1)
     {
         switch (opt)
         {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
             case 'l':
                 node_pow_lim_watts = atoi(optarg);
                 break;

--- a/src/examples/variorum-cap-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-cap-best-effort-node-power-limit-example.c
@@ -15,14 +15,14 @@ int main(int argc, char **argv)
     // 500W is based on minimum power on IBM Witherspoon
     int node_pow_lim_watts = 500;
 
-    const char *usage = "Usage: %s [-hvl] power_lim_watts\n";
+    const char *usage = "Usage: %s [-hv] -l Watts\n";
     int opt;
-    while ((opt = getopt(argc, argv, "hvl")) != -1)
+    while ((opt = getopt(argc, argv, "hvl:")) != -1)
     {
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-cap-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-cap-best-effort-node-power-limit-example.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -24,11 +25,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             case 'l':
                 node_pow_lim_watts = atoi(optarg);
                 break;

--- a/src/examples/variorum-cap-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-cap-best-effort-node-power-limit-example.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
     // 500W is based on minimum power on IBM Witherspoon
     int node_pow_lim_watts = 500;
 
-    const char *usage = "%s [-hvl] -l power_lim_watts\n";
+    const char *usage = "Usage: %s [-hvl] -l power_lim_watts\n";
     int opt;
     while ((opt = getopt(argc, argv, "lhv")) != -1)
     {

--- a/src/examples/variorum-cap-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-cap-best-effort-node-power-limit-example.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -16,14 +15,14 @@ int main(int argc, char **argv)
     // 500W is based on minimum power on IBM Witherspoon
     int node_pow_lim_watts = 500;
 
-    const char *usage = "%s [-hv] -l power_lim_watts\n";
+    const char *usage = "%s [-hvl] -l power_lim_watts\n";
     int opt;
     while ((opt = getopt(argc, argv, "lhv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-cap-each-core-frequency-limit-example.c
+++ b/src/examples/variorum-cap-each-core-frequency-limit-example.c
@@ -15,14 +15,14 @@ int main(int argc, char **argv)
     int ret = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "Usage: %s [-hvf] cpu_freq_mhz\n";
+    const char *usage = "Usage: %s [-hv] -f MHz\n";
     int opt;
-    while ((opt = getopt(argc, argv, "vhf")) != -1)
+    while ((opt = getopt(argc, argv, "vhf:")) != -1)
     {
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-cap-each-core-frequency-limit-example.c
+++ b/src/examples/variorum-cap-each-core-frequency-limit-example.c
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -16,14 +15,14 @@ int main(int argc, char **argv)
     int ret = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "%s [-hv] -f cpu_freq_mhz\n";
+    const char *usage = "%s [-hvf] -f cpu_freq_mhz\n";
     int opt;
     while ((opt = getopt(argc, argv, "vhf")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-cap-each-core-frequency-limit-example.c
+++ b/src/examples/variorum-cap-each-core-frequency-limit-example.c
@@ -24,11 +24,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             case 'f':
                 cpu_freq_mhz = atoi(optarg);
                 break;

--- a/src/examples/variorum-cap-each-core-frequency-limit-example.c
+++ b/src/examples/variorum-cap-each-core-frequency-limit-example.c
@@ -14,17 +14,17 @@ int main(int argc, char **argv)
     int ret = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "Usage: %s [-hv] -f MHz\n";
+    const char *usage = "Usage: %s [-h] [-v] -f MHz\n";
     int opt;
-    while ((opt = getopt(argc, argv, "vhf:")) != -1)
+    while ((opt = getopt(argc, argv, "hvf:")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             case 'f':
                 cpu_freq_mhz = atoi(optarg);

--- a/src/examples/variorum-cap-each-core-frequency-limit-example.c
+++ b/src/examples/variorum-cap-each-core-frequency-limit-example.c
@@ -6,7 +6,6 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-cap-each-core-frequency-limit-example.c
+++ b/src/examples/variorum-cap-each-core-frequency-limit-example.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -15,26 +16,20 @@ int main(int argc, char **argv)
     int ret = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "%s [--help | -h] -f cpu_freq_mhz\n";
-
-    if (argc == 1 || (argc > 1 && (
-                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
-                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
-    {
-        printf(usage, argv[0]);
-        return 0;
-    }
-    if (argc <= 2)
-    {
-        printf(usage, argv[0]);
-        return 1;
-    }
-
+    const char *usage = "%s [-hv] -f cpu_freq_mhz\n";
     int opt;
-    while ((opt = getopt(argc, argv, "f:")) != -1)
+    while ((opt = getopt(argc, argv, "vhf")) != -1)
     {
         switch (opt)
         {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
             case 'f':
                 cpu_freq_mhz = atoi(optarg);
                 break;

--- a/src/examples/variorum-cap-each-core-frequency-limit-example.c
+++ b/src/examples/variorum-cap-each-core-frequency-limit-example.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
     int ret = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "Usage: %s [-hvf] -f cpu_freq_mhz\n";
+    const char *usage = "Usage: %s [-hvf] cpu_freq_mhz\n";
     int opt;
     while ((opt = getopt(argc, argv, "vhf")) != -1)
     {

--- a/src/examples/variorum-cap-each-core-frequency-limit-example.c
+++ b/src/examples/variorum-cap-each-core-frequency-limit-example.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
     int ret = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "%s [-hvf] -f cpu_freq_mhz\n";
+    const char *usage = "Usage: %s [-hvf] -f cpu_freq_mhz\n";
     int opt;
     while ((opt = getopt(argc, argv, "vhf")) != -1)
     {

--- a/src/examples/variorum-cap-gpu-power-ratio-example.c
+++ b/src/examples/variorum-cap-gpu-power-ratio-example.c
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -16,14 +15,14 @@ int main(int argc, char **argv)
     int ret = 0;
     int gpu_power_ratio_pct = 0;
 
-    const char *usage = "%s [-hv] -r gpu_power_ratio_pct\n";
+    const char *usage = "%s [-hvr] -r gpu_power_ratio_pct\n";
     int opt;
     while ((opt = getopt(argc, argv, "rvh")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-cap-gpu-power-ratio-example.c
+++ b/src/examples/variorum-cap-gpu-power-ratio-example.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -23,11 +24,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             case 'r':
                 gpu_power_ratio_pct = atoi(optarg);
                 break;

--- a/src/examples/variorum-cap-gpu-power-ratio-example.c
+++ b/src/examples/variorum-cap-gpu-power-ratio-example.c
@@ -6,7 +6,6 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-cap-gpu-power-ratio-example.c
+++ b/src/examples/variorum-cap-gpu-power-ratio-example.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
     int ret = 0;
     int gpu_power_ratio_pct = 0;
 
-    const char *usage = "%s [-hvr] -r gpu_power_ratio_pct\n";
+    const char *usage = "Usage: %s [-hvr] -r gpu_power_ratio_pct\n";
     int opt;
     while ((opt = getopt(argc, argv, "rvh")) != -1)
     {

--- a/src/examples/variorum-cap-gpu-power-ratio-example.c
+++ b/src/examples/variorum-cap-gpu-power-ratio-example.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -15,26 +16,20 @@ int main(int argc, char **argv)
     int ret = 0;
     int gpu_power_ratio_pct = 0;
 
-    const char *usage = "%s [--help | -h] -r gpu_power_ratio_pct\n";
-
-    if (argc == 1 || (argc > 1 && (
-                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
-                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
-    {
-        printf(usage, argv[0]);
-        return 0;
-    }
-    if (argc <= 2)
-    {
-        printf(usage, argv[0]);
-        return 1;
-    }
-
+    const char *usage = "%s [-hv] -r gpu_power_ratio_pct\n";
     int opt;
-    while ((opt = getopt(argc, argv, "r:")) != -1)
+    while ((opt = getopt(argc, argv, "rvh")) != -1)
     {
         switch (opt)
         {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
             case 'r':
                 gpu_power_ratio_pct = atoi(optarg);
                 break;

--- a/src/examples/variorum-cap-gpu-power-ratio-example.c
+++ b/src/examples/variorum-cap-gpu-power-ratio-example.c
@@ -14,14 +14,14 @@ int main(int argc, char **argv)
     int ret = 0;
     int gpu_power_ratio_pct = 0;
 
-    const char *usage = "Usage: %s [-hvr] gpu_power_ratio_pct\n";
+    const char *usage = "Usage: %s [-hv] -r percent\n";
     int opt;
-    while ((opt = getopt(argc, argv, "rvh")) != -1)
+    while ((opt = getopt(argc, argv, "r:vh")) != -1)
     {
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-cap-gpu-power-ratio-example.c
+++ b/src/examples/variorum-cap-gpu-power-ratio-example.c
@@ -14,17 +14,17 @@ int main(int argc, char **argv)
     int ret = 0;
     int gpu_power_ratio_pct = 0;
 
-    const char *usage = "Usage: %s [-hv] -r percent\n";
+    const char *usage = "Usage: %s [-h] [-v] -r percent\n";
     int opt;
-    while ((opt = getopt(argc, argv, "r:vh")) != -1)
+    while ((opt = getopt(argc, argv, "hvr:")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             case 'r':
                 gpu_power_ratio_pct = atoi(optarg);

--- a/src/examples/variorum-cap-gpu-power-ratio-example.c
+++ b/src/examples/variorum-cap-gpu-power-ratio-example.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -15,7 +14,7 @@ int main(int argc, char **argv)
     int ret = 0;
     int gpu_power_ratio_pct = 0;
 
-    const char *usage = "Usage: %s [-hvr] -r gpu_power_ratio_pct\n";
+    const char *usage = "Usage: %s [-hvr] gpu_power_ratio_pct\n";
     int opt;
     while ((opt = getopt(argc, argv, "rvh")) != -1)
     {

--- a/src/examples/variorum-cap-socket-frequency-limit-example.c
+++ b/src/examples/variorum-cap-socket-frequency-limit-example.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
+#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -16,26 +16,20 @@ int main(int argc, char **argv)
     int cpu_id = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "%s [--help | -h] -i socket_id -f cpu_freq_mhz\n";
-
-    if (argc == 1 || (argc > 1 && (
-                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
-                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
-    {
-        printf(usage, argv[0]);
-        return 0;
-    }
-    if (argc <= 2)
-    {
-        printf(usage, argv[0]);
-        return 1;
-    }
-
+    const char *usage = "%s [-h] -i socket_id -f cpu_freq_mhz\n";
     int opt;
-    while ((opt = getopt(argc, argv, "i:f:")) != -1)
+    while ((opt = getopt(argc, argv, "ifhv")) != -1)
     {
         switch (opt)
         {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
             case 'i':
                 cpu_id = atoi(optarg);
                 break;

--- a/src/examples/variorum-cap-socket-frequency-limit-example.c
+++ b/src/examples/variorum-cap-socket-frequency-limit-example.c
@@ -15,9 +15,9 @@ int main(int argc, char **argv)
     int cpu_id = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "Usage: %s [-hifv] -i socket_id -f cpu_freq_mhz\n";
+    const char *usage = "Usage: %s [-hifv] socket_id cpu_freq_mhz\n";
     int opt;
-    while ((opt = getopt(argc, argv, "ifhv")) != -1)
+    while ((opt = getopt(argc, argv, "hifv")) != -1)
     {
         switch (opt)
         {

--- a/src/examples/variorum-cap-socket-frequency-limit-example.c
+++ b/src/examples/variorum-cap-socket-frequency-limit-example.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
     int cpu_id = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "%s [-hifv] -i socket_id -f cpu_freq_mhz\n";
+    const char *usage = "Usage: %s [-hifv] -i socket_id -f cpu_freq_mhz\n";
     int opt;
     while ((opt = getopt(argc, argv, "ifhv")) != -1)
     {

--- a/src/examples/variorum-cap-socket-frequency-limit-example.c
+++ b/src/examples/variorum-cap-socket-frequency-limit-example.c
@@ -6,7 +6,6 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-cap-socket-frequency-limit-example.c
+++ b/src/examples/variorum-cap-socket-frequency-limit-example.c
@@ -15,14 +15,14 @@ int main(int argc, char **argv)
     int cpu_id = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "Usage: %s [-hifv] socket_id cpu_freq_mhz\n";
+    const char *usage = "Usage: %s [-hv] [-i socket] [-f MHz]\n";
     int opt;
-    while ((opt = getopt(argc, argv, "hifv")) != -1)
+    while ((opt = getopt(argc, argv, "hi:f:v")) != -1)
     {
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-cap-socket-frequency-limit-example.c
+++ b/src/examples/variorum-cap-socket-frequency-limit-example.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -16,14 +15,14 @@ int main(int argc, char **argv)
     int cpu_id = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "%s [-h] -i socket_id -f cpu_freq_mhz\n";
+    const char *usage = "%s [-hifv] -i socket_id -f cpu_freq_mhz\n";
     int opt;
     while ((opt = getopt(argc, argv, "ifhv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-cap-socket-frequency-limit-example.c
+++ b/src/examples/variorum-cap-socket-frequency-limit-example.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -15,7 +16,7 @@ int main(int argc, char **argv)
     int cpu_id = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "Usage: %s [-hv] [-i socket] [-f MHz]\n";
+    const char *usage = "Usage: %s [-hv] -i socket -f MHz\n";
     int opt;
     while ((opt = getopt(argc, argv, "hi:f:v")) != -1)
     {
@@ -24,11 +25,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             case 'i':
                 cpu_id = atoi(optarg);
                 break;

--- a/src/examples/variorum-cap-socket-frequency-limit-example.c
+++ b/src/examples/variorum-cap-socket-frequency-limit-example.c
@@ -15,17 +15,17 @@ int main(int argc, char **argv)
     int cpu_id = 0;
     int cpu_freq_mhz = 0;
 
-    const char *usage = "Usage: %s [-hv] -i socket -f MHz\n";
+    const char *usage = "Usage: %s [-h] [-v] -i socket -f MHz\n";
     int opt;
-    while ((opt = getopt(argc, argv, "hi:f:v")) != -1)
+    while ((opt = getopt(argc, argv, "hvi:f:")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             case 'i':
                 cpu_id = atoi(optarg);

--- a/src/examples/variorum-cap-socket-power-limit-example.c
+++ b/src/examples/variorum-cap-socket-power-limit-example.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
     int ret = 0;
     int pkg_pow_lim_watts = 0;
 
-    const char *usage = "%s [-lvh] -l power_lim_watts\n";
+    const char *usage = "Usage: %s [-lvh] -l power_lim_watts\n";
     int opt;
     while ((opt = getopt(argc, argv, "lvh")) != -1)
     {

--- a/src/examples/variorum-cap-socket-power-limit-example.c
+++ b/src/examples/variorum-cap-socket-power-limit-example.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
                 printf(usage, argv[0]);
                 return 0;
                 break;
-	    case 'l':
+            case 'l':
                 pkg_pow_lim_watts = atoi(optarg);
                 break;
             default:

--- a/src/examples/variorum-cap-socket-power-limit-example.c
+++ b/src/examples/variorum-cap-socket-power-limit-example.c
@@ -14,14 +14,14 @@ int main(int argc, char **argv)
     int ret = 0;
     int pkg_pow_lim_watts = 0;
 
-    const char *usage = "Usage: %s [-hvl] power_lim_watts\n";
+    const char *usage = "Usage: %s [-hv] [-l Watts]\n";
     int opt;
-    while ((opt = getopt(argc, argv, "hvl")) != -1)
+    while ((opt = getopt(argc, argv, "hvl:")) != -1)
     {
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-cap-socket-power-limit-example.c
+++ b/src/examples/variorum-cap-socket-power-limit-example.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -15,27 +16,21 @@ int main(int argc, char **argv)
     int ret = 0;
     int pkg_pow_lim_watts = 0;
 
-    const char *usage = "%s [--help | -h] -l power_lim_watts\n";
-
-    if (argc == 1 || (argc > 1 && (
-                          strncmp(argv[1], "--help", strlen("--help")) == 0 ||
-                          strncmp(argv[1], "-h", strlen("-h")) == 0)))
-    {
-        printf(usage, argv[0]);
-        return 0;
-    }
-    if (argc <= 2)
-    {
-        printf(usage, argv[0]);
-        return 1;
-    }
-
+    const char *usage = "%s [-h] -l power_lim_watts\n";
     int opt;
-    while ((opt = getopt(argc, argv, "l:")) != -1)
+    while ((opt = getopt(argc, argv, "lvh")) != -1)
     {
         switch (opt)
         {
-            case 'l':
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+	    case 'l':
                 pkg_pow_lim_watts = atoi(optarg);
                 break;
             default:

--- a/src/examples/variorum-cap-socket-power-limit-example.c
+++ b/src/examples/variorum-cap-socket-power-limit-example.c
@@ -6,7 +6,6 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-cap-socket-power-limit-example.c
+++ b/src/examples/variorum-cap-socket-power-limit-example.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -15,9 +14,9 @@ int main(int argc, char **argv)
     int ret = 0;
     int pkg_pow_lim_watts = 0;
 
-    const char *usage = "Usage: %s [-lvh] -l power_lim_watts\n";
+    const char *usage = "Usage: %s [-hvl] power_lim_watts\n";
     int opt;
-    while ((opt = getopt(argc, argv, "lvh")) != -1)
+    while ((opt = getopt(argc, argv, "hvl")) != -1)
     {
         switch (opt)
         {

--- a/src/examples/variorum-cap-socket-power-limit-example.c
+++ b/src/examples/variorum-cap-socket-power-limit-example.c
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -16,14 +15,14 @@ int main(int argc, char **argv)
     int ret = 0;
     int pkg_pow_lim_watts = 0;
 
-    const char *usage = "%s [-h] -l power_lim_watts\n";
+    const char *usage = "%s [-lvh] -l power_lim_watts\n";
     int opt;
     while ((opt = getopt(argc, argv, "lvh")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-cap-socket-power-limit-example.c
+++ b/src/examples/variorum-cap-socket-power-limit-example.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -14,7 +15,7 @@ int main(int argc, char **argv)
     int ret = 0;
     int pkg_pow_lim_watts = 0;
 
-    const char *usage = "Usage: %s [-hv] [-l Watts]\n";
+    const char *usage = "Usage: %s [-hv] -l Watts\n";
     int opt;
     while ((opt = getopt(argc, argv, "hvl:")) != -1)
     {
@@ -23,11 +24,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             case 'l':
                 pkg_pow_lim_watts = atoi(optarg);
                 break;

--- a/src/examples/variorum-cap-socket-power-limit-example.c
+++ b/src/examples/variorum-cap-socket-power-limit-example.c
@@ -14,17 +14,17 @@ int main(int argc, char **argv)
     int ret = 0;
     int pkg_pow_lim_watts = 0;
 
-    const char *usage = "Usage: %s [-hv] -l Watts\n";
+    const char *usage = "Usage: %s [-h] [-v] -l power_lim_watts\n";
     int opt;
     while ((opt = getopt(argc, argv, "hvl:")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             case 'l':
                 pkg_pow_lim_watts = atoi(optarg);

--- a/src/examples/variorum-disable-turbo-example.c
+++ b/src/examples/variorum-disable-turbo-example.c
@@ -12,17 +12,17 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-disable-turbo-example.c
+++ b/src/examples/variorum-disable-turbo-example.c
@@ -4,11 +4,31 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     int ret;
 
     ret = variorum_disable_turbo();

--- a/src/examples/variorum-disable-turbo-example.c
+++ b/src/examples/variorum-disable-turbo-example.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-disable-turbo-example.c
+++ b/src/examples/variorum-disable-turbo-example.c
@@ -4,20 +4,19 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-disable-turbo-example.c
+++ b/src/examples/variorum-disable-turbo-example.c
@@ -3,13 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv] \n";
+    int ret;
+
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -18,17 +21,14 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
-    int ret;
 
     ret = variorum_disable_turbo();
     if (ret != 0)

--- a/src/examples/variorum-enable-turbo-example.c
+++ b/src/examples/variorum-enable-turbo-example.c
@@ -12,17 +12,17 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-enable-turbo-example.c
+++ b/src/examples/variorum-enable-turbo-example.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-enable-turbo-example.c
+++ b/src/examples/variorum-enable-turbo-example.c
@@ -3,13 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv] \n";
+    int ret;
+
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -18,17 +21,14 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
-    int ret;
 
     ret = variorum_enable_turbo();
     if (ret != 0)

--- a/src/examples/variorum-enable-turbo-example.c
+++ b/src/examples/variorum-enable-turbo-example.c
@@ -4,20 +4,19 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-enable-turbo-example.c
+++ b/src/examples/variorum-enable-turbo-example.c
@@ -4,11 +4,31 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     int ret;
 
     ret = variorum_enable_turbo();

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -14,17 +14,17 @@ int main(int argc, char **argv)
     int ret;
     char *s = NULL;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -3,16 +3,18 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <variorum_config.h>
-#include <getopt.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv] \n";
+    int ret;
+    char *s = NULL;
+
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -21,18 +23,14 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
-    int ret;
-    char *s = NULL;
 
     /* Allocate string based on vendor-neutral JSON structure*/
     s = (char *) malloc(800 * sizeof(char));

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -6,10 +6,31 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     int ret;
     char *s = NULL;
 

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -12,14 +12,14 @@
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -28,14 +28,14 @@ static inline double do_work(int input)
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -6,6 +6,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 #include <variorum_topology.h>
 
@@ -24,8 +26,27 @@ static inline double do_work(int input)
 }
 #endif
 
-int main(void)
+int main(int argc, char **argv)
 {
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     int ret;
     char *s = NULL;
     int num_sockets = 0;

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -36,17 +36,17 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -3,11 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <variorum_config.h>
-#include <getopt.h>
 #include <variorum.h>
 #include <variorum_topology.h>
 
@@ -28,25 +27,6 @@ static inline double do_work(int input)
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv] \n";
-    int opt;
-    while ((opt = getopt(argc, argv, "hv")) != -1)
-    {
-        switch (opt)
-        {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
-                break;
-            case 'h':
-                printf(usage, argv[0]);
-                return 0;
-                break;
-            default:
-                fprintf(stderr, usage, argv[0]);
-                return -1;
-        }
-    }
     int ret;
     char *s = NULL;
     int num_sockets = 0;
@@ -55,6 +35,24 @@ int main(int argc, char **argv)
     int size = 1E4;
     double x = 0.0;
 #endif
+
+    const char *usage = "Usage: %s [-hv]\n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
+                return 0;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
 
     /* Determine number of sockets */
     num_sockets = variorum_get_num_sockets();

--- a/src/examples/variorum-get-topology-info-example.c
+++ b/src/examples/variorum-get-topology-info-example.c
@@ -3,28 +3,28 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 #include <variorum_topology.h>
 
 int main(int argc, char **argv)
 {
     int num_sockets, num_cores, num_threads;
+
     int opt;
     const char *usage = "Usage: %s [-hv]\n";
-    while ((opt = getopt(argc, argv, "hvl")) != -1)
+    while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-get-topology-info-example.c
+++ b/src/examples/variorum-get-topology-info-example.c
@@ -14,22 +14,23 @@ int main(int argc, char **argv)
     int num_sockets, num_cores, num_threads;
 
     int opt;
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     // Demonstrates usage of Variorum's advanced API for obtaining topology information.
     printf("This example demonstrates the use of variorum_topology.h API \n"
            "to obtain basic information from the underlying architecture.\n");

--- a/src/examples/variorum-get-topology-info-example.c
+++ b/src/examples/variorum-get-topology-info-example.c
@@ -4,13 +4,32 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <getopt.h>
+#include <variorum.h>
 #include <variorum_topology.h>
 
-int main()
+int main(int argc, char **argv)
 {
     int num_sockets, num_cores, num_threads;
-
+    int opt;
+    const char *usage = "Usage: %s [-hv]\n";
+    while ((opt = getopt(argc, argv, "hvl")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     // Demonstrates usage of Variorum's advanced API for obtaining topology information.
     printf("This example demonstrates the use of variorum_topology.h API \n"
            "to obtain basic information from the underlying architecture.\n");

--- a/src/examples/variorum-integration-using-json-example.c
+++ b/src/examples/variorum-integration-using-json-example.c
@@ -3,12 +3,12 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <jansson.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 #include <variorum.h>
 #include <variorum_topology.h>
-#include <jansson.h>
 
 #ifdef SECOND_RUN
 static inline double do_work(int input)

--- a/src/examples/variorum-monitoring-to-file-example.c
+++ b/src/examples/variorum-monitoring-to-file-example.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-monitoring-to-file-example.c
+++ b/src/examples/variorum-monitoring-to-file-example.c
@@ -11,6 +11,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -39,6 +41,25 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     if (argc > 1)
     {
         printf("Fatal Error: No argument needed.\n");

--- a/src/examples/variorum-monitoring-to-file-example.c
+++ b/src/examples/variorum-monitoring-to-file-example.c
@@ -40,27 +40,22 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
-    }
-    if (argc > 1)
-    {
-        printf("Fatal Error: No argument needed.\n");
-        return 1;
     }
 
     gethostname(hostname, 1024);

--- a/src/examples/variorum-monitoring-to-file-example.c
+++ b/src/examples/variorum-monitoring-to-file-example.c
@@ -5,13 +5,13 @@
 
 #define _GNU_SOURCE
 
+#include <getopt.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <getopt.h>
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -49,11 +49,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-monitoring-to-file-example.c
+++ b/src/examples/variorum-monitoring-to-file-example.c
@@ -11,7 +11,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
@@ -41,14 +40,14 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-poll-power-to-file-example.c
+++ b/src/examples/variorum-poll-power-to-file-example.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-poll-power-to-file-example.c
+++ b/src/examples/variorum-poll-power-to-file-example.c
@@ -11,6 +11,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -39,6 +41,25 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     if (argc > 1)
     {
         printf("Fatal Error: No argument needed.\n");

--- a/src/examples/variorum-poll-power-to-file-example.c
+++ b/src/examples/variorum-poll-power-to-file-example.c
@@ -40,27 +40,22 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
-    }
-    if (argc > 1)
-    {
-        printf("Fatal Error: No argument needed.\n");
-        return 1;
     }
 
     gethostname(hostname, 1024);

--- a/src/examples/variorum-poll-power-to-file-example.c
+++ b/src/examples/variorum-poll-power-to-file-example.c
@@ -5,13 +5,13 @@
 
 #define _GNU_SOURCE
 
+#include <getopt.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <getopt.h>
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -49,11 +49,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-poll-power-to-file-example.c
+++ b/src/examples/variorum-poll-power-to-file-example.c
@@ -11,7 +11,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
@@ -41,14 +40,14 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-poll-power-to-stdout-example.c
+++ b/src/examples/variorum-poll-power-to-stdout-example.c
@@ -4,8 +4,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <variorum.h>
+#include <getopt.h>
 
 #ifdef SECOND_RUN
 static inline double do_work(int input)

--- a/src/examples/variorum-poll-power-to-stdout-example.c
+++ b/src/examples/variorum-poll-power-to-stdout-example.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-poll-power-to-stdout-example.c
+++ b/src/examples/variorum-poll-power-to-stdout-example.c
@@ -3,9 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
-#include <variorum.h>
 #include <getopt.h>
+#include <stdio.h>
+
+#include <variorum.h>
 
 #ifdef SECOND_RUN
 static inline double do_work(int input)
@@ -31,7 +32,7 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -40,11 +41,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-poll-power-to-stdout-example.c
+++ b/src/examples/variorum-poll-power-to-stdout-example.c
@@ -32,23 +32,24 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_poll_power(stdout);
     if (ret != 0)
     {

--- a/src/examples/variorum-poll-power-to-stdout-example.c
+++ b/src/examples/variorum-poll-power-to-stdout-example.c
@@ -5,7 +5,6 @@
 
 #include <stdio.h>
 #include <variorum_config.h>
-#include <getopt.h>
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -32,14 +31,14 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-poll-power-to-stdout-example.c
+++ b/src/examples/variorum-poll-power-to-stdout-example.c
@@ -4,7 +4,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -22,7 +23,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 #ifdef SECOND_RUN
@@ -31,6 +32,25 @@ int main(void)
     double x = 0.0;
 #endif
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_poll_power(stdout);
     if (ret != 0)
     {

--- a/src/examples/variorum-print-available-frequencies-example.c
+++ b/src/examples/variorum-print-available-frequencies-example.c
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
@@ -15,7 +16,7 @@ int main(int argc, char **argv)
      * How do we distinguish errors if this function pointer does not exist
      * because it has not yet been implemented or if it cannot be implemented?
      */
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -24,11 +25,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-available-frequencies-example.c
+++ b/src/examples/variorum-print-available-frequencies-example.c
@@ -16,23 +16,24 @@ int main(int argc, char **argv)
      * How do we distinguish errors if this function pointer does not exist
      * because it has not yet been implemented or if it cannot be implemented?
      */
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_available_frequencies();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-available-frequencies-example.c
+++ b/src/examples/variorum-print-available-frequencies-example.c
@@ -5,9 +5,11 @@
 
 #include <stdio.h>
 
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
@@ -15,6 +17,25 @@ int main(void)
      * How do we distinguish errors if this function pointer does not exist
      * because it has not yet been implemented or if it cannot be implemented?
      */
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_print_available_frequencies();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-available-frequencies-example.c
+++ b/src/examples/variorum-print-available-frequencies-example.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-available-frequencies-example.c
+++ b/src/examples/variorum-print-available-frequencies-example.c
@@ -4,8 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
@@ -17,14 +15,14 @@ int main(int argc, char **argv)
      * How do we distinguish errors if this function pointer does not exist
      * because it has not yet been implemented or if it cannot be implemented?
      */
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-counters-example.c
+++ b/src/examples/variorum-print-counters-example.c
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -31,7 +32,7 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -40,11 +41,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-counters-example.c
+++ b/src/examples/variorum-print-counters-example.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-counters-example.c
+++ b/src/examples/variorum-print-counters-example.c
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
@@ -32,14 +31,14 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-counters-example.c
+++ b/src/examples/variorum-print-counters-example.c
@@ -32,23 +32,24 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_counters();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-counters-example.c
+++ b/src/examples/variorum-print-counters-example.c
@@ -4,7 +4,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -22,7 +23,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 #ifdef SECOND_RUN
@@ -31,6 +32,25 @@ int main(void)
     double x = 0.0;
 #endif
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_print_counters();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-energy-example.c
+++ b/src/examples/variorum-print-energy-example.c
@@ -12,17 +12,17 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-print-energy-example.c
+++ b/src/examples/variorum-print-energy-example.c
@@ -3,13 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv] \n";
+    int ret;
+
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -18,17 +21,14 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
-    int ret;
 
     ret = variorum_print_energy();
     if (ret != 0)

--- a/src/examples/variorum-print-energy-example.c
+++ b/src/examples/variorum-print-energy-example.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-energy-example.c
+++ b/src/examples/variorum-print-energy-example.c
@@ -4,11 +4,31 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main()
+int main(int argc, char **argv)
 {
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     int ret;
 
     ret = variorum_print_energy();

--- a/src/examples/variorum-print-energy-example.c
+++ b/src/examples/variorum-print-energy-example.c
@@ -4,20 +4,19 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-features-example.c
+++ b/src/examples/variorum-print-features-example.c
@@ -12,17 +12,17 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-print-features-example.c
+++ b/src/examples/variorum-print-features-example.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-features-example.c
+++ b/src/examples/variorum-print-features-example.c
@@ -4,11 +4,27 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+    const char *usage = "Usage: %s [-h] \n"; 
+    int opt;
+    while ((opt = getopt(argc, argv, "h")) != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+		printf(usage,argv[0]);
+		return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
+    
     int ret;
 
     ret = variorum_print_features();

--- a/src/examples/variorum-print-features-example.c
+++ b/src/examples/variorum-print-features-example.c
@@ -3,13 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv] \n";
+    int ret;
+
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -18,18 +21,14 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
-
-    int ret;
 
     ret = variorum_print_features();
     if (ret != 0)

--- a/src/examples/variorum-print-features-example.c
+++ b/src/examples/variorum-print-features-example.c
@@ -6,18 +6,17 @@
 #include <stdio.h>
 #include <getopt.h>
 #include <variorum.h>
-#include <variorum_config.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-features-example.c
+++ b/src/examples/variorum-print-features-example.c
@@ -6,25 +6,32 @@
 #include <stdio.h>
 #include <getopt.h>
 #include <variorum.h>
+#include <variorum_config.h>
+#define QuoteIdent(ident) #ident
+#define QuoteMacro(macro) QuoteIdent(macro)
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-h] \n"; 
+    const char *usage = "Usage: %s [-h] \n";
     int opt;
-    while ((opt = getopt(argc, argv, "h")) != -1)
+    while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
             case 'h':
-		printf(usage,argv[0]);
-		return 0;
+                printf(usage, argv[0]);
+                return 0;
                 break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
-    
+
     int ret;
 
     ret = variorum_print_features();

--- a/src/examples/variorum-print-features-example.c
+++ b/src/examples/variorum-print-features-example.c
@@ -7,8 +7,6 @@
 #include <getopt.h>
 #include <variorum.h>
 #include <variorum_config.h>
-#define QuoteIdent(ident) #ident
-#define QuoteMacro(macro) QuoteIdent(macro)
 
 int main(int argc, char **argv)
 {

--- a/src/examples/variorum-print-frequency-example.c
+++ b/src/examples/variorum-print-frequency-example.c
@@ -12,17 +12,17 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-print-frequency-example.c
+++ b/src/examples/variorum-print-frequency-example.c
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
@@ -12,14 +11,14 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-frequency-example.c
+++ b/src/examples/variorum-print-frequency-example.c
@@ -4,13 +4,33 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_print_frequency();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-frequency-example.c
+++ b/src/examples/variorum-print-frequency-example.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-frequency-example.c
+++ b/src/examples/variorum-print-frequency-example.c
@@ -3,15 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -20,16 +21,15 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_frequency();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-gpu-utilization-example.c
+++ b/src/examples/variorum-print-gpu-utilization-example.c
@@ -12,17 +12,17 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-print-gpu-utilization-example.c
+++ b/src/examples/variorum-print-gpu-utilization-example.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-gpu-utilization-example.c
+++ b/src/examples/variorum-print-gpu-utilization-example.c
@@ -4,14 +4,34 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
     ret = variorum_print_gpu_utilization();
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     if (ret != 0)
     {
         printf("Print GPU utilization failed!\n");

--- a/src/examples/variorum-print-gpu-utilization-example.c
+++ b/src/examples/variorum-print-gpu-utilization-example.c
@@ -3,13 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv] \n";
+    int ret;
+
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -18,17 +21,14 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
-    int ret;
 
     ret = variorum_print_gpu_utilization();
     if (ret != 0)

--- a/src/examples/variorum-print-gpu-utilization-example.c
+++ b/src/examples/variorum-print-gpu-utilization-example.c
@@ -4,23 +4,19 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    int ret;
-
-    ret = variorum_print_gpu_utilization();
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':
@@ -32,6 +28,9 @@ int main(int argc, char **argv)
                 return -1;
         }
     }
+    int ret;
+
+    ret = variorum_print_gpu_utilization();
     if (ret != 0)
     {
         printf("Print GPU utilization failed!\n");

--- a/src/examples/variorum-print-hyperthreading-example.c
+++ b/src/examples/variorum-print-hyperthreading-example.c
@@ -12,17 +12,17 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-print-hyperthreading-example.c
+++ b/src/examples/variorum-print-hyperthreading-example.c
@@ -3,13 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv] \n";
+    int ret;
+
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -18,17 +21,15 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
-    int ret;
+
     ret = variorum_print_hyperthreading();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-hyperthreading-example.c
+++ b/src/examples/variorum-print-hyperthreading-example.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-hyperthreading-example.c
+++ b/src/examples/variorum-print-hyperthreading-example.c
@@ -4,13 +4,32 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     int ret;
-
     ret = variorum_print_hyperthreading();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-hyperthreading-example.c
+++ b/src/examples/variorum-print-hyperthreading-example.c
@@ -4,20 +4,19 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-power-example.c
+++ b/src/examples/variorum-print-power-example.c
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -31,7 +32,7 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -40,11 +41,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-power-example.c
+++ b/src/examples/variorum-print-power-example.c
@@ -4,7 +4,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -22,7 +23,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 #ifdef SECOND_RUN
@@ -31,6 +32,25 @@ int main(void)
     double x = 0.0;
 #endif
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_print_power();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-power-example.c
+++ b/src/examples/variorum-print-power-example.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-power-example.c
+++ b/src/examples/variorum-print-power-example.c
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
@@ -32,14 +31,14 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-power-example.c
+++ b/src/examples/variorum-print-power-example.c
@@ -32,23 +32,24 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_power();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-power-limit-example.c
+++ b/src/examples/variorum-print-power-limit-example.c
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
@@ -12,14 +11,14 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-power-limit-example.c
+++ b/src/examples/variorum-print-power-limit-example.c
@@ -4,13 +4,33 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_print_power_limit();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-power-limit-example.c
+++ b/src/examples/variorum-print-power-limit-example.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-power-limit-example.c
+++ b/src/examples/variorum-print-power-limit-example.c
@@ -3,15 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -20,11 +21,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-power-limit-example.c
+++ b/src/examples/variorum-print-power-limit-example.c
@@ -12,23 +12,24 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_power_limit();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-thermals-example.c
+++ b/src/examples/variorum-print-thermals-example.c
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
@@ -12,14 +11,14 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-thermals-example.c
+++ b/src/examples/variorum-print-thermals-example.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-thermals-example.c
+++ b/src/examples/variorum-print-thermals-example.c
@@ -3,15 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -20,11 +21,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-thermals-example.c
+++ b/src/examples/variorum-print-thermals-example.c
@@ -12,23 +12,24 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_thermals();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-thermals-example.c
+++ b/src/examples/variorum-print-thermals-example.c
@@ -4,13 +4,33 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_print_thermals();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-topology-example.c
+++ b/src/examples/variorum-print-topology-example.c
@@ -5,7 +5,6 @@
 
 #include <getopt.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-print-topology-example.c
+++ b/src/examples/variorum-print-topology-example.c
@@ -4,36 +4,31 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
+#include <stdlib.h>
 #include <getopt.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    variorum_print_topology();
-
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
-    while ((opt = getopt(argc, argv, "hvt")) != -1)
+    while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
-                return 0;
+		printf("%s\n", variorum_get_current_version());
+		exit(0);
                 break;
             case 'h':
                 printf(usage, argv[0]);
-                return 0;
-                break;
-            case 't':
-                variorum_print_topology();
-                return 0;
+		exit(0);
                 break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+    variorum_print_topology();
     return 0;
 }

--- a/src/examples/variorum-print-topology-example.c
+++ b/src/examples/variorum-print-topology-example.c
@@ -3,14 +3,15 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <getopt.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -18,12 +19,10 @@ int main(int argc, char **argv)
         {
             case 'v':
                 printf("%s\n", variorum_get_current_version());
-                exit(0);
-                break;
+                return 0;
             case 'h':
                 printf(usage, argv[0]);
-                exit(0);
-                break;
+                return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-topology-example.c
+++ b/src/examples/variorum-print-topology-example.c
@@ -4,11 +4,36 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     variorum_print_topology();
+
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hvt")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+	    case 't':
+    		variorum_print_topology();
+		return 0;
+		break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     return 0;
 }

--- a/src/examples/variorum-print-topology-example.c
+++ b/src/examples/variorum-print-topology-example.c
@@ -17,12 +17,12 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
-		exit(0);
+                printf("%s\n", variorum_get_current_version());
+                exit(0);
                 break;
             case 'h':
                 printf(usage, argv[0]);
-		exit(0);
+                exit(0);
                 break;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-print-topology-example.c
+++ b/src/examples/variorum-print-topology-example.c
@@ -10,23 +10,24 @@
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     variorum_print_topology();
     return 0;
 }

--- a/src/examples/variorum-print-topology-example.c
+++ b/src/examples/variorum-print-topology-example.c
@@ -26,10 +26,10 @@ int main(int argc, char **argv)
                 printf(usage, argv[0]);
                 return 0;
                 break;
-	    case 't':
-    		variorum_print_topology();
-		return 0;
-		break;
+            case 't':
+                variorum_print_topology();
+                return 0;
+                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-turbo-example.c
+++ b/src/examples/variorum-print-turbo-example.c
@@ -4,34 +4,34 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {
     int ret;
 
-    ret = variorum_print_turbo();
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
-                return 0;
+		printf("%s\n", variorum_get_current_version());
+                exit (0);
                 break;
             case 'h':
                 printf(usage, argv[0]);
-                return 0;
+                exit (0);
                 break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+    ret = variorum_print_turbo();
     if (ret != 0)
     {
         printf("Print turbo failed!\n");

--- a/src/examples/variorum-print-turbo-example.c
+++ b/src/examples/variorum-print-turbo-example.c
@@ -5,7 +5,6 @@
 
 #include <getopt.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-print-turbo-example.c
+++ b/src/examples/variorum-print-turbo-example.c
@@ -12,23 +12,24 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_turbo();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-turbo-example.c
+++ b/src/examples/variorum-print-turbo-example.c
@@ -3,16 +3,17 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
-#include <variorum.h>
+#include <stdio.h>
 #include <stdlib.h>
+
+#include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -20,12 +21,10 @@ int main(int argc, char **argv)
         {
             case 'v':
                 printf("%s\n", variorum_get_current_version());
-                exit(0);
-                break;
+                return 0;
             case 'h':
                 printf(usage, argv[0]);
-                exit(0);
-                break;
+                return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-turbo-example.c
+++ b/src/examples/variorum-print-turbo-example.c
@@ -4,14 +4,34 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
     ret = variorum_print_turbo();
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     if (ret != 0)
     {
         printf("Print turbo failed!\n");

--- a/src/examples/variorum-print-turbo-example.c
+++ b/src/examples/variorum-print-turbo-example.c
@@ -19,12 +19,12 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
-                exit (0);
+                printf("%s\n", variorum_get_current_version());
+                exit(0);
                 break;
             case 'h':
                 printf(usage, argv[0]);
-                exit (0);
+                exit(0);
                 break;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-print-verbose-counters-example.c
+++ b/src/examples/variorum-print-verbose-counters-example.c
@@ -4,14 +4,34 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
     ret = variorum_print_verbose_counters();
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     if (ret != 0)
     {
         printf("Print verbose counters failed!\n");

--- a/src/examples/variorum-print-verbose-counters-example.c
+++ b/src/examples/variorum-print-verbose-counters-example.c
@@ -5,7 +5,6 @@
 
 #include <getopt.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-print-verbose-counters-example.c
+++ b/src/examples/variorum-print-verbose-counters-example.c
@@ -3,14 +3,15 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <getopt.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -18,12 +19,10 @@ int main(int argc, char **argv)
         {
             case 'v':
                 printf("%s\n", variorum_get_current_version());
-                exit(0);
-                break;
+                return 0;
             case 'h':
                 printf(usage, argv[0]);
-                exit(0);
-                break;
+                return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-verbose-counters-example.c
+++ b/src/examples/variorum-print-verbose-counters-example.c
@@ -4,34 +4,34 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
+#include <stdlib.h>
 #include <getopt.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    int ret;
-
-    ret = variorum_print_verbose_counters();
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
-                return 0;
+		printf("%s\n", variorum_get_current_version());
+		exit(0);
                 break;
             case 'h':
                 printf(usage, argv[0]);
-                return 0;
+		exit(0);
                 break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+    int ret;
+
+    ret = variorum_print_verbose_counters();
     if (ret != 0)
     {
         printf("Print verbose counters failed!\n");

--- a/src/examples/variorum-print-verbose-counters-example.c
+++ b/src/examples/variorum-print-verbose-counters-example.c
@@ -17,12 +17,12 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
-		exit(0);
+                printf("%s\n", variorum_get_current_version());
+                exit(0);
                 break;
             case 'h':
                 printf(usage, argv[0]);
-		exit(0);
+                exit(0);
                 break;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-print-verbose-counters-example.c
+++ b/src/examples/variorum-print-verbose-counters-example.c
@@ -10,24 +10,25 @@
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv]\n";
+    int ret;
+
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
-    int ret;
 
     ret = variorum_print_verbose_counters();
     if (ret != 0)

--- a/src/examples/variorum-print-verbose-frequency-example.c
+++ b/src/examples/variorum-print-verbose-frequency-example.c
@@ -5,7 +5,6 @@
 
 #include <getopt.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-print-verbose-frequency-example.c
+++ b/src/examples/variorum-print-verbose-frequency-example.c
@@ -4,34 +4,34 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
+#include <stdlib.h>
 #include <getopt.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    int ret;
-
-    ret = variorum_print_verbose_frequency();
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-vh] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
-                return 0;
+		printf("%s\n", variorum_get_current_version());
+                exit (0);
                 break;
             case 'h':
                 printf(usage, argv[0]);
-                return 0;
+                exit (0);
                 break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+    int ret;
+
+    ret = variorum_print_verbose_frequency();
     if (ret != 0)
     {
         printf("Print verbose frequency failed!\n");

--- a/src/examples/variorum-print-verbose-frequency-example.c
+++ b/src/examples/variorum-print-verbose-frequency-example.c
@@ -3,14 +3,15 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <getopt.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-vh] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -18,12 +19,10 @@ int main(int argc, char **argv)
         {
             case 'v':
                 printf("%s\n", variorum_get_current_version());
-                exit(0);
-                break;
+                return 0;
             case 'h':
                 printf(usage, argv[0]);
-                exit(0);
-                break;
+                return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-verbose-frequency-example.c
+++ b/src/examples/variorum-print-verbose-frequency-example.c
@@ -10,24 +10,25 @@
 
 int main(int argc, char **argv)
 {
-    const char *usage = "Usage: %s [-hv]\n";
+    int ret;
+
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
-    int ret;
 
     ret = variorum_print_verbose_frequency();
     if (ret != 0)

--- a/src/examples/variorum-print-verbose-frequency-example.c
+++ b/src/examples/variorum-print-verbose-frequency-example.c
@@ -4,14 +4,34 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
     ret = variorum_print_verbose_frequency();
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     if (ret != 0)
     {
         printf("Print verbose frequency failed!\n");

--- a/src/examples/variorum-print-verbose-frequency-example.c
+++ b/src/examples/variorum-print-verbose-frequency-example.c
@@ -17,12 +17,12 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
-                exit (0);
+                printf("%s\n", variorum_get_current_version());
+                exit(0);
                 break;
             case 'h':
                 printf(usage, argv[0]);
-                exit (0);
+                exit(0);
                 break;
             default:
                 fprintf(stderr, usage, argv[0]);

--- a/src/examples/variorum-print-verbose-gpu-utilization-example.c
+++ b/src/examples/variorum-print-verbose-gpu-utilization-example.c
@@ -11,23 +11,25 @@
 int main(int argc, char **argv)
 {
     int ret;
-    const char *usage = "Usage: %s [-hv]\n";
+
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_verbose_gpu_utilization();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-verbose-gpu-utilization-example.c
+++ b/src/examples/variorum-print-verbose-gpu-utilization-example.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-verbose-gpu-utilization-example.c
+++ b/src/examples/variorum-print-verbose-gpu-utilization-example.c
@@ -3,15 +3,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
-
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -20,11 +20,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-verbose-gpu-utilization-example.c
+++ b/src/examples/variorum-print-verbose-gpu-utilization-example.c
@@ -4,13 +4,33 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_print_verbose_gpu_utilization();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-verbose-gpu-utilization-example.c
+++ b/src/examples/variorum-print-verbose-gpu-utilization-example.c
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 

--- a/src/examples/variorum-print-verbose-gpu-utilization-example.c
+++ b/src/examples/variorum-print-verbose-gpu-utilization-example.c
@@ -12,7 +12,7 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {

--- a/src/examples/variorum-print-verbose-power-example.c
+++ b/src/examples/variorum-print-verbose-power-example.c
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -31,7 +32,7 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -40,11 +41,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-verbose-power-example.c
+++ b/src/examples/variorum-print-verbose-power-example.c
@@ -4,7 +4,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
 #ifdef SECOND_RUN
@@ -22,7 +23,7 @@ static inline double do_work(int input)
 }
 #endif
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 #ifdef SECOND_RUN
@@ -31,6 +32,25 @@ int main(void)
     double x = 0.0;
 #endif
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_print_verbose_power();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-verbose-power-example.c
+++ b/src/examples/variorum-print-verbose-power-example.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-verbose-power-example.c
+++ b/src/examples/variorum-print-verbose-power-example.c
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
@@ -32,14 +31,14 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-verbose-power-example.c
+++ b/src/examples/variorum-print-verbose-power-example.c
@@ -32,23 +32,24 @@ int main(int argc, char **argv)
     double x = 0.0;
 #endif
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_verbose_power();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-verbose-power-limit-example.c
+++ b/src/examples/variorum-print-verbose-power-limit-example.c
@@ -5,21 +5,20 @@
 
 #include <stdio.h>
 #include <variorum_config.h>
-#include <getopt.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-verbose-power-limit-example.c
+++ b/src/examples/variorum-print-verbose-power-limit-example.c
@@ -6,7 +6,6 @@
 #include <stdio.h>
 #include <getopt.h>
 #include <stdlib.h>
-#include <variorum_config.h>
 #include <variorum.h>
 
 int main(int argc, char **argv)

--- a/src/examples/variorum-print-verbose-power-limit-example.c
+++ b/src/examples/variorum-print-verbose-power-limit-example.c
@@ -5,7 +5,6 @@
 
 #include <getopt.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-print-verbose-power-limit-example.c
+++ b/src/examples/variorum-print-verbose-power-limit-example.c
@@ -12,23 +12,24 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_verbose_power_limit();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-verbose-power-limit-example.c
+++ b/src/examples/variorum-print-verbose-power-limit-example.c
@@ -3,16 +3,17 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
 #include <stdlib.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -21,11 +22,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-verbose-power-limit-example.c
+++ b/src/examples/variorum-print-verbose-power-limit-example.c
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-verbose-power-limit-example.c
+++ b/src/examples/variorum-print-verbose-power-limit-example.c
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
+#include <getopt.h>
+#include <stdlib.h>
 #include <variorum_config.h>
 #include <variorum.h>
 

--- a/src/examples/variorum-print-verbose-power-limit-example.c
+++ b/src/examples/variorum-print-verbose-power-limit-example.c
@@ -4,13 +4,33 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_print_verbose_power_limit();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-verbose-thermals-example.c
+++ b/src/examples/variorum-print-verbose-thermals-example.c
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-#include <variorum_config.h>
 #include <getopt.h>
 #include <variorum.h>
 
@@ -12,14 +11,14 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-h] \n";
+    const char *usage = "Usage: %s [-hv] \n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
             case 'v':
-                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+		printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-verbose-thermals-example.c
+++ b/src/examples/variorum-print-verbose-thermals-example.c
@@ -12,23 +12,24 @@ int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv]\n";
+    const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
         switch (opt)
         {
-            case 'v':
-                printf("%s\n", variorum_get_current_version());
-                return 0;
             case 'h':
                 printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
                 return 0;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;
         }
     }
+
     ret = variorum_print_verbose_thermals();
     if (ret != 0)
     {

--- a/src/examples/variorum-print-verbose-thermals-example.c
+++ b/src/examples/variorum-print-verbose-thermals-example.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
         switch (opt)
         {
             case 'v':
-		printf("%s\n", variorum_get_current_version());
+                printf("%s\n", variorum_get_current_version());
                 return 0;
                 break;
             case 'h':

--- a/src/examples/variorum-print-verbose-thermals-example.c
+++ b/src/examples/variorum-print-verbose-thermals-example.c
@@ -3,15 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include <getopt.h>
+#include <stdio.h>
+
 #include <variorum.h>
 
 int main(int argc, char **argv)
 {
     int ret;
 
-    const char *usage = "Usage: %s [-hv] \n";
+    const char *usage = "Usage: %s [-hv]\n";
     int opt;
     while ((opt = getopt(argc, argv, "hv")) != -1)
     {
@@ -20,11 +21,9 @@ int main(int argc, char **argv)
             case 'v':
                 printf("%s\n", variorum_get_current_version());
                 return 0;
-                break;
             case 'h':
                 printf(usage, argv[0]);
                 return 0;
-                break;
             default:
                 fprintf(stderr, usage, argv[0]);
                 return -1;

--- a/src/examples/variorum-print-verbose-thermals-example.c
+++ b/src/examples/variorum-print-verbose-thermals-example.c
@@ -4,13 +4,33 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
-
+#include <variorum_config.h>
+#include <getopt.h>
 #include <variorum.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int ret;
 
+    const char *usage = "Usage: %s [-h] \n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'v':
+                printf(QuoteMacro(VARIORUM_VERSION)"\n");
+                return 0;
+                break;
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
     ret = variorum_print_verbose_thermals();
     if (ret != 0)
     {

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1138,7 +1138,7 @@ int variorum_print_energy(void)
     return err;
 }
 
-char* variorum_get_current_version()
+char *variorum_get_current_version()
 {
     return QuoteMacro(VARIORUM_VERSION);
 }

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1138,4 +1138,7 @@ int variorum_print_energy(void)
     return err;
 }
 
-
+char* variorum_get_current_version()
+{
+    return QuoteMacro(VARIORUM_VERSION);
+}

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -539,5 +539,5 @@ int variorum_tester(void);
 /// @brief To get a quoted variorum version, use QuoteMacro(VARIORUM_VERSION).
 #define QuoteIdent(ident) #ident
 #define QuoteMacro(macro) QuoteIdent(macro)
-
+char* variorum_get_current_version(void);
 #endif

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -530,14 +530,20 @@ int variorum_get_node_power_json(char **get_power_obj_str);
 /// check for NULL strings.
 int variorum_get_node_power_domain_info_json(char **get_domain_obj_str);
 
+/// @brief Returns Variorum version as a constant string.
+///
+/// @supparch
+/// - All architectures
+///
+/// @return Returns a constant string containing the
+/// current value of VARIORUM_VERSION.
+#define QuoteIdent(ident) #ident
+#define QuoteMacro(macro) QuoteIdent(macro)
+char *variorum_get_current_version(void);
+
 /***********/
 /* Testing */
 /***********/
 /// @brief Test for memory leaks.
 int variorum_tester(void);
-
-/// @brief To get a quoted variorum version, use QuoteMacro(VARIORUM_VERSION).
-#define QuoteIdent(ident) #ident
-#define QuoteMacro(macro) QuoteIdent(macro)
-char *variorum_get_current_version(void);
 #endif

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -539,5 +539,5 @@ int variorum_tester(void);
 /// @brief To get a quoted variorum version, use QuoteMacro(VARIORUM_VERSION).
 #define QuoteIdent(ident) #ident
 #define QuoteMacro(macro) QuoteIdent(macro)
-char* variorum_get_current_version(void);
+char *variorum_get_current_version(void);
 #endif

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -536,4 +536,8 @@ int variorum_get_node_power_domain_info_json(char **get_domain_obj_str);
 /// @brief Test for memory leaks.
 int variorum_tester(void);
 
+/// @brief To get a quoted variorum version, use QuoteMacro(VARIORUM_VERSION).
+#define QuoteIdent(ident) #ident
+#define QuoteMacro(macro) QuoteIdent(macro)
+
 #endif


### PR DESCRIPTION
# Description

Improves examples by adding `-h` and a `-v` flags and usage statement to all examples.

First step in fixing #267

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# How Has This Been Tested?
- [x] Comus (Broadwell),
- [x] Thompson (Haswell),
- [x] Alehouse (Power9)
- [x] Rhetoric (Skylake, single socket)
- [x] ARM Juno r2
- [x] Lassen with the CUDA host-config file build for NVML testing (different than alehouse).

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass with my changes