### PR TITLE
Changing JSON API to use char** instead of json_t* as parameter. 

### DIFF
--- a/src/docs/sphinx/Examples.rst
+++ b/src/docs/sphinx/Examples.rst
@@ -8,7 +8,11 @@
  Example Programs
 ##################
 
-Variorum provides some examples in the ``examples/`` directory.
+Variorum provides some examples in the ``examples/`` directory. These include 
+examples of our APIs, usage with MPI and OpenMP, and an example for integrating 
+with Variorum using the JSON API. 
+Note that on Intel systems, we make a call to Variorum print API twice in our examples, 
+as Intel systems require a delta between values to report adequate power numbers. 
 
 .. note::
 
@@ -24,7 +28,7 @@ prints the output in tabular format that can be filtered and parsed by a data
 analysis framework, such as ``R`` or ``Python``.
 
 On an Intel platform, the output of this example should be similar to the
-following:
+following. 
 
 .. code::
 

--- a/src/docs/sphinx/VariorumAPI.rst
+++ b/src/docs/sphinx/VariorumAPI.rst
@@ -38,13 +38,13 @@ used to easily integrate with Variorum (see :doc:`VariorumTools`).
 Obtaining Power Consumption
 ===========================
 
-The API to obtain node power has the following format. It takes a ``json_t``
-object by reference as input, and populates this JSON object with CPU, memory,
+The API to obtain node power has the following format. It takes a string (``char**``)
+by reference as input, and populates this string with a JSON object with CPU, memory,
 GPU (when available), and total node power. The total node power is estimated as
 a summation of available domains if it is not directly reported by the
 underlying architecture (such as Intel).
 
-The ``variorum_get_node_power_json(json_t *)`` includes the JSON object with the
+The ``variorum_get_node_power_json(char**)`` includes a string type JSON object with the
 following keys:
 
 -  hostname (string value)
@@ -55,19 +55,24 @@ following keys:
 -  power_gpu_watts_socket* (real value)
 
 The "*" here refers to Socket ID. While more than one socket is supported, our
-test systems had only 2 sockets. Note that on IBM Witherspoon platform, only the
+test systems had only 2 sockets. Note that on the IBM Power9 platform, only the
 first socket (Chip-0) has the PWRSYS sensor, which directly reports total node
-power. Both sockets here report CPU, Memory and GPU power. On Intel Broadwell,
-total node power is not reported by hardware, thus total node power is estimated
-by adding CPU and DRAM power on both sockets. For GPU power, IBM Witherspoon
+power. Addtionally, both sockets here report CPU, Memory and GPU power. 
+
+On Intel microarchitectures, total node power is not reported by hardware. As a result,
+total node power is estimated by adding CPU and DRAM power on both sockets. 
+
+For GPU power, IBM Power9
 reports a single value, which is the sum of power consumed by all the GPUs on a
 particular socket. Our JSON object captures this with a ``power_gpu_socket_*``
 interface, and does not report individual GPU power in the JSON object (this
-data is however available separately without JSON). On Intel Broadwell, on our
-system without GPUs, this value is currently set to -1.0 to indicate that the
-GPU power value cannot be measured directly through MSRs. This has been done to
-ensure that the JSON object in itself is vendor-neutral from a tools
-perspective. A future extension through NVML integration in the JSON object will
+data is however available separately without JSON). 
+
+On systems without GPUs, or systems without memory power information, the value
+of the JSON fields is currently set to -1.0 to indicate that the
+GPU power or memory power cannot be measured directly. This has been done to
+ensure that the JSON object in itself stays vendor-neutral from a tools
+perspective. A future extension through NVML integration will
 allow for this information to report individual GPU power as well as total GPU
 power per socket with a cross-architectural build, similar to Variorum's
 ``variorum_get_node_power()`` API.
@@ -82,8 +87,8 @@ control, as well as information on the minimum and maximum values for setting
 the controls (control_range). If a certain domain is unsupported, it is marked
 as such.
 
-The query API, ``variorum_get_node_power_domain_info_json(json_t *)``, accepts a
-JSON object by reference and includes the following vendor-neutral keys:
+The query API, ``variorum_get_node_power_domain_info_json(char**)``, accepts a
+string by reference and includes the following vendor-neutral keys:
 
 -  hostname (string value)
 -  timestamp (integer value)

--- a/src/docs/sphinx/VariorumTools.rst
+++ b/src/docs/sphinx/VariorumTools.rst
@@ -69,6 +69,7 @@ retrieved in a similar manner by other JSON libraries and supporting tools.
    {
        // Define a JSON object to retrieve data from Variorum in
        json_t *power_obj = json_object();
+       char *s = NULL;
 
        // Define a local variable for the value of interest. For example, the
        // client side tool may only be interested in node power, or it may be
@@ -79,18 +80,24 @@ retrieved in a similar manner by other JSON libraries and supporting tools.
        int ret;
 
        // Call the Variorum JSON API
-       ret = variorum_get_node_power_json(power_obj);
+       ret = variorum_get_node_power_json(&s);
        if (ret != 0)
        {
            printf("Variorum get node power API failed.\n");
+           free(s);
+           exit(-1);
        }
 
        // Extract the value of interest from the JSON object by using the
        // appropriate get function. Documentation of these can be found in the
        // JANSSON library documentation.
+       power_obj = json_loads(s, JSON_DECODE_ANY, NULL);
        power_node = json_real_value(json_object_get(power_obj, "power_node_watts"));
        printf("Node power is: %lf\n", power_node);
 
        // Decrement references to JSON object, required for JANSSON library.
        json_decref(power_obj);
+
+        // Deallocate the string
+       free(s);
    }

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -17,6 +17,7 @@ set(BASIC_EXAMPLES
     variorum-enable-turbo-example
     variorum-get-node-power-json-example
     variorum-get-node-power-domain-info-json-example
+    variorum-integration-using-json-example
     variorum-get-topology-info-example
     variorum-monitoring-to-file-example
     variorum-poll-power-to-file-example

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -20,7 +20,9 @@ int main(void)
 
     if (ret != 0)
     {
-        printf("First run: JSON get node power domain information failed!\n");
+        printf("JSON get node power domain information failed!\n");
+        free(s);
+        exit (-1);
     }
 
     /* Print the entire JSON object */

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -14,22 +14,22 @@ int main(void)
     char *s = NULL;
 
     /* Allocate string based on number of sockets on the platform */
-    /* String allocation below assumes the following: 
+    /* String allocation below assumes the following:
      * Upper bound of 180 characters for hostname, timestamp and node power.
      * Upper bound of 150 characters for per-socket information */
     s = (char *) malloc(800 * sizeof(char));
- 
+
     ret = variorum_get_node_power_domain_info_json(&s);
     if (ret != 0)
     {
         printf("First run: JSON get node power domain information failed!\n");
     }
-    
-    /* Print the entire JSON object */ 
+
+    /* Print the entire JSON object */
     puts(s);
 
     /* Deallocate the string */
-    free(s); 
+    free(s);
 
     return ret;
 }

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -6,20 +6,17 @@
 #include <stdio.h>
 
 #include <variorum.h>
