### PR TITLE
add new header to expose topology get APIs

### DIFF
--- a/src/variorum/CMakeLists.txt
+++ b/src/variorum/CMakeLists.txt
@@ -17,6 +17,7 @@ set(variorum_headers
   variorum.h
   variorum_timers.h
   variorum_error.h
+  variorum_topology.h
 )
 
 set(variorum_sources
@@ -24,6 +25,7 @@ set(variorum_sources
   variorum.c
   variorum_timers.c
   variorum_error.c
+  variorum_topology.c
 )
 
 set(variorum_deps ""
@@ -122,6 +124,7 @@ install(TARGETS variorum
 
 set(variorum_install_headers
     variorum.h
+    variorum_topology.h
 )
 
 install(FILES ${variorum_install_headers}

--- a/src/variorum/variorum_topology.c
+++ b/src/variorum/variorum_topology.c
@@ -1,0 +1,63 @@
+// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <hwloc.h>
+
+
+int variorum_get_num_sockets(void)
+{
+    hwloc_topology_t topology;
+    int rc;
+
+    rc = hwloc_topology_init(&topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    rc = hwloc_topology_load(topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    return hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
+}
+
+int variorum_get_num_cores(void)
+{
+    hwloc_topology_t topology;
+    int rc;
+
+    rc = hwloc_topology_init(&topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    rc = hwloc_topology_load(topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    return hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+}
+
+int variorum_get_num_threads(void)
+{
+    hwloc_topology_t topology;
+    int rc;
+
+    rc = hwloc_topology_init(&topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    rc = hwloc_topology_load(topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    return hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
+}

--- a/src/variorum/variorum_topology.h
+++ b/src/variorum/variorum_topology.h
@@ -1,0 +1,17 @@
+// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef VARIORUM_TOPOLOGY_H_INCLUDE
+#define VARIORUM_TOPOLOGY_H_INCLUDE
+
+#include <stdio.h>
+
+int variorum_get_num_sockets(void);
+
+int variorum_get_num_cores(void);
+
+int variorum_get_num_threads(void);
+
+#endif


### PR DESCRIPTION
- adds variorum_topology.h, which exposes APIs to get basic topology info
  including as number of sockets, cores, and threads
- installs this header alongside variorum.h

Resolves #266 