### PR TITLE
Check-code-format was not picking up c/h files in bash 5.1.4+.

### DIFF
--- a/scripts/check-code-format.sh
+++ b/scripts/check-code-format.sh
@@ -3,7 +3,7 @@
 # check format for all *.cpp, *.h, and *.c files in src/ directory
 #   exclude files in thirdparty_builtin/ (gtest source files)
 #   exclude files in fortran/ (EP source files)
-FILES=$(find src -type f  \( -name *.[ch] -o -name *.cpp \) \
+FILES=$(find src -type f  \( -name "*.[ch]" -o -name *.cpp \) \
         | grep -v thirdparty_builtin \
         | grep -v fortran)
 


### PR DESCRIPTION
Fixes #255 identified by @chaz-browne and @rountree -- thank you so much for finding this bug! Creating a separate PR for this so it can be merged in independently and easily while @chaz-browne works on the examples and `variorum.h` definitions. 