-#include <variorum_topology.h>
 
 int main(void)
 {
     int ret;
     char *s = NULL;
 
-    /* Allocate string based on number of sockets on the platform */
-    /* String allocation below assumes the following:
-     * Upper bound of 180 characters for hostname, timestamp and node power.
-     * Upper bound of 150 characters for per-socket information */
+    /* Allocate string based on vendor-neutral JSON structure*/
     s = (char *) malloc(800 * sizeof(char));
 
     ret = variorum_get_node_power_domain_info_json(&s);
+
     if (ret != 0)
     {
         printf("First run: JSON get node power domain information failed!\n");

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -6,24 +6,30 @@
 #include <stdio.h>
 
 #include <variorum.h>
-#include <jansson.h>
+#include <variorum_topology.h>
 
 int main(void)
 {
     int ret;
-    json_t *my_domain_obj = NULL;
     char *s = NULL;
 
-    // Create JSON object and pass to variorum API as reference.
-    my_domain_obj = json_object();
-    ret = variorum_get_node_power_domain_info_json(my_domain_obj);
+    /* Allocate string based on number of sockets on the platform */
+    /* String allocation below assumes the following: 
+     * Upper bound of 180 characters for hostname, timestamp and node power.
+     * Upper bound of 150 characters for per-socket information */
+    s = (char *) malloc(800 * sizeof(char));
+ 
+    ret = variorum_get_node_power_domain_info_json(&s);
     if (ret != 0)
     {
         printf("First run: JSON get node power domain information failed!\n");
     }
-    s = json_dumps(my_domain_obj, 0);
+    
+    /* Print the entire JSON object */ 
     puts(s);
 
-    json_decref(my_domain_obj);
+    /* Deallocate the string */
+    free(s); 
+
     return ret;
 }

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <variorum.h>
 

--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -22,7 +22,7 @@ int main(void)
     {
         printf("JSON get node power domain information failed!\n");
         free(s);
-        exit (-1);
+        exit(-1);
     }
 
     /* Print the entire JSON object */

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -55,7 +55,7 @@ int main(void)
     {
         printf("First run: JSON get node power failed!\n");
         free(s);
-        exit (-1);
+        exit(-1);
     }
 
     /* Print the entire JSON object */
@@ -71,7 +71,7 @@ int main(void)
     {
         printf("Second run: JSON get node power failed!\n");
         free(s);
-        exit (-1);
+        exit(-1);
     }
 #endif
 

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -48,7 +48,7 @@ int main(void)
     /* String allocation below assumes the following:
      * Upper bound of 180 characters for hostname, timestamp and node power.
      * Upper bound of 150 characters for per-socket information */
-    s = (char *) malloc((num_sockets * 150 + 150) * sizeof(char));
+    s = (char *) malloc((num_sockets * 150 + 180) * sizeof(char));
 
     ret = variorum_get_node_power_json(&s);
     if (ret != 0)
@@ -73,10 +73,10 @@ int main(void)
         free(s);
         exit(-1);
     }
-#endif
 
     /* Print the entire JSON object */
     puts(s);
+#endif
 
     /* Deallocate the string */
     free(s);

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <variorum.h>
 #include <variorum_topology.h>

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -54,6 +54,8 @@ int main(void)
     if (ret != 0)
     {
         printf("First run: JSON get node power failed!\n");
+        free(s);
+        exit (-1);
     }
 
     /* Print the entire JSON object */
@@ -68,6 +70,8 @@ int main(void)
     if (ret != 0)
     {
         printf("Second run: JSON get node power failed!\n");
+        free(s);
+        exit (-1);
     }
 #endif
 

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -37,14 +37,14 @@ int main(void)
     /* Determine number of sockets */
     num_sockets = variorum_get_num_sockets();
 
-    if (num_sockets <=0)
+    if (num_sockets <= 0)
     {
         printf("HWLOC returned an invalid number of sockets. Exiting.\n");
-        exit (-1);
+        exit(-1);
     }
 
     /* Allocate string based on number of sockets on the platform */
-    /* String allocation below assumes the following: 
+    /* String allocation below assumes the following:
      * Upper bound of 180 characters for hostname, timestamp and node power.
      * Upper bound of 150 characters for per-socket information */
     s = (char *) malloc((num_sockets * 150 + 150) * sizeof(char));
@@ -55,7 +55,7 @@ int main(void)
         printf("First run: JSON get node power failed!\n");
     }
 
-    /* Print the entire JSON object */ 
+    /* Print the entire JSON object */
     puts(s);
 
 #ifdef SECOND_RUN
@@ -70,11 +70,11 @@ int main(void)
     }
 #endif
 
-    /* Print the entire JSON object */ 
+    /* Print the entire JSON object */
     puts(s);
 
     /* Deallocate the string */
-    free(s); 
+    free(s);
 
     return ret;
 }

--- a/src/examples/variorum-integration-using-json-example.c
+++ b/src/examples/variorum-integration-using-json-example.c
@@ -10,27 +10,36 @@
 #include <variorum_topology.h>
 #include <jansson.h>
 
-int main(void)
+#ifdef SECOND_RUN
+static inline double do_work(int input)
 {
-    int ret;
-    char *s = NULL;
-    int num_sockets = 0;
+    int i;
+    double result = (double)input;
+
+    for (i = 0; i < 100000; i++)
+    {
+        result += i * result;
+    }
+
+    return result;
+}
+#endif
+
+void parse_json_obj(char *s, int num_sockets)
+{
     int i, j;
+
+    /* Create a Jansson based JSON structure */
     json_t *power_obj = NULL;
+
     double power_node, power_cpu, power_gpu, power_mem;
     static char **json_metric_names = NULL;
+
+    /* List of socket-level JSON object metrics */
     static const char *metrics[] = {"power_cpu_watts_socket_",
-                                    "power_gpu_watts_socket_", "power_mem_watts_socket_"
+                                    "power_gpu_watts_socket_",
+                                    "power_mem_watts_socket_"
                                    };
-
-    /* Determine number of sockets */
-    num_sockets = variorum_get_num_sockets();
-
-    if (num_sockets <= 0)
-    {
-        printf("HWLOC returned an invalid number of sockets. Exiting.\n");
-        exit(-1);
-    }
 
     /* Allocate space for metric names */
     json_metric_names = malloc(3 * num_sockets * sizeof(char *));
@@ -52,29 +61,6 @@ int main(void)
             strcpy(json_metric_names[(num_sockets * j) + i], current_metric);
         }
     }
-
-    /* Allocate string based on number of sockets on the platform */
-    /* String allocation below assumes the following:
-     * Upper bound of 180 characters for hostname, timestamp and node power.
-     * Upper bound of 150 characters for per-socket information */
-    s = (char *) malloc((num_sockets * 150 + 180) * sizeof(char));
-
-    ret = variorum_get_node_power_json(&s);
-    if (ret != 0)
-    {
-        printf("First run: JSON get node power failed!\n");
-        free(s);
-        for (int i = 0; i < num_sockets * 3; i++)
-        {
-            free(json_metric_names[i]);
-        }
-        free(json_metric_names);
-        exit(-1);
-    }
-
-    /* Print the entire JSON object */
-    printf("\nJSON object received from Variorum is: \n");
-    puts(s);
 
     /* Load the string as a JSON object using Jansson */
     power_obj = json_loads(s, JSON_DECODE_ANY, NULL);
@@ -98,9 +84,6 @@ int main(void)
         printf("Socket %d, Memory Power: %lf Watts\n\n", i, power_mem);
     }
 
-    /* Deallocate the string */
-    free(s);
-
     /* Deallocate metric array */
     for (i = 0; i < num_sockets * 3; i++)
     {
@@ -110,6 +93,68 @@ int main(void)
 
     /*Deallocate JSON object*/
     json_decref(power_obj);
+}
+
+int main(void)
+{
+    int ret;
+    int num_sockets = 0;
+    char *s = NULL;
+#ifdef SECOND_RUN
+    int i;
+    int size = 1E4;
+    double x = 0.0;
+#endif
+
+    /* Determine number of sockets */
+    num_sockets = variorum_get_num_sockets();
+
+    if (num_sockets <= 0)
+    {
+        printf("HWLOC returned an invalid number of sockets. Exiting.\n");
+        exit(-1);
+    }
+
+    /* Allocate string based on number of sockets on the platform */
+    /* String allocation below assumes the following:
+     * Upper bound of 180 characters for hostname, timestamp and node power.
+     * Upper bound of 150 characters for per-socket information */
+    s = (char *) malloc((num_sockets * 150 + 180) * sizeof(char));
+
+    ret = variorum_get_node_power_json(&s);
+    if (ret != 0)
+    {
+        printf("First run: JSON get node power failed!\n");
+        free(s);
+        exit(-1);
+    }
+
+    /* Print the entire JSON object and then the parsed JSON object */
+    printf("\n*****JSON object received from first run is: \n");
+    puts(s);
+    parse_json_obj(s, num_sockets);
+
+#ifdef SECOND_RUN
+    for (i = 0; i < size; i++)
+    {
+        x += do_work(i);
+    }
+
+    ret = variorum_get_node_power_json(&s);
+    if (ret != 0)
+    {
+        printf("Second run: JSON get node power failed!\n");
+        free(s);
+        exit(-1);
+    }
+
+    printf("\n*****JSON object received from second run is: \n");
+    puts(s);
+    parse_json_obj(s, num_sockets);
+#endif
+
+    /* Deallocate the string */
+    free(s);
 
     return ret;
 }

