### PR TITLE
Move m_hostname and m_num_package to .c from .h

### DIFF
--- a/src/variorum/ARM/power_features.c
+++ b/src/variorum/ARM/power_features.c
@@ -18,6 +18,9 @@
 #include <variorum_error.h>
 #include <variorum_timers.h>
 
+unsigned m_num_package;
+char m_hostname[1024];
+
 int read_file_ui64(const int file, uint64_t *val)
 {
     char buf[32];

--- a/src/variorum/ARM/power_features.h
+++ b/src/variorum/ARM/power_features.h
@@ -10,8 +10,8 @@
 #include <stdio.h>
 #include <jansson.h>
 
-unsigned m_num_package;
-char m_hostname[1024];
+extern unsigned m_num_package;
+extern char m_hostname[1024];
 
 void init_arm(void);
 


### PR DESCRIPTION
# Description

The ARM backend was failing to compile because of multiple definitions of `m_hostname` and `m_num_package` (similar to #216).

Fixes #276

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This was tested in the [OCaml-CI](https://github.com/ocurrent/ocaml-ci) infrastructure which includes ARM machines. Note the logs from the builds will eventually disappear, they have been preserved in [this gist](https://gist.github.com/patricoferris/ccd0e78945cb466a8b7eca9e92f8d221).

 - Before: https://github.com/patricoferris/ocaml-variorum/runs/7119215341
 - After: https://github.com/patricoferris/ocaml-variorum/runs/7119762194

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code follows the style guidelines of variorum
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass with my changes

