### PR TITLE
add new header to expose topology get APIs

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -17,6 +17,7 @@ set(BASIC_EXAMPLES
     variorum-enable-turbo-example
     variorum-get-node-power-json-example
     variorum-get-node-power-domain-info-json-example
+    variorum-get-topology-info-example
     variorum-monitoring-to-file-example
     variorum-poll-power-to-file-example
     variorum-poll-power-to-stdout-example

--- a/src/examples/variorum-get-topology-info-example.c
+++ b/src/examples/variorum-get-topology-info-example.c
@@ -1,0 +1,53 @@
+// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+
+#include <variorum_topology.h>
+
+int main(int argc, char **argv)
+{
+    int num_sockets, num_cores, num_threads; 
+
+    // Demonstrates usage of Variorum's advanced API for obtaining topology information. 
+    printf("This example demonstrates the use of variorum_topology.h API \n"
+           "to obtain basic information from the underlying architecture.\n"); 
+
+    num_sockets =  variorum_get_num_sockets();
+
+    if (num_sockets > 0) 
+    {
+        printf("Number of sockets on this hardware: %d\n", num_sockets); 
+    }
+    else
+    {
+        printf("HWLOC returned an invalid number of sockets (<=0)."
+               "Variorum does not handle this case. \n"); 
+    }
+
+    num_cores = variorum_get_num_cores(); 
+
+    if (num_cores > 0) 
+    {
+        printf("Number of cores on this hardware: %d\n", num_cores); 
+    }
+    else
+    {
+        printf("HWLOC returned an invalid number of cores (<=0)."
+               "Variorum does not handle this case. \n"); 
+    }
+
+    num_threads = variorum_get_num_threads(); 
+    
+    if (num_threads > 0) 
+    {
+        printf("Number of threads on this hardware: %d\n", num_threads); 
+    }
+    else
+    {
+        printf("HWLOC returned an invalid number of threads (<=0)."
+               "Variorum does not handle this case. \n"); 
+    }
+}

--- a/src/examples/variorum-get-topology-info-example.c
+++ b/src/examples/variorum-get-topology-info-example.c
@@ -7,7 +7,7 @@
 
 #include <variorum_topology.h>
 
-int main(int argc, char **argv)
+int main()
 {
     int num_sockets, num_cores, num_threads;
 
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
 
     if (num_cores > 0)
     {
-        printf("Number of cores on this hardware: %d\n", num_cores);
+        printf("Number of cores/socket on this hardware: %d\n", num_cores);
     }
     else
     {
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
 
     if (num_threads > 0)
     {
-        printf("Number of threads on this hardware: %d\n", num_threads);
+        printf("Number of threads/socket on this hardware: %d\n", num_threads);
     }
     else
     {

--- a/src/examples/variorum-get-topology-info-example.c
+++ b/src/examples/variorum-get-topology-info-example.c
@@ -9,45 +9,45 @@
 
 int main(int argc, char **argv)
 {
-    int num_sockets, num_cores, num_threads; 
+    int num_sockets, num_cores, num_threads;
 
-    // Demonstrates usage of Variorum's advanced API for obtaining topology information. 
+    // Demonstrates usage of Variorum's advanced API for obtaining topology information.
     printf("This example demonstrates the use of variorum_topology.h API \n"
-           "to obtain basic information from the underlying architecture.\n"); 
+           "to obtain basic information from the underlying architecture.\n");
 
     num_sockets =  variorum_get_num_sockets();
 
-    if (num_sockets > 0) 
+    if (num_sockets > 0)
     {
-        printf("Number of sockets on this hardware: %d\n", num_sockets); 
+        printf("Number of sockets on this hardware: %d\n", num_sockets);
     }
     else
     {
         printf("HWLOC returned an invalid number of sockets (<=0)."
-               "Variorum does not handle this case. \n"); 
+               "Variorum does not handle this case. \n");
     }
 
-    num_cores = variorum_get_num_cores(); 
+    num_cores = variorum_get_num_cores();
 
-    if (num_cores > 0) 
+    if (num_cores > 0)
     {
-        printf("Number of cores on this hardware: %d\n", num_cores); 
+        printf("Number of cores on this hardware: %d\n", num_cores);
     }
     else
     {
         printf("HWLOC returned an invalid number of cores (<=0)."
-               "Variorum does not handle this case. \n"); 
+               "Variorum does not handle this case. \n");
     }
 
-    num_threads = variorum_get_num_threads(); 
-    
-    if (num_threads > 0) 
+    num_threads = variorum_get_num_threads();
+
+    if (num_threads > 0)
     {
-        printf("Number of threads on this hardware: %d\n", num_threads); 
+        printf("Number of threads on this hardware: %d\n", num_threads);
     }
     else
     {
         printf("HWLOC returned an invalid number of threads (<=0)."
-               "Variorum does not handle this case. \n"); 
+               "Variorum does not handle this case. \n");
     }
 }