--- a/src/examples/variorum-integration-using-json-example.c
+++ b/src/examples/variorum-integration-using-json-example.c
@@ -1,0 +1,115 @@
+// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <variorum.h>
+#include <variorum_topology.h>
+#include <jansson.h>
+
+int main(void)
+{
+    int ret;
+    char *s = NULL;
+    int num_sockets = 0;
+    int i, j;
+    json_t *power_obj = NULL;
+    double power_node, power_cpu, power_gpu, power_mem;
+    static char **json_metric_names = NULL;
+    static const char *metrics[] = {"power_cpu_watts_socket_",
+                                    "power_gpu_watts_socket_", "power_mem_watts_socket_"
+                                   };
+
+    /* Determine number of sockets */
+    num_sockets = variorum_get_num_sockets();
+
+    if (num_sockets <= 0)
+    {
+        printf("HWLOC returned an invalid number of sockets. Exiting.\n");
+        exit(-1);
+    }
+
+    /* Allocate space for metric names */
+    json_metric_names = malloc(3 * num_sockets * sizeof(char *));
+    for (i = 0; i < (3 * num_sockets); i++)
+    {
+        json_metric_names[i] = malloc(40);
+    }
+
+    for (i = 0; i < num_sockets; i++)
+    {
+        /* Create a metric name list for querying json object later on */
+        for (j = 0; j < 3; j++)
+        {
+            char current_metric[40];
+            char current_socket[8];
+            strcpy(current_metric, metrics[j]);
+            sprintf(current_socket, "%d", i);
+            strcat(current_metric, current_socket);
+            strcpy(json_metric_names[(num_sockets * j) + i], current_metric);
+        }
+    }
+
+    /* Allocate string based on number of sockets on the platform */
+    /* String allocation below assumes the following:
+     * Upper bound of 180 characters for hostname, timestamp and node power.
+     * Upper bound of 150 characters for per-socket information */
+    s = (char *) malloc((num_sockets * 150 + 180) * sizeof(char));
+
+    ret = variorum_get_node_power_json(&s);
+    if (ret != 0)
+    {
+        printf("First run: JSON get node power failed!\n");
+        free(s);
+        for (int i = 0; i < num_sockets * 3; i++)
+        {
+            free(json_metric_names[i]);
+        }
+        free(json_metric_names);
+        exit(-1);
+    }
+
+    /* Print the entire JSON object */
+    printf("\nJSON object received from Variorum is: \n");
+    puts(s);
+
+    /* Load the string as a JSON object using Jansson */
+    power_obj = json_loads(s, JSON_DECODE_ANY, NULL);
+
+    /* Extract and print values from JSON object */
+    power_node = json_real_value(json_object_get(power_obj, "power_node_watts"));
+
+    printf("\nExtracted power values at node and socket level are:");
+    printf("\n\nNode Power: %lf Watts\n\n", power_node);
+
+    for (i = 0; i < num_sockets; i++)
+    {
+        power_cpu = json_real_value(json_object_get(power_obj, json_metric_names[i]));
+        power_gpu = json_real_value(json_object_get(power_obj,
+                                    json_metric_names[num_sockets + i]));
+        power_mem = json_real_value(json_object_get(power_obj,
+                                    json_metric_names[(num_sockets * 2) + i]));
+
+        printf("Socket %d, CPU Power: %lf Watts\n", i, power_cpu);
+        printf("Socket %d, GPU Power: %lf Watts\n", i, power_gpu);
+        printf("Socket %d, Memory Power: %lf Watts\n\n", i, power_mem);
+    }
+
+    /* Deallocate the string */
+    free(s);
+
+    /* Deallocate metric array */
+    for (i = 0; i < num_sockets * 3; i++)
+    {
+        free(json_metric_names[i]);
+    }
+    free(json_metric_names);
+
+    /*Deallocate JSON object*/
+    json_decref(power_obj);
+
+    return ret;
+}

--- a/src/examples/variorum-integration-using-json-example.c
+++ b/src/examples/variorum-integration-using-json-example.c
@@ -45,7 +45,7 @@ int main(void)
         for (j = 0; j < 3; j++)
         {
             char current_metric[40];
-            char current_socket[8];
+            char current_socket[16];
             strcpy(current_metric, metrics[j]);
             sprintf(current_socket, "%d", i);
             strcat(current_metric, current_socket);

--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -498,7 +498,7 @@ int epyc_set_socket_boostlimit(int socket, int boostlimit)
  * the variorum development team.
  * We expect to test and update these two functions when access is made available.
  * */
-int epyc_get_node_power_json(json_t *get_power_obj)
+int epyc_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -510,6 +510,7 @@ int epyc_get_node_power_json(json_t *get_power_obj)
     /* AMD authors declared this as uint32_t and typecast it to double,
      * not sure why. Just following their lead from the get_power function*/
     uint32_t current_power;
+    json_t *get_power_obj = json_object();
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);
@@ -555,10 +556,14 @@ int epyc_get_node_power_json(json_t *get_power_obj)
 
     // Set the node power key with pwrnode value.
     json_object_set_new(get_power_obj, "power_node_watts", json_real(node_power));
+
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
+
     return 0;
 }
 
-int epyc_get_node_power_domain_info_json(json_t *get_domain_obj)
+int epyc_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -570,6 +575,7 @@ int epyc_get_node_power_domain_info_json(json_t *get_domain_obj)
     int ret = 0;
     uint32_t max_power = 0;
     char range_str[100];
+    json_t *get_domain_obj = json_object();
 
     //Get max power from E-SMI from socket 0, same for both sockets.
     //E-SMI doesn't expose minimum yet, something we need AMD to help with.
@@ -599,6 +605,9 @@ int epyc_get_node_power_domain_info_json(json_t *get_domain_obj)
                         json_string("[Watts]"));
     json_object_set_new(get_domain_obj, "control_range",
                         json_string(range_str));
+
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
+    json_decref(get_domain_obj);
 
     return 0;
 }

--- a/src/variorum/AMD/epyc.h
+++ b/src/variorum/AMD/epyc.h
@@ -26,8 +26,8 @@ int epyc_set_each_core_boostlimit(int boostlimit);
 
 int epyc_set_socket_boostlimit(int socket, int boostlimit);
 
-int epyc_get_node_power_json(json_t *get_power_obj);
+int epyc_get_node_power_json(char **get_power_obj_str);
 
-int epyc_get_node_power_domain_info_json(json_t *get_domain_obj);
+int epyc_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 #endif

--- a/src/variorum/ARM/ARM.c
+++ b/src/variorum/ARM/ARM.c
@@ -102,7 +102,7 @@ int arm_get_power_json(char **get_power_obj_str)
     return ret;
 }
 
-int arm_get_power_domain_info_json(char **get_power_domain_obj_str)
+int arm_get_power_domain_info_json(char **get_domain_obj_str)
 {
     int ret;
 #ifdef VARIORUM_LOG

--- a/src/variorum/ARM/ARM.c
+++ b/src/variorum/ARM/ARM.c
@@ -85,22 +85,36 @@ int arm_cap_socket_frequency(int cpuid, int freq)
     return ret;
 }
 
-int arm_get_power_json(json_t *get_power_obj)
+int arm_get_power_json(char** get_power_obj_str)
 {
     int ret;
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
+
+    json_t *get_power_obj = json_object();
+
     ret = json_get_power_data(get_power_obj);
+
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
+
     return ret;
 }
 
-int arm_get_power_domain_info_json(json_t *get_power_domain_obj)
+int arm_get_power_domain_info_json(char** get_power_domain_obj_str)
 {
     int ret;
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
-    ret = json_get_power_domain_info(get_power_domain_obj);
+
+    json_t *get_domain_obj = json_object();  
+
+    ret = json_get_power_domain_info(get_domain_obj);
+    
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
+    json_decref(get_domain_obj); 
+
     return ret;
 }

--- a/src/variorum/ARM/ARM.c
+++ b/src/variorum/ARM/ARM.c
@@ -85,7 +85,7 @@ int arm_cap_socket_frequency(int cpuid, int freq)
     return ret;
 }
 
-int arm_get_power_json(char** get_power_obj_str)
+int arm_get_power_json(char **get_power_obj_str)
 {
     int ret;
 #ifdef VARIORUM_LOG
@@ -102,19 +102,19 @@ int arm_get_power_json(char** get_power_obj_str)
     return ret;
 }
 
-int arm_get_power_domain_info_json(char** get_power_domain_obj_str)
+int arm_get_power_domain_info_json(char **get_power_domain_obj_str)
 {
     int ret;
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_t *get_domain_obj = json_object();  
+    json_t *get_domain_obj = json_object();
 
     ret = json_get_power_domain_info(get_domain_obj);
-    
+
     *get_domain_obj_str = json_dumps(get_domain_obj, 0);
-    json_decref(get_domain_obj); 
+    json_decref(get_domain_obj);
 
     return ret;
 }

--- a/src/variorum/ARM/ARM.h
+++ b/src/variorum/ARM/ARM.h
@@ -18,8 +18,8 @@ int arm_get_frequencies(void);
 
 int arm_cap_socket_frequency(int cpuid, int freq);
 
-int arm_get_power_json(json_t *get_power_obj);
+int arm_get_power_json(char** get_power_obj_str);
 
-int arm_get_power_domain_info_json(json_t *get_power_domain_obj);
+int arm_get_power_domain_info_json(char** get_domain_obj_str);
 
 #endif

--- a/src/variorum/ARM/ARM.h
+++ b/src/variorum/ARM/ARM.h
@@ -18,8 +18,8 @@ int arm_get_frequencies(void);
 
 int arm_cap_socket_frequency(int cpuid, int freq);
 
-int arm_get_power_json(char** get_power_obj_str);
+int arm_get_power_json(char **get_power_obj_str);
 
-int arm_get_power_domain_info_json(char** get_domain_obj_str);
+int arm_get_power_domain_info_json(char **get_domain_obj_str);
 
 #endif

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -350,7 +350,7 @@ int p9_cap_socket_power_limit(int long_ver)
     return 0;
 }
 
-int p9_get_node_power_json(char** get_power_obj_str)
+int p9_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -416,16 +416,16 @@ int p9_get_node_power_json(char** get_power_obj_str)
 
         free(buf);
     }
-        
+
     // Export JSON object as a string for returning.
-    *get_power_obj_str = json_dumps(get_power_obj, 0); 
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
 
     json_decref(get_power_obj);
     close(fd);
     return 0;
 }
 
-int p9_get_node_power_domain_info_json(char** get_domain_obj_str)
+int p9_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -455,9 +455,9 @@ int p9_get_node_power_domain_info_json(char** get_domain_obj_str)
     json_object_set_new(get_domain_obj, "control_range",
                         json_string("[{min: 500, max: 3050}, {min: 0, max: 100}]"));
 
-    
+
     // Export JSON object as a string for returning.
-    *get_domain_obj_str = json_dumps(get_domain_obj, 0); 
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
 
     json_decref(get_domain_obj);
 

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -413,13 +413,11 @@ int p9_get_node_power_json(char **get_power_obj_str)
         }
 
         json_get_power_sensors(iter, get_power_obj, buf);
-
         free(buf);
     }
 
     // Export JSON object as a string for returning.
     *get_power_obj_str = json_dumps(get_power_obj, 0);
-
     json_decref(get_power_obj);
     close(fd);
     return 0;
@@ -455,10 +453,8 @@ int p9_get_node_power_domain_info_json(char **get_domain_obj_str)
     json_object_set_new(get_domain_obj, "control_range",
                         json_string("[{min: 500, max: 3050}, {min: 0, max: 100}]"));
 
-
     // Export JSON object as a string for returning.
     *get_domain_obj_str = json_dumps(get_domain_obj, 0);
-
     json_decref(get_domain_obj);
 
     return 0;

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -350,7 +350,7 @@ int p9_cap_socket_power_limit(int long_ver)
     return 0;
 }
 
-int p9_get_node_power_json(json_t *get_power_obj)
+int p9_get_node_power_json(char** get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -365,6 +365,8 @@ int p9_get_node_power_json(json_t *get_power_obj)
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
+
+    json_t *get_power_obj = json_object();
 
     variorum_get_topology(&nsockets, NULL, NULL);
 
@@ -411,13 +413,19 @@ int p9_get_node_power_json(json_t *get_power_obj)
         }
 
         json_get_power_sensors(iter, get_power_obj, buf);
+
         free(buf);
     }
+        
+    // Export JSON object as a string for returning.
+    *get_power_obj_str = json_dumps(get_power_obj, 0); 
+
+    json_decref(get_power_obj);
     close(fd);
     return 0;
 }
 
-int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
+int p9_get_node_power_domain_info_json(char** get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -426,6 +434,7 @@ int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
+    json_t *get_domain_obj = json_object();
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);
@@ -445,6 +454,12 @@ int p9_get_node_power_domain_info_json(json_t *get_domain_obj)
                         json_string("[Watts, Percentage]"));
     json_object_set_new(get_domain_obj, "control_range",
                         json_string("[{min: 500, max: 3050}, {min: 0, max: 100}]"));
+
+    
+    // Export JSON object as a string for returning.
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0); 
+
+    json_decref(get_domain_obj);
 
     return 0;
 }

--- a/src/variorum/IBM/Power9.h
+++ b/src/variorum/IBM/Power9.h
@@ -20,8 +20,8 @@ int p9_cap_gpu_power_ratio(int gpu_power_ratio);
 
 int p9_monitoring(FILE *output);
 
-int p9_get_node_power_json(json_t *get_power_obj);
+int p9_get_node_power_json(char** get_power_obj_str);
 
-int p9_get_node_power_domain_info_json(json_t *get_domain_obj);
+int p9_get_node_power_domain_info_json(char** get_domain_obj_str);
 
 #endif

--- a/src/variorum/IBM/Power9.h
+++ b/src/variorum/IBM/Power9.h
@@ -20,8 +20,8 @@ int p9_cap_gpu_power_ratio(int gpu_power_ratio);
 
 int p9_monitoring(FILE *output);
 
-int p9_get_node_power_json(char** get_power_obj_str);
+int p9_get_node_power_json(char **get_power_obj_str);
 
-int p9_get_node_power_domain_info_json(char** get_domain_obj_str);
+int p9_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 #endif

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -424,7 +424,7 @@ int fm_06_4f_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_4f_get_node_power_json(char** get_power_obj_str)
+int fm_06_4f_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -438,11 +438,11 @@ int fm_06_4f_get_node_power_json(char** get_power_obj_str)
 
     *get_power_obj_str = json_dumps(get_power_obj, 0);
     json_decref(get_power_obj);
-    
+
     return 0;
 }
 
-int fm_06_4f_get_node_power_domain_info_json(char** get_domain_obj_str)
+int fm_06_4f_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);

--- a/src/variorum/Intel/Broadwell_4F.c
+++ b/src/variorum/Intel/Broadwell_4F.c
@@ -424,29 +424,38 @@ int fm_06_4f_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_4f_get_node_power_json(json_t *get_power_obj)
+int fm_06_4f_get_node_power_json(char** get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
+
+    json_t *get_power_obj = json_object();
 
     json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                         msrs.msr_dram_energy_status);
 
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
+    
     return 0;
 }
 
-int fm_06_4f_get_node_power_domain_info_json(json_t *get_domain_obj)
+int fm_06_4f_get_node_power_domain_info_json(char** get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
+    json_t *get_domain_obj = json_object();
+
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
                                msrs.msr_dram_power_info,
                                msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
+    json_decref(get_domain_obj);
     return 0;
 }
 

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -107,9 +107,9 @@ int fm_06_4f_poll_power(FILE *output);
 
 int fm_06_4f_monitoring(FILE *output);
 
-int fm_06_4f_get_node_power_json(json_t *get_power_obj);
+int fm_06_4f_get_node_power_json(char** get_power_obj_str);
 
-int fm_06_4f_get_node_power_domain_info_json(json_t *get_domain_obj);
+int fm_06_4f_get_node_power_domain_info_json(char** get_domain_obj_str);
 
 int fm_06_4f_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/Broadwell_4F.h
+++ b/src/variorum/Intel/Broadwell_4F.h
@@ -107,9 +107,9 @@ int fm_06_4f_poll_power(FILE *output);
 
 int fm_06_4f_monitoring(FILE *output);
 
-int fm_06_4f_get_node_power_json(char** get_power_obj_str);
+int fm_06_4f_get_node_power_json(char **get_power_obj_str);
 
-int fm_06_4f_get_node_power_domain_info_json(char** get_domain_obj_str);
+int fm_06_4f_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 int fm_06_4f_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -400,27 +400,37 @@ int fm_06_3f_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_3f_get_node_power_json(json_t *get_power_obj)
+int fm_06_3f_get_node_power_json(char** get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
+
+    json_t *get_power_obj = json_object();
 
     json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                         msrs.msr_dram_energy_status);
 
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
+
     return 0;
 }
 