--- a/src/variorum/CMakeLists.txt
+++ b/src/variorum/CMakeLists.txt
@@ -17,6 +17,7 @@ set(variorum_headers
   variorum.h
   variorum_timers.h
   variorum_error.h
+  variorum_topology.h
 )
 
 set(variorum_sources
@@ -24,6 +25,7 @@ set(variorum_sources
   variorum.c
   variorum_timers.c
   variorum_error.c
+  variorum_topology.c
 )
 
 set(variorum_deps ""
@@ -122,6 +124,7 @@ install(TARGETS variorum
 
 set(variorum_install_headers
     variorum.h
+    variorum_topology.h
 )
 
 install(FILES ${variorum_install_headers}

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-//#include <hwloc.h>
 #include <variorum_topology.h>
 #include <assert.h>
 
@@ -172,7 +171,7 @@ void variorum_get_topology(unsigned *nsockets, unsigned *ncores,
         init_variorum_get_topology = 1;
 
         rc = variorum_init_topology();
-        
+
         if (rc != 0)
         {
             fprintf(stderr, "%s:%d "

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -161,8 +161,8 @@ int variorum_detect_arch(void)
 void variorum_get_topology(unsigned *nsockets, unsigned *ncores,
                            unsigned *nthreads)
 {
-//    hwloc_topology_t topology;
     int rc;
+
     static int init_variorum_get_topology = 0;
 
     gethostname(g_platform.hostname, 1024);
@@ -171,21 +171,18 @@ void variorum_get_topology(unsigned *nsockets, unsigned *ncores,
     {
         init_variorum_get_topology = 1;
 
-        // hwloc should give us expected results on any reasonable arch.
-        // If something goes wrong, there's no sense in trying to keep
-        // marching forward.
-        rc = hwloc_topology_init(&topology);
+        rc = variorum_init_topology();
+        
         if (rc != 0)
         {
+            fprintf(stderr, "%s:%d "
+                    "hwloc topology initialization error. "
+                    "Exiting.", __FILE__, __LINE__);
             exit(-1);
-        }
-        rc = hwloc_topology_load(topology);
-        if (rc != 0)
-        {
-            exit(-1);
+
         }
 
-        g_platform.num_sockets = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
+        g_platform.num_sockets = variorum_get_num_sockets();
         //-1 if Several levels exist with OBJ_SOCKET
         if (g_platform.num_sockets == -1)
         {
@@ -206,7 +203,7 @@ void variorum_get_topology(unsigned *nsockets, unsigned *ncores,
             exit(-1);
         }
 
-        g_platform.total_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+        g_platform.total_cores = variorum_get_num_cores();
         if (g_platform.total_cores == -1)
         {
             fprintf(stderr, "%s:%d "
@@ -225,7 +222,7 @@ void variorum_get_topology(unsigned *nsockets, unsigned *ncores,
             exit(-1);
         }
 
-        g_platform.total_threads = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
+        g_platform.total_threads = variorum_get_num_threads();
         if (g_platform.total_threads == -1)
         {
             fprintf(stderr, "%s:%d "
@@ -272,7 +269,6 @@ void variorum_get_topology(unsigned *nsockets, unsigned *ncores,
             exit(-1);
         }
 
-        hwloc_topology_destroy(topology);
     }
 
     if (nsockets != NULL)

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <variorum_topology.h>
 #include <assert.h>
 

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -7,7 +7,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <hwloc.h>
+//#include <hwloc.h>
+#include <variorum_topology.h>
 #include <assert.h>
 
 #include <config_architecture.h>
@@ -160,7 +161,7 @@ int variorum_detect_arch(void)
 void variorum_get_topology(unsigned *nsockets, unsigned *ncores,
                            unsigned *nthreads)
 {
-    hwloc_topology_t topology;
+//    hwloc_topology_t topology;
     int rc;
     static int init_variorum_get_topology = 0;
 

--- a/src/variorum/variorum_topology.c
+++ b/src/variorum/variorum_topology.c
@@ -5,59 +5,75 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <hwloc.h>
+#include <variorum_topology.h>
 
+
+int variorum_init_topology(void)
+{
+    int rc = -1;
+
+    rc = hwloc_topology_init(&topology);
+
+    if (rc == 0)
+    {
+        rc = hwloc_topology_load(topology);
+    }
+
+    return rc;
+}
+
+void variorum_destroy_topology(void)
+{
+    hwloc_topology_destroy(topology);
+}
 
 int variorum_get_num_sockets(void)
 {
-    hwloc_topology_t topology;
-    int rc;
+    int num_sockets = -1; 
+    int rc = -1;
 
-    rc = hwloc_topology_init(&topology);
-    if (rc != 0)
+    rc = variorum_init_topology();
+
+    if (rc == 0)
     {
-        exit(-1);
+        num_sockets = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
+        variorum_destroy_topology();
+        return num_sockets;
     }
-    rc = hwloc_topology_load(topology);
-    if (rc != 0)
-    {
-        exit(-1);
-    }
-    return hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
+
+    return rc;
 }
 
 int variorum_get_num_cores(void)
 {
-    hwloc_topology_t topology;
-    int rc;
+    int num_cores = -1; 
+    int rc = -1;
 
-    rc = hwloc_topology_init(&topology);
-    if (rc != 0)
+    rc = variorum_init_topology();
+
+    if (rc == 0)
     {
-        exit(-1);
+        num_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+        variorum_destroy_topology();
+        return num_cores;
     }
-    rc = hwloc_topology_load(topology);
-    if (rc != 0)
-    {
-        exit(-1);
-    }
-    return hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+
+    return rc;
 }
 
 int variorum_get_num_threads(void)
 {
-    hwloc_topology_t topology;
-    int rc;
+    int num_threads = -1; 
+    int rc = -1;
 
-    rc = hwloc_topology_init(&topology);
-    if (rc != 0)
+    rc = variorum_init_topology();
+
+    if (rc == 0)
     {
-        exit(-1);
+        num_threads = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
+        variorum_destroy_topology();
+        return num_threads;
     }
-    rc = hwloc_topology_load(topology);
-    if (rc != 0)
-    {
-        exit(-1);
-    }
-    return hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
+
+    return rc;
 }

--- a/src/variorum/variorum_topology.c
+++ b/src/variorum/variorum_topology.c
@@ -7,40 +7,51 @@
 #include <stdlib.h>
 #include <hwloc.h>
 
-hwloc_topology_t topology;
+#include <variorum_topology.h>
+
+extern hwloc_topology_t topology;
 
 int variorum_init_topology(void)
 {
     int rc;
+    static int init_variorum_init_topology = 0;
 
-    rc = hwloc_topology_init(&topology);
-
-    if (rc != 0)
+    if (!init_variorum_init_topology)
     {
-        fprintf(stderr, "%s:%d "
-                "hwloc topology initialization error. "
-                "Exiting.", __FILE__, __LINE__);
-        exit(-1);
+        printf("INIT topology\n");
+        init_variorum_init_topology = 1;
+
+        rc = hwloc_topology_init(&topology);
+        if (rc != 0)
+        {
+            fprintf(stderr, "%s:%d "
+                    "hwloc topology initialization error. "
+                    "Exiting.", __FILE__, __LINE__);
+            exit(-1);
+        }
+
+        rc = hwloc_topology_load(topology);
+        if (rc != 0)
+        {
+            fprintf(stderr, "%s:%d "
+                    "hwloc topology load error. "
+                    "Exiting.", __FILE__, __LINE__);
+            exit(-1);
+        }
     }
-
-    rc = hwloc_topology_load(topology);
-
-    if (rc != 0)
+    else
     {
-        fprintf(stderr, "%s:%d "
-                "hwloc topology load error. "
-                "Exiting.", __FILE__, __LINE__);
-        exit(-1);
+        printf("Already init, returning...\n");
     }
 
     // Initialization is successful if we reach this point.
     return 0;
 }
 
-void variorum_destroy_topology(void)
-{
-    hwloc_topology_destroy(topology);
-}
+//void variorum_destroy_topology(void)
+//{
+//    hwloc_topology_destroy(topology);
+//}
 
 int variorum_get_num_sockets(void)
 {
@@ -52,7 +63,7 @@ int variorum_get_num_sockets(void)
     if (rc == 0)
     {
         num_sockets = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
-        variorum_destroy_topology();
+        //variorum_destroy_topology();
         return num_sockets;
     }
 
@@ -69,7 +80,7 @@ int variorum_get_num_cores(void)
     if (rc == 0)
     {
         num_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
-        variorum_destroy_topology();
+        //variorum_destroy_topology();
         return num_cores;
     }
 
@@ -86,7 +97,7 @@ int variorum_get_num_threads(void)
     if (rc == 0)
     {
         num_threads = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
-        variorum_destroy_topology();
+        //variorum_destroy_topology();
         return num_threads;
     }
 

--- a/src/variorum/variorum_topology.c
+++ b/src/variorum/variorum_topology.c
@@ -10,16 +10,30 @@
 
 int variorum_init_topology(void)
 {
-    int rc = -1;
+    int rc;
 
     rc = hwloc_topology_init(&topology);
 
-    if (rc == 0)
+    if (rc != 0)
     {
-        rc = hwloc_topology_load(topology);
+        fprintf(stderr, "%s:%d "
+                "hwloc topology initialization error. "
+                "Exiting.", __FILE__, __LINE__);
+        exit (-1);
     }
 
-    return rc;
+    rc = hwloc_topology_load(topology);
+
+    if (rc != 0)
+    {
+        fprintf(stderr, "%s:%d "
+                "hwloc topology load error. "
+                "Exiting.", __FILE__, __LINE__);
+        exit (-1);
+    }
+
+    // Initialization is successful if we reach this point. 
+    return 0;
 }
 
 void variorum_destroy_topology(void)

--- a/src/variorum/variorum_topology.c
+++ b/src/variorum/variorum_topology.c
@@ -18,7 +18,6 @@ int variorum_init_topology(void)
 
     if (!init_variorum_init_topology)
     {
-        printf("INIT topology\n");
         init_variorum_init_topology = 1;
 
         rc = hwloc_topology_init(&topology);
@@ -39,19 +38,10 @@ int variorum_init_topology(void)
             exit(-1);
         }
     }
-    else
-    {
-        printf("Already init, returning...\n");
-    }
 
     // Initialization is successful if we reach this point.
     return 0;
 }
-
-//void variorum_destroy_topology(void)
-//{
-//    hwloc_topology_destroy(topology);
-//}
 
 int variorum_get_num_sockets(void)
 {
@@ -63,7 +53,6 @@ int variorum_get_num_sockets(void)
     if (rc == 0)
     {
         num_sockets = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
-        //variorum_destroy_topology();
         return num_sockets;
     }
 
@@ -80,7 +69,6 @@ int variorum_get_num_cores(void)
     if (rc == 0)
     {
         num_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
-        //variorum_destroy_topology();
         return num_cores;
     }
 
@@ -97,7 +85,6 @@ int variorum_get_num_threads(void)
     if (rc == 0)
     {
         num_threads = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
-        //variorum_destroy_topology();
         return num_threads;
     }
 

--- a/src/variorum/variorum_topology.c
+++ b/src/variorum/variorum_topology.c
@@ -5,8 +5,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <variorum_topology.h>
+#include <hwloc.h>
 
+hwloc_topology_t topology;
 
 int variorum_init_topology(void)
 {
@@ -19,7 +20,7 @@ int variorum_init_topology(void)
         fprintf(stderr, "%s:%d "
                 "hwloc topology initialization error. "
                 "Exiting.", __FILE__, __LINE__);
-        exit (-1);
+        exit(-1);
     }
 
     rc = hwloc_topology_load(topology);
@@ -29,10 +30,10 @@ int variorum_init_topology(void)
         fprintf(stderr, "%s:%d "
                 "hwloc topology load error. "
                 "Exiting.", __FILE__, __LINE__);
-        exit (-1);
+        exit(-1);
     }
 
-    // Initialization is successful if we reach this point. 
+    // Initialization is successful if we reach this point.
     return 0;
 }
 
@@ -43,7 +44,7 @@ void variorum_destroy_topology(void)
 
 int variorum_get_num_sockets(void)
 {
-    int num_sockets = -1; 
+    int num_sockets = -1;
     int rc = -1;
 
     rc = variorum_init_topology();
@@ -60,7 +61,7 @@ int variorum_get_num_sockets(void)
 
 int variorum_get_num_cores(void)
 {
-    int num_cores = -1; 
+    int num_cores = -1;
     int rc = -1;
 
     rc = variorum_init_topology();
@@ -77,7 +78,7 @@ int variorum_get_num_cores(void)
 
 int variorum_get_num_threads(void)
 {
-    int num_threads = -1; 
+    int num_threads = -1;
     int rc = -1;
 
     rc = variorum_init_topology();

--- a/src/variorum/variorum_topology.c
+++ b/src/variorum/variorum_topology.c
@@ -9,7 +9,7 @@
 
 #include <variorum_topology.h>
 
-extern hwloc_topology_t topology;
+hwloc_topology_t topology;
 
 int variorum_init_topology(void)
 {

--- a/src/variorum/variorum_topology.c
+++ b/src/variorum/variorum_topology.c
@@ -1,0 +1,63 @@
+// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <hwloc.h>
+
+
+int variorum_get_num_sockets(void)
+{
+    hwloc_topology_t topology;
+    int rc;
+
+    rc = hwloc_topology_init(&topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    rc = hwloc_topology_load(topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    return hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_SOCKET);
+}
+
+int variorum_get_num_cores(void)
+{
+    hwloc_topology_t topology;
+    int rc;
+
+    rc = hwloc_topology_init(&topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    rc = hwloc_topology_load(topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    return hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+}
+
+int variorum_get_num_threads(void)
+{
+    hwloc_topology_t topology;
+    int rc;
+
+    rc = hwloc_topology_init(&topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    rc = hwloc_topology_load(topology);
+    if (rc != 0)
+    {
+        exit(-1);
+    }
+    return hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
+}

--- a/src/variorum/variorum_topology.h
+++ b/src/variorum/variorum_topology.h
@@ -7,6 +7,9 @@
 #define VARIORUM_TOPOLOGY_H_INCLUDE
 
 #include <stdio.h>
+#include <hwloc.h>
+
+static hwloc_topology_t topology;
 
 int variorum_init_topology(void);
 

--- a/src/variorum/variorum_topology.h
+++ b/src/variorum/variorum_topology.h
@@ -7,11 +7,18 @@
 #define VARIORUM_TOPOLOGY_H_INCLUDE
 
 #include <stdio.h>
+#include <hwloc.h>
+
+hwloc_topology_t topology;
+
+int variorum_init_topology(void); 
 
 int variorum_get_num_sockets(void);
 
 int variorum_get_num_cores(void);
 
 int variorum_get_num_threads(void);
+
+void variorum_destroy_topology(void); 
 
 #endif

--- a/src/variorum/variorum_topology.h
+++ b/src/variorum/variorum_topology.h
@@ -1,0 +1,17 @@
+// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef VARIORUM_TOPOLOGY_H_INCLUDE
+#define VARIORUM_TOPOLOGY_H_INCLUDE
+
+#include <stdio.h>
+
+int variorum_get_num_sockets(void);
+
+int variorum_get_num_cores(void);
+
+int variorum_get_num_threads(void);
+
+#endif

--- a/src/variorum/variorum_topology.h
+++ b/src/variorum/variorum_topology.h
@@ -7,11 +7,8 @@
 #define VARIORUM_TOPOLOGY_H_INCLUDE
 
 #include <stdio.h>
-#include <hwloc.h>
 
-hwloc_topology_t topology;
-
-int variorum_init_topology(void); 
+int variorum_init_topology(void);
 
 int variorum_get_num_sockets(void);
 
@@ -19,6 +16,6 @@ int variorum_get_num_cores(void);
 
 int variorum_get_num_threads(void);
 
-void variorum_destroy_topology(void); 
+void variorum_destroy_topology(void);
 
 #endif

--- a/src/variorum/variorum_topology.h
+++ b/src/variorum/variorum_topology.h
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <hwloc.h>
 
-static hwloc_topology_t topology;
+extern hwloc_topology_t topology;
 
 int variorum_init_topology(void);
 

--- a/src/variorum/variorum_topology.h
+++ b/src/variorum/variorum_topology.h
@@ -19,6 +19,4 @@ int variorum_get_num_cores(void);
 
 int variorum_get_num_threads(void);
 
-void variorum_destroy_topology(void);
-
 #endif


### PR DESCRIPTION
Refactors Stephanie's PR #268 by exposing a `hwloc` struct variable to the users in `variorum_topology.h`, adding `init/destroy` functions, and refactoring `config_architecture.c` to use `variorum_topology.h`. 

- adds variorum_topology.h, which exposes APIs to get basic topology info
including number of sockets, cores, and threads
- installs this header alongside variorum.h
- Resolves https://github.com/LLNL/variorum/issues/266

Some advantages include:

- no code duplication
- users can use the same hwloc topology object to do other complex tasks in their code if needed (by including `hwloc.h` of course, and calling functions there in addition to variorum_topology API for `num_sockets` `num_cores` etc). 

Questions:
- Unclear if adding the struct to variorum_topology.h creates other problems, unsure if this needs to be static.

Testing:
- Works on Lassen. Tested with the `variorum_print_power`, `variorum_print_power_limit` and `variorum_get_node_power_json` APIs, as well as the following test:

```
#include <stdio.h>
#include <stdlib.h>

#include <variorum.h>
#include <variorum_topology.h>

int main(int argc, char **argv)
{
    printf("Num sockets %d\n", variorum_get_num_sockets());
    printf("Num cores %d\n", variorum_get_num_cores());
    printf("Num threads %d\n", variorum_get_num_threads());
}

```
Built as follows:
```
$ gcc test.c -I/g/g90/patki1/src/var-clean/variorum/install-topo-test/include/ -L/g/g90/patki1/src/var-clean/variorum/install-topo-test/lib/ -lvariorum

$ ./a.out 
Num sockets 2
Num cores 40
Num threads 160
```

ToDo testing:
- [x] Comus (Broadwell), 
- [x] Thompson (Haswell), 
- [x] Alehouse (Power9)
- [x] Rhetoric (Skylake, single socket)
- [x] ARM Juno r2
- [x] Lassen with the CUDA host-config file build for NVML testing (different than alehouse).
- [x] Cleanup print statements
- [x] Add example .