-int fm_06_3f_get_node_power_domain_info_json(json_t *get_domain_obj)
+int fm_06_3f_get_node_power_domain_info_json(char** get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
+    json_t *get_domain_obj = json_object();  
+
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
                                msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
+
+     *get_domain_obj_str = json_dumps(get_domain_obj, 0);      
+     json_decref(get_domain_obj);   
 
     return 0;
 }

--- a/src/variorum/Intel/Haswell_3F.c
+++ b/src/variorum/Intel/Haswell_3F.c
@@ -400,7 +400,7 @@ int fm_06_3f_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_3f_get_node_power_json(char** get_power_obj_str)
+int fm_06_3f_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -418,19 +418,19 @@ int fm_06_3f_get_node_power_json(char** get_power_obj_str)
     return 0;
 }
 
-int fm_06_3f_get_node_power_domain_info_json(char** get_domain_obj_str)
+int fm_06_3f_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_t *get_domain_obj = json_object();  
+    json_t *get_domain_obj = json_object();
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
                                msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
-     *get_domain_obj_str = json_dumps(get_domain_obj, 0);      
-     json_decref(get_domain_obj);   
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
+    json_decref(get_domain_obj);
 
     return 0;
 }

--- a/src/variorum/Intel/Haswell_3F.h
+++ b/src/variorum/Intel/Haswell_3F.h
@@ -107,9 +107,9 @@ int fm_06_3f_poll_power(FILE *output);
 
 int fm_06_3f_monitoring(FILE *output);
 
-int fm_06_3f_get_node_power_json(json_t *get_power_obj);
+int fm_06_3f_get_node_power_json(char** get_power_obj_str);
 
-int fm_06_3f_get_node_power_domain_info_json(json_t *get_domain_obj);
+int fm_06_3f_get_node_power_domain_info_json(char** get_domain_obj_str);
 
 int fm_06_3f_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/Haswell_3F.h
+++ b/src/variorum/Intel/Haswell_3F.h
@@ -107,9 +107,9 @@ int fm_06_3f_poll_power(FILE *output);
 
 int fm_06_3f_monitoring(FILE *output);
 
-int fm_06_3f_get_node_power_json(char** get_power_obj_str);
+int fm_06_3f_get_node_power_json(char **get_power_obj_str);
 
-int fm_06_3f_get_node_power_domain_info_json(char** get_domain_obj_str);
+int fm_06_3f_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 int fm_06_3f_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/IceLake_6A.c
+++ b/src/variorum/Intel/IceLake_6A.c
@@ -115,3 +115,40 @@ int fm_06_6a_get_power(int long_ver)
     }
     return 0;
 }
+
+int fm_06_6a_get_node_power_json(char** get_power_obj_str)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_t *get_power_obj = json_object();
+
+    json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
+                        msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                        msrs.msr_dram_energy_status);
+
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
+
+    return 0;
+}
+
+int fm_06_6a_get_node_power_domain_info_json(char** get_domain_obj_str)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+
+    json_t *get_domain_obj = json_object();  
+
+    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit,
+                               msrs.msr_pkg_power_limit);
+
+     *get_domain_obj_str = json_dumps(get_domain_obj, 0);      
+     json_decref(get_domain_obj);   
+
+    return 0;
+}
+

--- a/src/variorum/Intel/IceLake_6A.c
+++ b/src/variorum/Intel/IceLake_6A.c
@@ -116,7 +116,7 @@ int fm_06_6a_get_power(int long_ver)
     return 0;
 }
 
-int fm_06_6a_get_node_power_json(char** get_power_obj_str)
+int fm_06_6a_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -134,20 +134,20 @@ int fm_06_6a_get_node_power_json(char** get_power_obj_str)
     return 0;
 }
 
-int fm_06_6a_get_node_power_domain_info_json(char** get_domain_obj_str)
+int fm_06_6a_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_t *get_domain_obj = json_object();  
+    json_t *get_domain_obj = json_object();
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
                                msrs.msr_dram_power_info, msrs.msr_rapl_power_unit,
                                msrs.msr_pkg_power_limit);
 
-     *get_domain_obj_str = json_dumps(get_domain_obj, 0);      
-     json_decref(get_domain_obj);   
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
+    json_decref(get_domain_obj);
 
     return 0;
 }

--- a/src/variorum/Intel/IceLake_6A.c
+++ b/src/variorum/Intel/IceLake_6A.c
@@ -22,6 +22,7 @@ static struct icelake_6a_offsets msrs =
     .msr_pkg_power_info           = 0x614,
     .msr_dram_power_limit         = 0x618,
     .msr_dram_energy_status       = 0x619,
+    .msr_dram_power_info          = 0x61C,
 };
 
 int fm_06_6a_get_power_limits(int long_ver)
@@ -94,6 +95,8 @@ int fm_06_6a_get_features(void)
             msrs.msr_dram_power_limit);
     fprintf(stdout, "msr_dram_energy_status       = 0x%lx\n",
             msrs.msr_dram_energy_status);
+    fprintf(stdout, "msr_dram_power_info          = 0x%lx\n",
+            msrs.msr_dram_power_info);
     return 0;
 }
 

--- a/src/variorum/Intel/IceLake_6A.h
+++ b/src/variorum/Intel/IceLake_6A.h
@@ -36,4 +36,8 @@ int fm_06_6a_get_power(int long_ver);
 
 int fm_06_6a_get_features(void);
 
+int fm_06_6a_get_node_power_json(char** get_power_obj_str);
+
+int fm_06_6a_get_node_power_domain_info_json(char** get_domain_obj_str);
+
 #endif

--- a/src/variorum/Intel/IceLake_6A.h
+++ b/src/variorum/Intel/IceLake_6A.h
@@ -36,8 +36,8 @@ int fm_06_6a_get_power(int long_ver);
 
 int fm_06_6a_get_features(void);
 
-int fm_06_6a_get_node_power_json(char** get_power_obj_str);
+int fm_06_6a_get_node_power_json(char **get_power_obj_str);
 
-int fm_06_6a_get_node_power_domain_info_json(char** get_domain_obj_str);
+int fm_06_6a_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 #endif

--- a/src/variorum/Intel/IceLake_6A.h
+++ b/src/variorum/Intel/IceLake_6A.h
@@ -28,6 +28,8 @@ struct icelake_6a_offsets
     off_t msr_dram_power_limit;
     /// @brief Address for DRAM_ENERGY_STATUS.
     off_t msr_dram_energy_status;
+    /// @brief Address for DRAM_POWER_INFO.
+    off_t msr_dram_power_info;
 };
 
 int fm_06_6a_get_power_limits(int long_ver);

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -414,7 +414,7 @@ int fm_06_3e_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_3e_get_node_power_json(char** get_power_obj_str)
+int fm_06_3e_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -432,20 +432,20 @@ int fm_06_3e_get_node_power_json(char** get_power_obj_str)
     return 0;
 }
 
-int fm_06_3e_get_node_power_domain_info_json(char** get_domain_obj_str)
+int fm_06_3e_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-     json_t *get_domain_obj = json_object(); 
+    json_t *get_domain_obj = json_object();
 
-     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, 
+    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit,
                                msrs.msr_pkg_power_limit);
 
-     *get_domain_obj_str = json_dumps(get_domain_obj, 0);   
-     json_decref(get_domain_obj);   
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
+    json_decref(get_domain_obj);
     return 0;
 }
 

--- a/src/variorum/Intel/IvyBridge_3E.c
+++ b/src/variorum/Intel/IvyBridge_3E.c
@@ -414,28 +414,38 @@ int fm_06_3e_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_3e_get_node_power_json(json_t *get_power_obj)
+int fm_06_3e_get_node_power_json(char** get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
+
+    json_t *get_power_obj = json_object();
 
     json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                         msrs.msr_dram_energy_status);
 
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
+
     return 0;
 }
 
-int fm_06_3e_get_node_power_domain_info_json(json_t *get_domain_obj)
+int fm_06_3e_get_node_power_domain_info_json(char** get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
+     json_t *get_domain_obj = json_object(); 
 
+     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, 
+                               msrs.msr_pkg_power_limit);
+
+     *get_domain_obj_str = json_dumps(get_domain_obj, 0);   
+     json_decref(get_domain_obj);   
     return 0;
 }
 

--- a/src/variorum/Intel/IvyBridge_3E.h
+++ b/src/variorum/Intel/IvyBridge_3E.h
@@ -105,9 +105,9 @@ int fm_06_3e_poll_power(FILE *output);
 
 int fm_06_3e_monitoring(FILE *output);
 
-int fm_06_3e_get_node_power_json(char** get_power_obj_str);
+int fm_06_3e_get_node_power_json(char **get_power_obj_str);
 
-int fm_06_3e_get_node_power_domain_info_json(char** get_domain_obj_str);
+int fm_06_3e_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 int fm_06_3e_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/IvyBridge_3E.h
+++ b/src/variorum/Intel/IvyBridge_3E.h
@@ -105,9 +105,9 @@ int fm_06_3e_poll_power(FILE *output);
 
 int fm_06_3e_monitoring(FILE *output);
 
-int fm_06_3e_get_node_power_json(json_t *get_power_obj);
+int fm_06_3e_get_node_power_json(char** get_power_obj_str);
 
-int fm_06_3e_get_node_power_domain_info_json(json_t *get_domain_obj);
+int fm_06_3e_get_node_power_domain_info_json(char** get_domain_obj_str);
 
 int fm_06_3e_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -352,7 +352,7 @@ int fm_06_9e_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_9e_get_node_power_json(char** get_power_obj_str)
+int fm_06_9e_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -370,7 +370,7 @@ int fm_06_9e_get_node_power_json(char** get_power_obj_str)
     return 0;
 }
 
-int fm_06_9e_get_node_power_domain_info_json(char** get_domain_obj_str)
+int fm_06_9e_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -379,11 +379,11 @@ int fm_06_9e_get_node_power_domain_info_json(char** get_domain_obj_str)
     json_t *get_domain_obj = json_object();
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, 
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit,
                                msrs.msr_pkg_power_limit);
 
-    *get_domain_obj_str = json_dumps(get_domain_obj, 0);  
-    json_decref(get_domain_obj); 
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
+    json_decref(get_domain_obj);
 
     return 0;
 }

--- a/src/variorum/Intel/KabyLake_9E.c
+++ b/src/variorum/Intel/KabyLake_9E.c
@@ -352,27 +352,38 @@ int fm_06_9e_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_9e_get_node_power_json(json_t *get_power_obj)
+int fm_06_9e_get_node_power_json(char** get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
+
+    json_t *get_power_obj = json_object();
 
     json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                         msrs.msr_dram_energy_status);
 
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
+
     return 0;
 }
 
-int fm_06_9e_get_node_power_domain_info_json(json_t *get_domain_obj)
+int fm_06_9e_get_node_power_domain_info_json(char** get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
+    json_t *get_domain_obj = json_object();
+
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, 
+                               msrs.msr_pkg_power_limit);
+
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);  
+    json_decref(get_domain_obj); 
 
     return 0;
 }

--- a/src/variorum/Intel/KabyLake_9E.h
+++ b/src/variorum/Intel/KabyLake_9E.h
@@ -101,9 +101,9 @@ int fm_06_9e_poll_power(FILE *output);
 
 int fm_06_9e_monitoring(FILE *output);
 
-int fm_06_9e_get_node_power_json(char** get_power_obj_str);
+int fm_06_9e_get_node_power_json(char **get_power_obj_str);
 
-int fm_06_9e_get_node_power_domain_info_json(char** get_domain_obj_str);
+int fm_06_9e_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 int fm_06_9e_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/KabyLake_9E.h
+++ b/src/variorum/Intel/KabyLake_9E.h
@@ -101,9 +101,9 @@ int fm_06_9e_poll_power(FILE *output);
 
 int fm_06_9e_monitoring(FILE *output);
 
-int fm_06_9e_get_node_power_json(json_t *get_power_obj);
+int fm_06_9e_get_node_power_json(char** get_power_obj_str);
 
-int fm_06_9e_get_node_power_domain_info_json(json_t *get_domain_obj);
+int fm_06_9e_get_node_power_domain_info_json(char** get_domain_obj_str);
 
 int fm_06_9e_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -382,7 +382,7 @@ int fm_06_2a_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_2a_get_node_power_json(char** get_power_obj_str)
+int fm_06_2a_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -395,12 +395,12 @@ int fm_06_2a_get_node_power_json(char** get_power_obj_str)
                         msrs.msr_dram_energy_status);
 
     *get_power_obj_str = json_dumps(get_power_obj, 0);
-    json_decref(get_power_obj); 
+    json_decref(get_power_obj);
 
     return 0;
 }
 
-int fm_06_2a_get_node_power_domain_info_json(char** get_domain_obj_str)
+int fm_06_2a_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -409,11 +409,11 @@ int fm_06_2a_get_node_power_domain_info_json(char** get_domain_obj_str)
     json_t *get_domain_obj = json_object();
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, 
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit,
                                msrs.msr_pkg_power_limit);
 
     *get_domain_obj_str = json_dumps(get_domain_obj, 0);
-    json_decref(get_domain_obj); 
+    json_decref(get_domain_obj);
 
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2A.c
+++ b/src/variorum/Intel/SandyBridge_2A.c
@@ -382,27 +382,38 @@ int fm_06_2a_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_2a_get_node_power_json(json_t *get_power_obj)
+int fm_06_2a_get_node_power_json(char** get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
+
+    json_t *get_power_obj = json_object();
 
     json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                         msrs.msr_dram_energy_status);
 
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj); 
+
     return 0;
 }
 
-int fm_06_2a_get_node_power_domain_info_json(json_t *get_domain_obj)
+int fm_06_2a_get_node_power_domain_info_json(char** get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
+    json_t *get_domain_obj = json_object();
+
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, 
+                               msrs.msr_pkg_power_limit);
+
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
+    json_decref(get_domain_obj); 
 
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2A.h
+++ b/src/variorum/Intel/SandyBridge_2A.h
@@ -102,9 +102,9 @@ int fm_06_2a_poll_power(FILE *output);
 
 int fm_06_2a_monitoring(FILE *output);
 
-int fm_06_2a_get_node_power_json(json_t *get_power_obj);
+int fm_06_2a_get_node_power_json(char** get_power_obj_str);
 
-int fm_06_2a_get_node_power_domain_info_json(json_t *get_domain_obj);
+int fm_06_2a_get_node_power_domain_info_json(char** get_domain_obj_str);
 
 int fm_06_2a_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/SandyBridge_2A.h
+++ b/src/variorum/Intel/SandyBridge_2A.h
@@ -102,9 +102,9 @@ int fm_06_2a_poll_power(FILE *output);
 
 int fm_06_2a_monitoring(FILE *output);
 
-int fm_06_2a_get_node_power_json(char** get_power_obj_str);
+int fm_06_2a_get_node_power_json(char **get_power_obj_str);
 
-int fm_06_2a_get_node_power_domain_info_json(char** get_domain_obj_str);
+int fm_06_2a_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 int fm_06_2a_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -385,27 +385,38 @@ int fm_06_2d_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_2d_get_node_power_json(json_t *get_power_obj)
+int fm_06_2d_get_node_power_json(char** get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
+
+    json_t *get_power_obj = json_object();
 
     json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                         msrs.msr_dram_energy_status);
+  
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
 
     return 0;
 }
 
-int fm_06_2d_get_node_power_domain_info_json(json_t *get_domain_obj)
+int fm_06_2d_get_node_power_domain_info_json(char** get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
+    json_t *get_domain_obj = json_object(); 
+
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, 
+                               msrs.msr_pkg_power_limit);
+
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0); 
+    json_decref(get_domain_obj);
 
     return 0;
 }

--- a/src/variorum/Intel/SandyBridge_2D.c
+++ b/src/variorum/Intel/SandyBridge_2D.c
@@ -385,7 +385,7 @@ int fm_06_2d_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_2d_get_node_power_json(char** get_power_obj_str)
+int fm_06_2d_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -396,26 +396,26 @@ int fm_06_2d_get_node_power_json(char** get_power_obj_str)
     json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                         msrs.msr_dram_energy_status);
-  
+
     *get_power_obj_str = json_dumps(get_power_obj, 0);
     json_decref(get_power_obj);
 
     return 0;
 }
 
-int fm_06_2d_get_node_power_domain_info_json(char** get_domain_obj_str)
+int fm_06_2d_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
-    json_t *get_domain_obj = json_object(); 
+    json_t *get_domain_obj = json_object();
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, 
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit,
                                msrs.msr_pkg_power_limit);
 
-    *get_domain_obj_str = json_dumps(get_domain_obj, 0); 
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
     json_decref(get_domain_obj);
 
     return 0;

--- a/src/variorum/Intel/SandyBridge_2D.h
+++ b/src/variorum/Intel/SandyBridge_2D.h
@@ -104,9 +104,9 @@ int fm_06_2d_poll_power(FILE *output);
 
 int fm_06_2d_monitoring(FILE *output);
 
-int fm_06_2d_get_node_power_json(char** get_power_obj_str);
+int fm_06_2d_get_node_power_json(char **get_power_obj_str);
 
-int fm_06_2d_get_node_power_domain_info_json(char** get_domain_obj_str);
+int fm_06_2d_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 int fm_06_2d_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/SandyBridge_2D.h
+++ b/src/variorum/Intel/SandyBridge_2D.h
@@ -104,9 +104,9 @@ int fm_06_2d_poll_power(FILE *output);
 
 int fm_06_2d_monitoring(FILE *output);
 
-int fm_06_2d_get_node_power_json(json_t *get_power_obj);
+int fm_06_2d_get_node_power_json(char** get_power_obj_str);
 
-int fm_06_2d_get_node_power_domain_info_json(json_t *get_domain_obj);
+int fm_06_2d_get_node_power_domain_info_json(char** get_domain_obj_str);
 
 int fm_06_2d_cap_best_effort_node_power_limit(int node_power_limit);
 

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -350,7 +350,7 @@ int fm_06_55_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_55_get_node_power_json(char **get_power_obj_str)
+int fm_06_55_get_node_power_json(char** get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -368,7 +368,7 @@ int fm_06_55_get_node_power_json(char **get_power_obj_str)
     return 0;
 }
 
-int fm_06_55_get_node_power_domain_info_json(char **get_domain_obj_str)
+int fm_06_55_get_node_power_domain_info_json(char** get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -377,7 +377,8 @@ int fm_06_55_get_node_power_domain_info_json(char **get_domain_obj_str)
     json_t *get_domain_obj = json_object();
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, 
+                               msrs.msr_pkg_power_limit);
 
     *get_domain_obj_str = json_dumps(get_domain_obj, 0);
     json_decref(get_domain_obj);

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -350,15 +350,20 @@ int fm_06_55_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_55_get_node_power_json(json_t *get_power_obj)
+int fm_06_55_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
 #endif
 
+    json_t *get_power_obj = json_object();
+
     json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
                         msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
                         msrs.msr_dram_energy_status);
+
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json - decref(get_power_obj);
 
     return 0;
 }
@@ -369,8 +374,13 @@ int fm_06_55_get_node_power_domain_info_json(json_t *get_domain_obj)
     printf("Running %s\n", __FUNCTION__);
 #endif
 
+    json_t *get_domain_obj = json_object();
+
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
                                msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
+
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
+    json - decref(get_domain_obj);
 
     return 0;
 }

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -363,12 +363,12 @@ int fm_06_55_get_node_power_json(char **get_power_obj_str)
                         msrs.msr_dram_energy_status);
 
     *get_power_obj_str = json_dumps(get_power_obj, 0);
-    json - decref(get_power_obj);
+    json_decref(get_power_obj);
 
     return 0;
 }
 
-int fm_06_55_get_node_power_domain_info_json(json_t *get_domain_obj)
+int fm_06_55_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -380,7 +380,7 @@ int fm_06_55_get_node_power_domain_info_json(json_t *get_domain_obj)
                                msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, msrs.msr_pkg_power_limit);
 
     *get_domain_obj_str = json_dumps(get_domain_obj, 0);
-    json - decref(get_domain_obj);
+    json_decref(get_domain_obj);
 
     return 0;
 }

--- a/src/variorum/Intel/Skylake_55.c
+++ b/src/variorum/Intel/Skylake_55.c
@@ -350,7 +350,7 @@ int fm_06_55_monitoring(FILE *output)
     return 0;
 }
 
-int fm_06_55_get_node_power_json(char** get_power_obj_str)
+int fm_06_55_get_node_power_json(char **get_power_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -368,7 +368,7 @@ int fm_06_55_get_node_power_json(char** get_power_obj_str)
     return 0;
 }
 
-int fm_06_55_get_node_power_domain_info_json(char** get_domain_obj_str)
+int fm_06_55_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
 #ifdef VARIORUM_LOG
     printf("Running %s\n", __FUNCTION__);
@@ -377,7 +377,7 @@ int fm_06_55_get_node_power_domain_info_json(char** get_domain_obj_str)
     json_t *get_domain_obj = json_object();
 
     json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
-                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit, 
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit,
                                msrs.msr_pkg_power_limit);
 
     *get_domain_obj_str = json_dumps(get_domain_obj, 0);

--- a/src/variorum/Intel/Skylake_55.h
+++ b/src/variorum/Intel/Skylake_55.h
@@ -101,11 +101,11 @@ int fm_06_55_poll_power(FILE *output);
 
 int fm_06_55_monitoring(FILE *output);
 
-int fm_06_55_get_node_power_json(json_t *get_power_obj);
+int fm_06_55_get_node_power_json(char **get_power_obj_str);
 
 int fm_06_55_cap_best_effort_node_power_limit(int node_power_limit);
 
-int fm_06_55_get_node_power_domain_info_json(json_t *get_domain_obj);
+int fm_06_55_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 int fm_06_55_cap_frequency(int core_freq_mhz);
 

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -7,7 +7,6 @@
 #define CONFIG_ARCHIECTURE_H_INCLUDE
 
 #include <stdint.h>
-#include <jansson.h>
 
 #include <variorum_config.h>
 
@@ -196,12 +195,12 @@ struct platform
     /// @brief Function pointer to get JSON object for node power data.
     ///
     /// @return Error code.
-    int (*variorum_get_node_power_json)(json_t *get_power_obj);
+    int (*variorum_get_node_power_json)(char** get_power_obj_str);
 
     /// @brief Function pointer to get JSON object for power domain information.
     ///
     /// @return Error code.
-    int (*variorum_get_node_power_domain_info_json)(json_t *get_domain_obj);
+    int (*variorum_get_node_power_domain_info_json)(char** get_domain_obj_str);
 
     /// @brief Function pointer to get list of available frequencies.
     ///

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -195,12 +195,12 @@ struct platform
     /// @brief Function pointer to get JSON object for node power data.
     ///
     /// @return Error code.
-    int (*variorum_get_node_power_json)(char** get_power_obj_str);
+    int (*variorum_get_node_power_json)(char **get_power_obj_str);
 
     /// @brief Function pointer to get JSON object for power domain information.
     ///
     /// @return Error code.
-    int (*variorum_get_node_power_domain_info_json)(char** get_domain_obj_str);
+    int (*variorum_get_node_power_domain_info_json)(char **get_domain_obj_str);
 
     /// @brief Function pointer to get list of available frequencies.
     ///

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -989,7 +989,7 @@ int variorum_disable_turbo(void)
     return err;
 }
 
-int variorum_get_node_power_json(char** get_power_obj_str)
+int variorum_get_node_power_json(char **get_power_obj_str)
 {
     int err = 0;
 #ifdef VARIORUM_LOG
@@ -1011,7 +1011,7 @@ int variorum_get_node_power_json(char** get_power_obj_str)
     }
 
     err = g_platform.variorum_get_node_power_json(get_power_obj_str);
-    
+
     if (err)
     {
         return -1;
@@ -1028,7 +1028,7 @@ int variorum_get_node_power_json(char** get_power_obj_str)
     return err;
 }
 
-int variorum_get_node_power_domain_info_json(char** get_domain_obj_str)
+int variorum_get_node_power_domain_info_json(char **get_domain_obj_str)
 {
     int err = 0;
 #ifdef VARIORUM_LOG

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1007,7 +1007,9 @@ int variorum_get_node_power_json(char **get_power_obj_str)
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
                                getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
-        return 0;
+        // For the JSON functions, we return a -1 here, so users don't need
+        // to explicitly check for NULL strings.
+        return -1;
 
     }
 
@@ -1047,7 +1049,9 @@ int variorum_get_node_power_domain_info_json(char **get_domain_obj_str)
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
                                getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
-        return 0;
+        // For the JSON functions, we return a -1 here, so users don't need
+        // to explicitly check for NULL strings.
+        return -1;
     }
     err = g_platform.variorum_get_node_power_domain_info_json(get_domain_obj_str);
     if (err)

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1007,7 +1007,8 @@ int variorum_get_node_power_json(char **get_power_obj_str)
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
                                getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
-        return -1;
+        return 0;
+
     }
 
     err = g_platform.variorum_get_node_power_json(get_power_obj_str);

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -989,7 +989,7 @@ int variorum_disable_turbo(void)
     return err;
 }
 
-int variorum_get_node_power_json(json_t *get_power_obj)
+int variorum_get_node_power_json(char** get_power_obj_str)
 {
     int err = 0;
 #ifdef VARIORUM_LOG
@@ -1007,9 +1007,11 @@ int variorum_get_node_power_json(json_t *get_power_obj)
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
                                getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
-        return 0;
+        return -1;
     }
-    err = g_platform.variorum_get_node_power_json(get_power_obj);
+
+    err = g_platform.variorum_get_node_power_json(get_power_obj_str);
+    
     if (err)
     {
         return -1;
@@ -1026,7 +1028,7 @@ int variorum_get_node_power_json(json_t *get_power_obj)
     return err;
 }
 
-int variorum_get_node_power_domain_info_json(json_t *get_domain_obj)
+int variorum_get_node_power_domain_info_json(char** get_domain_obj_str)
 {
     int err = 0;
 #ifdef VARIORUM_LOG
@@ -1046,7 +1048,7 @@ int variorum_get_node_power_domain_info_json(json_t *get_domain_obj)
                                __FUNCTION__, __LINE__);
         return 0;
     }
-    err = g_platform.variorum_get_node_power_domain_info_json(get_domain_obj);
+    err = g_platform.variorum_get_node_power_domain_info_json(get_domain_obj_str);
     if (err)
     {
         return -1;

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -7,7 +7,6 @@
 #define VARIORUM_H_INCLUDE
 
 #include <stdio.h>
-#include <jansson.h>
 
 /// @brief Collect power limits and energy usage for both the package and DRAM
 /// domains.
@@ -443,7 +442,8 @@ int variorum_disable_turbo(void);
 /****************/
 /* JSON Support */
 /****************/
-/// @brief Populate json_t object parameter with total node power.
+/// @brief Populate a string in JSON format with total node power, socket-level,
+/// memory-level and GPU-level power.
 ///
 /// @supparch
 /// - AMD EPYC Milan
@@ -456,13 +456,15 @@ int variorum_disable_turbo(void);
 /// - Intel Skylake
 /// - Intel Kaby Lake
 ///
-/// @param [out] get_power_obj JSON object storing power info.
+/// @param [out] output String (passed by reference) that contains the node-level
+/// power information.
 ///
 /// @return 0 if successful or if feature has not been implemented or is
 /// not supported, otherwise -1
-int variorum_get_node_power_json(json_t *get_power_obj);
+int variorum_get_node_power_json(char** get_power_obj_str);
 
-/// @brief Populate json_t object parameter with measurable power domains.
+/// @brief Populate a string in JSON format with measurable and controllable 
+/// power domains, along with the ranges.
 ///
 /// @supparch
 /// - AMD EPYC Milan
@@ -475,11 +477,12 @@ int variorum_get_node_power_json(json_t *get_power_obj);
 /// - Intel Skylake
 /// - Intel Kaby Lake
 ///
-/// @param [out] get_domain_obj JSON object storing domain-level info.
+/// @param [out] output String (passed by reference) that contains the node-level
+/// domain information.
 ///
 /// @return 0 if successful or if feature has not been implemented or is
 /// not supported, otherwise -1
-int variorum_get_node_power_domain_info_json(json_t *get_domain_obj);
+int variorum_get_node_power_domain_info_json(char** get_domain_obj_str);
 
 /***********/
 /* Testing */

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -461,7 +461,7 @@ int variorum_disable_turbo(void);
 ///
 /// @return 0 if successful, otherwise -1. Note that feature not implemented
 /// returns a -1 for the JSON APIs so that users don't have to explicitly
-/// check for NULL strings. 
+/// check for NULL strings.
 int variorum_get_node_power_json(char **get_power_obj_str);
 
 /// @brief Populate a string in JSON format with measurable and controllable
@@ -483,7 +483,7 @@ int variorum_get_node_power_json(char **get_power_obj_str);
 ///
 /// @return 0 if successful, otherwise -1. Note that feature not implemented
 /// returns a -1 for the JSON APIs so that users don't have to explicitly
-/// check for NULL strings. 
+/// check for NULL strings.
 int variorum_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 /***********/

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -461,9 +461,9 @@ int variorum_disable_turbo(void);
 ///
 /// @return 0 if successful or if feature has not been implemented or is
 /// not supported, otherwise -1
-int variorum_get_node_power_json(char** get_power_obj_str);
+int variorum_get_node_power_json(char **get_power_obj_str);
 
-/// @brief Populate a string in JSON format with measurable and controllable 
+/// @brief Populate a string in JSON format with measurable and controllable
 /// power domains, along with the ranges.
 ///
 /// @supparch
@@ -482,7 +482,7 @@ int variorum_get_node_power_json(char** get_power_obj_str);
 ///
 /// @return 0 if successful or if feature has not been implemented or is
 /// not supported, otherwise -1
-int variorum_get_node_power_domain_info_json(char** get_domain_obj_str);
+int variorum_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 /***********/
 /* Testing */

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -459,8 +459,9 @@ int variorum_disable_turbo(void);
 /// @param [out] output String (passed by reference) that contains the node-level
 /// power information.
 ///
-/// @return 0 if successful or if feature has not been implemented or is
-/// not supported, otherwise -1
+/// @return 0 if successful, otherwise -1. Note that feature not implemented
+/// returns a -1 for the JSON APIs so that users don't have to explicitly
+/// check for NULL strings. 
 int variorum_get_node_power_json(char **get_power_obj_str);
 
 /// @brief Populate a string in JSON format with measurable and controllable
@@ -480,8 +481,9 @@ int variorum_get_node_power_json(char **get_power_obj_str);
 /// @param [out] output String (passed by reference) that contains the node-level
 /// domain information.
 ///
-/// @return 0 if successful or if feature has not been implemented or is
-/// not supported, otherwise -1
+/// @return 0 if successful, otherwise -1. Note that feature not implemented
+/// returns a -1 for the JSON APIs so that users don't have to explicitly
+/// check for NULL strings. 
 int variorum_get_node_power_domain_info_json(char **get_domain_obj_str);
 
 /***********/


### PR DESCRIPTION
# Description

Changes existing JSON APIs to use `char**` as parameter input as opposed to the `json_t*` input, to remove jansson dependencies externally and allow for easy wrap arounds. 

Fixes #277, needed in support of #265 and #222 . 

## Type of change

~~- [ ] Bug fix (non-breaking change which fixes an issue)~~
- [x] New feature (non-breaking change which adds functionality)

~~- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- [x] Documentation update

# Implementation ToDo

- [x] IBM Power9
- [x] AMD Milan
- [x] ARM Juno r2
- [x] Intel SandyBridge (2A)
- [x] Intel SandyBridge (2D)
- [x] Intel Ivy Bridge
- [x] Intel Haswell
- [x] Intel Broadwell
- [x] Intel Skylake
- [x] Intel Kaby Lake
- [x] Intel Ice Lake
- [x] Fix error when returning with Lassen GPU build. Null string should not get printed.

# Examples ToDo

- [x] Add example for `get_node_power_json` with new API
- [x] Add example for `get_node_power_domain_info_json` with new API
- [x] Add example for parsing string with JSON content to obtain field values using Jansson (C) 
- [x] Update parsing example to include a `SECOND_RUN` to better support Intel values
- [x] Check 150 vs 180 char mallocs in example

# Testing ToDo

- [x] Lassen with CPU only build
- [x] Lassen with GPU build
- [x] Alehouse : IBM Power9 
- [x] Juno: ARM Juno r2
- [x] Thompson: Intel Haswell
- [x] Comus: Intel Broadwell
- [x] Rhetoric: Intel Skylake

# Documentation ToDo

- [x] Update get_node_power_json docs
- [x] Update get_node_power_domain_info docs
- [x] Update Integrating with Variorum docs
- [x] Add note about deltas on Intel systems

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass with my changes

    