### PR TITLE
Format RST files and add CI check

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -396,7 +396,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          python -m pip install --upgrade pip flake8
+          python -m pip install --upgrade pip flake8 rstfmt
 
       - name: Update Black
         run: |
@@ -408,6 +408,13 @@ jobs:
           flake8
           # specify excluded dirs on command line
           black --diff --check --exclude "/(src/thirdparty_builtin/googletest|build|src/docs)/" .
+
+      - name: Style check docs files
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          ./scripts/.ci-check-rst-format.sh
+          err=$?
+          if [ $err -eq 0 ]; then exit 0; else echo -e "Formatting issue found in RST files. Please run ./scripts/check-rst-format.sh."; exit 1; fi
 
   build-with-spack-mirrors:
     runs-on: ubuntu-latest

--- a/scripts/.ci-check-rst-format.sh
+++ b/scripts/.ci-check-rst-format.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+# Variorum Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+TMP=$(./scripts/check-rst-format.sh)
+
+RES=$(git ls-files -m)
+
+echo -e "$RES"
+
+if [ -z "$RES" ]; then
+    exit 0
+else
+    exit 1
+fi
+
+#

--- a/scripts/check-rst-format.sh
+++ b/scripts/check-rst-format.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+# Variorum Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+# re-format all *.rst files in src/docs directory
+FILES=$(find src -type f  \( -name *.rst \))
+
+rstfmt -w 80 ${FILES}
+
+#

--- a/src/docs/sphinx/AMD.rst
+++ b/src/docs/sphinx/AMD.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -7,65 +8,62 @@
  AMD Overview
 ##############
 
-AMD platforms support in-band monitoring and control through sensors and 
-machine-specific registers. AMD provides and open-source stack of its drivers
-as well as its in-band library that Variorum leverages.
+AMD platforms support in-band monitoring and control through sensors and
+machine-specific registers. AMD provides and open-source stack of its drivers as
+well as its in-band library that Variorum leverages.
 
-************
-Requirements
-************
+**************
+ Requirements
+**************
 
-Beginning with Variorum 0.5.0, AMD processors
-from the AMD EPYC Milan family 19h, models 0-Fh and 30h-3Fh are supported.
-This functionality has been tested on Linux distributions SLES15 and Ubuntu 18.04.
-This version of depends on the AMD open-sourced software stack components
-listed below:
+Beginning with Variorum 0.5.0, AMD processors from the AMD EPYC Milan family
+19h, models 0-Fh and 30h-3Fh are supported. This functionality has been tested
+on Linux distributions SLES15 and Ubuntu 18.04. This version of depends on the
+AMD open-sourced software stack components listed below:
 
-1. EPYC™ System Management Interface In-band Library (E-SMI library) available at
-   https://github.com/amd/esmi_ib_library
+#. EPYC™ System Management Interface In-band Library (E-SMI library) available
+   at https://github.com/amd/esmi_ib_library
+#. AMD Energy Driver https://github.com/amd/amd_energy
+#. HSMP driver for power metrics https://github.com/amd/amd_hsmp
 
-2. AMD Energy Driver
-   https://github.com/amd/amd_energy
+The E-SMI library provides the C API for user space application of the AMD
+Energy Driver and the AMD HSMP modules.
 
-3. HSMP driver for power metrics
-   https://github.com/amd/amd_hsmp
+The AMD Energy Driver is an out-of-tree kernel module that allows for core and
+socket energy counter access through MSRs and RAPL via ``hwmon`` sys entries.
+These registers are updated every millisecond and cleared on reset of the
+system. Some registers of interest include:
 
-The E-SMI library provides the C API for user space application
-of the AMD Energy Driver and the AMD HSMP modules.
+-  Power, Energy and Time Units
+      -  ``MSR_RAPL_POWER_UNIT/ C001_0299``: shared with all cores in the socket
 
-The AMD Energy Driver is an out-of-tree kernel module that allows for
-core and socket energy counter access through MSRs and RAPL via ``hwmon`` sys entries.
-These registers are updated every millisecond and cleared on reset of the system.
-Some registers of interest include:
+-  Energy consumed by each core
+      -  ``MSR_CORE_ENERGY_STATUS/ C001_029A``: 32-bitRO, Accumulator,
+         core-level power reporting
 
-* Power, Energy and Time Units
-    - ``MSR_RAPL_POWER_UNIT/ C001_0299``: shared with all cores in the socket
-
-* Energy consumed by each core
-    - ``MSR_CORE_ENERGY_STATUS/ C001_029A``: 32-bitRO, Accumulator, core-level power reporting
-
-* Energy consumed by Socket
-    - ``MSR_PACKAGE_ENERGY_STATUS/ C001_029B``: 32-bitRO, Accumulator, socket-level power reporting, shared with all cores in socket
+-  Energy consumed by Socket
+      -  ``MSR_PACKAGE_ENERGY_STATUS/ C001_029B``: 32-bitRO, Accumulator,
+         socket-level power reporting, shared with all cores in socket
 
 The Host System Management Port (HSMP) kernel module allows for *setting* of
 power caps, boostlimits and PCIe access. It provides user level access to the
 HSMP mailboxes implemented by the firmware in the System Management Unit (SMU).
 AMD Power Control Knobs are exposed through HSMP via sysfs.
 
-* ``amd_hsmp/cpuX/``: Directory for each possible CPU
-    - ``boost_limit`` (RW): HSMP boost limit for the core in MHz
+-  ``amd_hsmp/cpuX/``: Directory for each possible CPU
+      -  ``boost_limit`` (RW): HSMP boost limit for the core in MHz
 
-* ``amd_hsmp/socketX/``:  Directory for each possible socket
-    - ``boost_limit`` (WO): Set HSMP boost limit for the socket in MHz
-    - ``c0_residency`` (RO): Average % all cores are in C0 state
-    - ``cclk_limit`` (RO): Most restrictive core clock (CCLK) limit in MHz
-    - ``fabric_clocks`` (RO): Data fabric (FCLK) and memory (MCLK) in MHz
-    - ``fabric_pstate`` (WO): Set data fabric P-state, -1 for autonomous
-    - ``power`` (RO): Average socket power in milliwatts
-    - ``power_limit`` (RW): Socket power limit in milliwatts
-    - ``power_limit_max`` (RO): Maximum possible value for power limit in mW
-    - ``proc_hot`` (RO): Socket PROC_HOT status (1 = active, 0 = inactive)
-    - ``tctl`` (RO): Thermal Control value (not temperature)
+-  ``amd_hsmp/socketX/``: Directory for each possible socket
+      -  ``boost_limit`` (WO): Set HSMP boost limit for the socket in MHz
+      -  ``c0_residency`` (RO): Average % all cores are in C0 state
+      -  ``cclk_limit`` (RO): Most restrictive core clock (CCLK) limit in MHz
+      -  ``fabric_clocks`` (RO): Data fabric (FCLK) and memory (MCLK) in MHz
+      -  ``fabric_pstate`` (WO): Set data fabric P-state, -1 for autonomous
+      -  ``power`` (RO): Average socket power in milliwatts
+      -  ``power_limit`` (RW): Socket power limit in milliwatts
+      -  ``power_limit_max`` (RO): Maximum possible value for power limit in mW
+      -  ``proc_hot`` (RO): Socket PROC_HOT status (1 = active, 0 = inactive)
+      -  ``tctl`` (RO): Thermal Control value (not temperature)
 
 We expect a similar software stack to be available on the upcoming El Capitan
 supercomputer at Lawrence Livermore National Laboratory.
@@ -80,31 +78,32 @@ information. These E-SMI APIs are described below.
 The built-in monitoring interface on the AMD EPYC™ processors is implemented by
 the SMU FW. All registers are updated every 1 millisecond.
 
-
 Power telemetry
-=================
+===============
 
-* ``esmi_socket_power_get()``: Instantaneous power is reported in milliwatts
-
-* ``esmi_socket_power_cap_get()`` and ``esmi_socket_power_cap_set()``: Get and Set power limit of the socket in milliwatts
-
-* ``esmi_socket_power_cap_max_get()``: Maximum Power limit of the socket in milliwatts
+-  ``esmi_socket_power_get()``: Instantaneous power is reported in milliwatts
+-  ``esmi_socket_power_cap_get()`` and ``esmi_socket_power_cap_set()``: Get and
+   Set power limit of the socket in milliwatts
+-  ``esmi_socket_power_cap_max_get()``: Maximum Power limit of the socket in
+   milliwatts
 
 Boostlimit telemetry
-======================
+====================
 
 Boostlimit is a maximum frequency a CPU can run at.
 
-* ``esmi_core_boostlimit_get()`` and ``esmi_core_boostlimit_set()``: Get and set the current boostlimit for a given core
-
-* ``esmi_socket_boostlimit_set()``: Set boostlimit for all the cores in the socket
+-  ``esmi_core_boostlimit_get()`` and ``esmi_core_boostlimit_set()``: Get and
+   set the current boostlimit for a given core
+-  ``esmi_socket_boostlimit_set()``: Set boostlimit for all the cores in the
+   socket
 
 Energy telemetry
-==================
+================
 
-* ``esmi_socket_energy_get()``: Get software accumulated 64-bit energy counter for a given socket
-
-* ``esmi_core_energy_get()``: Get software accumulated 64-bit energy counter for a given core
+-  ``esmi_socket_energy_get()``: Get software accumulated 64-bit energy counter
+   for a given socket
+-  ``esmi_core_energy_get()``: Get software accumulated 64-bit energy counter
+   for a given core
 
 ************
  References

--- a/src/docs/sphinx/ARM.rst
+++ b/src/docs/sphinx/ARM.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -9,13 +10,13 @@
 
 This implementation of the ARM port of Variorum supports the Arm Juno r2 SoC.
 The Arm Juno r2 platform is a big.LITTLE cluster with Cortex-A72 (big) and
-Cortex-A53 (LITTLE) clusters (also called processors), respectively. It also
-has an Arm Mali GP-GPU. We have tested the ARM functionality of Variorum on
-Linaro supported Linux.
+Cortex-A53 (LITTLE) clusters (also called processors), respectively. It also has
+an Arm Mali GP-GPU. We have tested the ARM functionality of Variorum on Linaro
+supported Linux.
 
-************
-Requirements
-************
+**************
+ Requirements
+**************
 
 This version of the ARM port of Variorum depends on the Linux Hardware
 Monitoring (hwmon) subsystem for access to the telemetry and control interfaces
@@ -26,11 +27,11 @@ hwmon framework enable a generic ARM implementation of Variorum.
  Monitoring and Control Through Sysfs Interface
 ************************************************
 
-The built-in monitoring interface on the Arm Juno r2 board is implemented by
-the on-board FPGA. Since this interface is not universally available on most
-Arm implementations, we leverage the standard Linux sysfs interface for
-monitoring and control. The following subsections provide the specific metrics
-that are monitored on Arm Juno r2:
+The built-in monitoring interface on the Arm Juno r2 board is implemented by the
+on-board FPGA. Since this interface is not universally available on most Arm
+implementations, we leverage the standard Linux sysfs interface for monitoring
+and control. The following subsections provide the specific metrics that are
+monitored on Arm Juno r2:
 
 Power telemetry
 ===============
@@ -76,8 +77,8 @@ cluster.
       ``/sys/devices/system/cpu/cpufreq/policy1/scaling_cur_freq``
 
 Frequencies are reported by the sysfs interface in KHz. Variorum reports the
-clocks in MHz to keep it consistent with the clocks reported for other
-supported architectures.
+clocks in MHz to keep it consistent with the clocks reported for other supported
+architectures.
 
 Frequency control
 =================
@@ -95,9 +96,8 @@ frequency as input in MHz and performs this conversion internally.
 If you run into an error accessing the sysfs interface, this could be due to an
 the specified frequency value or the set governor. The sysfs interface only
 accepts valid values for frequencies as output by
-``policy*/scaling_available_frequencies``. Also, the specified frequency is
-only applied when the governor in ``policy*/scaling_governor`` is set to
-`userspace`.
+``policy*/scaling_available_frequencies``. Also, the specified frequency is only
+applied when the governor in ``policy*/scaling_governor`` is set to `userspace`.
 
 ************
  References
@@ -105,9 +105,9 @@ only applied when the governor in ``policy*/scaling_governor`` is set to
 
 -  `Arm Juno r2 technical reference
    <https://developer.arm.com/documentation/100114/0200/>`_
-- `hwmon sysfs interface
-  <https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface>`_
-- `hwmon documentation
-  <http://blog.foool.net/wp-content/uploads/linuxdocs/hwmon.pdf>`_
-- `Energy Monitoring on Juno
-  <https://community.arm.com/developer/tools-software/oss-platforms/w/docs/482/energy-monitoring-on-juno>`_
+-  `hwmon sysfs interface
+   <https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface>`_
+-  `hwmon documentation
+   <http://blog.foool.net/wp-content/uploads/linuxdocs/hwmon.pdf>`_
+-  `Energy Monitoring on Juno
+   <https://community.arm.com/developer/tools-software/oss-platforms/w/docs/482/energy-monitoring-on-juno>`_

--- a/src/docs/sphinx/Argo.rst
+++ b/src/docs/sphinx/Argo.rst
@@ -1,47 +1,49 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
 
-################
-ECP Argo Project
-################
+##################
+ ECP Argo Project
+##################
 
-Argo is a collaborative project between Argonne National Laboratory and 
-Lawrence Livermore National Laboratory. It is funded by the U.S. Department of 
-Energy as part of the Exascale Computing Project (ECP).The goal of the Argo project 
-is to augment and optimize existing Operating Systems/Runtime components for use 
-in production HPC systems, providing portable, open source, integrated software 
-that improves the performance and scalability of and that offers increased 
-functionality to exascale applications and runtime systems. Argo software is 
-developed as a toolbox -- a collection of autonomous components that can be 
-freely mixed and matched to best meet the user's needs. The project has four focus areas:
+Argo is a collaborative project between Argonne National Laboratory and Lawrence
+Livermore National Laboratory. It is funded by the U.S. Department of Energy as
+part of the Exascale Computing Project (ECP).The goal of the Argo project is to
+augment and optimize existing Operating Systems/Runtime components for use in
+production HPC systems, providing portable, open source, integrated software
+that improves the performance and scalability of and that offers increased
+functionality to exascale applications and runtime systems. Argo software is
+developed as a toolbox -- a collection of autonomous components that can be
+freely mixed and matched to best meet the user's needs. The project has four
+focus areas:
 
-    - Memory management
-    - Power management
-    - Resource management
-    - Hardware co-design
+   -  Memory management
+   -  Power management
+   -  Resource management
+   -  Hardware co-design
 
 Variorum is a key player for the `power management` and `hardware co-design`
-focus areas for Argo. Details about the broader Argo project, along with relevant
-source code, publications, and accomplishments can be found on the
-Argo website (https://web.cels.anl.gov/projects/argo/). The Argo project is also
-a key contributor to the :doc:`PowerStack`, which is a community effort for
-power management. 
+focus areas for Argo. Details about the broader Argo project, along with
+relevant source code, publications, and accomplishments can be found on the Argo
+website (https://web.cels.anl.gov/projects/argo/). The Argo project is also a
+key contributor to the :doc:`PowerStack`, which is a community effort for power
+management.
 
-`Dynamic power management` is expected to be critical in the 
-exascale era, both in terms of not exceeding the overall available power budget 
-and in terms of utilizing the available power to make the most application progress. 
-Argo employs hierarchical power management that includes both system-level (global) 
-and node-local mechanisms and policies. This includes developing and enabling power
-management in HPC schedulers (such as SLURM and Flux), large-scale system monitoring
-frameworks (LDMS), application profilers (such as Caliper), runtime system frameworks
-(such as Kokkos, GEOPM), and similar system- and application-level frameworks. 
+`Dynamic power management` is expected to be critical in the exascale era, both
+in terms of not exceeding the overall available power budget and in terms of
+utilizing the available power to make the most application progress. Argo
+employs hierarchical power management that includes both system-level (global)
+and node-local mechanisms and policies. This includes developing and enabling
+power management in HPC schedulers (such as SLURM and Flux), large-scale system
+monitoring frameworks (LDMS), application profilers (such as Caliper), runtime
+system frameworks (such as Kokkos, GEOPM), and similar system- and
+application-level frameworks.
 
-`Hardware co-design` involves working closely
-with our vendors to continuously explore emerging new hardware trends and devices,
-and look for how best to exploit the new capabilities in both traditional HPC 
-workloads and emerging scientific workflows, ones such as machine learning. 
-We try to identify how the new features should be integrated into existing runtime 
-systems and operating systems for the exascale era.
-
+`Hardware co-design` involves working closely with our vendors to continuously
+explore emerging new hardware trends and devices, and look for how best to
+exploit the new capabilities in both traditional HPC workloads and emerging
+scientific workflows, ones such as machine learning. We try to identify how the
+new features should be integrated into existing runtime systems and operating
+systems for the exascale era.

--- a/src/docs/sphinx/BuildingVariorum.rst
+++ b/src/docs/sphinx/BuildingVariorum.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -7,14 +8,16 @@
  Building Variorum
 ###################
 
-Variorum can be built from source with CMake or with ``spack``. Building Variorum creates the
-``libvariorum`` library, the ``powmon`` monitoring tool, and Variorum examples.
+Variorum can be built from source with CMake or with ``spack``. Building
+Variorum creates the ``libvariorum`` library, the ``powmon`` monitoring tool,
+and Variorum examples.
 
 ********************
  Build Dependencies
 ********************
 
-The build dependencies for a **minimal build** with no parallel components require the following:
+The build dependencies for a **minimal build** with no parallel components
+require the following:
 
    -  C
    -  hwloc
@@ -25,10 +28,9 @@ For a **parallel build** with MPI/OpenMP, Variorum depends on:
 
    -  rankstr (only required for MPI/OpenMP builds)
 
-The CMake variables (``ENABLE_MPI={ON,OFF}`` and ``ENABLE_OPENMP={ON,OFF}``) control
-the building of parallel examples. If ``ENABLE_MPI=ON``, an MPI compiler is
-required.
-
+The CMake variables (``ENABLE_MPI={ON,OFF}`` and ``ENABLE_OPENMP={ON,OFF}``)
+control the building of parallel examples. If ``ENABLE_MPI=ON``, an MPI compiler
+is required.
 
 hwloc (Required)
 ================
@@ -37,8 +39,8 @@ hwloc (Required)
 providing a portable abstraction of the hierarchical topology of modern
 architectures.
 
-Variorum leverages hwloc for detecting hardware topology. When reading/writing
-a register on a particular hardware thread, hwloc can map that to the correct
+Variorum leverages hwloc for detecting hardware topology. When reading/writing a
+register on a particular hardware thread, hwloc can map that to the correct
 physical socket.
 
 jansson (Required)
@@ -57,13 +59,13 @@ rankstr (Optional)
 providing functions that identify unique strings across an MPI communicator.
 
 Variorum leverages rankstr to split a communicator into subcommunicators by
-hostname. The allows for a single control or monitor process in Variorum to
-for example, enforce a power or frequency limit on a node or to print the
-hardware counters once on a node.
+hostname. The allows for a single control or monitor process in Variorum to for
+example, enforce a power or frequency limit on a node or to print the hardware
+counters once on a node.
 
-********************
+*********************
  Building with CMake
-********************
+*********************
 
 Variorum can be built and installed as follows after cloning from GitHub:
 
@@ -82,14 +84,15 @@ Variorum can be built and installed as follows after cloning from GitHub:
    make -j8
    make install
 
-******************
+*******************
  Host Config Files
-******************
+*******************
 
 To handle build options, third party library paths, etc., we rely on CMake's
-initial-cache file mechanism. We call these initial-cache files ``host-config`` files,
-as we typically create a file for each platform or specific hosts if necessary.
-These can be passed to CMake via the ``-C`` command line option as shown below:
+initial-cache file mechanism. We call these initial-cache files ``host-config``
+files, as we typically create a file for each platform or specific hosts if
+necessary. These can be passed to CMake via the ``-C`` command line option as
+shown below:
 
 .. code:: bash
 
@@ -99,63 +102,51 @@ An example is provided in ``host-configs/boilerplate.cmake`` to create your own
 configuration file. Example configuration files named by machine hostname, the
 ``SYS_TYPE`` environment variable, and platform name (via ``uname``) are also
 provided in the ``host-configs`` directory. These files use standard CMake
-commands. CMake ``set`` commands need to specify the root cache path as
-follows:
+commands. CMake ``set`` commands need to specify the root cache path as follows:
 
 .. code:: cmake
 
    set(CMAKE_VARIABLE_NAME {VALUE} CACHE PATH "")
 
-********************
+*********************
  CMake Build Options
-********************
+*********************
 
 Variorum's build system supports the following CMake options:
 
 -  ``HWLOC_DIR`` - Path to an HWLOC install.
-
 -  ``JANSSON_DIR`` - Path to a JANSSON install.
-
 -  ``SPHINX_EXECUTABLE`` - Path to sphinx-build binary (required for
    documentation).
-
--  ``VARIORUM_WITH_AMD (default=OFF)`` - Enable Variorum build for AMD architecture.
-
--  ``VARIORUM_WITH_NVIDIA (default=OFF)`` - Enable Variorum build for Nvidia architecture.
-
--  ``VARIORUM_WITH_IBM (default=OFF)`` - Enable Variorum build for IBM architecture.
-
--  ``VARIORUM_WITH_ARM (default=OFF)`` - Enable Variorum build for ARM architecture.
-
--  ``VARIORUM_WITH_INTEL (default=ON)`` - Enable Variorum build for Intel architecture.
-
--  ``ENABLE_FORTRAN (default=ON)`` - Enable Fortran compiler for building example
-   integration with Fortran application, Fortran compiler must exist.
-
--  ``ENABLE_MPI (default=OFF)`` - Enable MPI compiler for building MPI examples, MPI compiler
-   must exist.
-
--  ``ENABLE_OPENMP (default=ON)`` - Enable OpenMP extensions for building OpenMP examples.
-
--  ``ENABLE_WARNINGS (default=OFF)`` - Build with compiler warning flags -Wall -Wextra
-   -Werror, used primarily by developers.
-
--  ``BUILD_DOCS (default=ON)`` - Controls if the Variorum documentation is built (when
-   sphinx and doxygen are found).
-
--  ``BUILD_SHARED_LIBS (default=ON)`` - Controls if shared (ON) or static (OFF) libraries
-   are built.
-
+-  ``VARIORUM_WITH_AMD (default=OFF)`` - Enable Variorum build for AMD
+   architecture.
+-  ``VARIORUM_WITH_NVIDIA (default=OFF)`` - Enable Variorum build for Nvidia
+   architecture.
+-  ``VARIORUM_WITH_IBM (default=OFF)`` - Enable Variorum build for IBM
+   architecture.
+-  ``VARIORUM_WITH_ARM (default=OFF)`` - Enable Variorum build for ARM
+   architecture.
+-  ``VARIORUM_WITH_INTEL (default=ON)`` - Enable Variorum build for Intel
+   architecture.
+-  ``ENABLE_FORTRAN (default=ON)`` - Enable Fortran compiler for building
+   example integration with Fortran application, Fortran compiler must exist.
+-  ``ENABLE_MPI (default=OFF)`` - Enable MPI compiler for building MPI examples,
+   MPI compiler must exist.
+-  ``ENABLE_OPENMP (default=ON)`` - Enable OpenMP extensions for building OpenMP
+   examples.
+-  ``ENABLE_WARNINGS (default=OFF)`` - Build with compiler warning flags -Wall
+   -Wextra -Werror, used primarily by developers.
+-  ``BUILD_DOCS (default=ON)`` - Controls if the Variorum documentation is built
+   (when sphinx and doxygen are found).
+-  ``BUILD_SHARED_LIBS (default=ON)`` - Controls if shared (ON) or static (OFF)
+   libraries are built.
 -  ``BUILD_TESTS (default=ON)`` - Controls if unit tests are built.
-
--  ``VARIORUM_DEBUG (default=OFF)`` - Enable Variorum debug statements, useful if values are
-   not translating correctly.
-
--  ``VARIORUM_LOG (default=ON)`` - Enable Variorum logging statements, useful for tracking
-   what code path is being taken.
-
--  ``USE_MSR_SAFE_BEFORE_1_5_0 (default=OFF)`` - Use msr-safe prior to v1.5.0, dependency of
-   Intel architectures for accessing counters from userspace.
+-  ``VARIORUM_DEBUG (default=OFF)`` - Enable Variorum debug statements, useful
+   if values are not translating correctly.
+-  ``VARIORUM_LOG (default=ON)`` - Enable Variorum logging statements, useful
+   for tracking what code path is being taken.
+-  ``USE_MSR_SAFE_BEFORE_1_5_0 (default=OFF)`` - Use msr-safe prior to v1.5.0,
+   dependency of Intel architectures for accessing counters from userspace.
 
 *********************
  Building with Spack
@@ -170,8 +161,8 @@ necessary) run:
 
 The Variorum spack package provides several `variants
 <http://spack.readthedocs.io/en/latest/basic_usage.html#specs-dependencies>`_
-that customize the options and dependencies used to build Variorum (see table below).
-Variants are enabled using ``+`` and disabled using ``~``.
+that customize the options and dependencies used to build Variorum (see table
+below). Variants are enabled using ``+`` and disabled using ``~``.
 
    +----------------+----------------------------------------+------------------------------+
    | Variant        | Description                            | Default                      |
@@ -184,6 +175,5 @@ Variants are enabled using ``+`` and disabled using ``~``.
    |                | infrastructure                         |                              |
    +----------------+----------------------------------------+------------------------------+
    | **build_type** | Specify build type                     | Release with Debug Info      |
-   |                |                                        | (build_type=RelWithDebugInfo)|
+   |                |                                        | (build_type=RelWithDebugInfo) |
    +----------------+----------------------------------------+------------------------------+
-

--- a/src/docs/sphinx/CodeOfConduct.rst
+++ b/src/docs/sphinx/CodeOfConduct.rst
@@ -1,61 +1,65 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
 
-#####################################
-Contributor Covenant Code of Conduct
-#####################################
+######################################
+ Contributor Covenant Code of Conduct
+######################################
 
-**********
-Our Pledge
-**********
+************
+ Our Pledge
+************
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+size, disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
 
-*************
-Our Standards
-*************
+***************
+ Our Standards
+***************
 
 Examples of behavior that contributes to creating a positive environment
 include:
 
-    - Using welcoming and inclusive language
-    - Being respectful of differing viewpoints and experiences
-    - Gracefully accepting constructive criticism
-    - Focusing on what is best for the community
-    - Showing empathy towards other community members
+   -  Using welcoming and inclusive language
+   -  Being respectful of differing viewpoints and experiences
+   -  Gracefully accepting constructive criticism
+   -  Focusing on what is best for the community
+   -  Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-    - The use of sexualized language or imagery and unwelcome sexual attention or advances
-    - Trolling, insulting/derogatory comments, and personal or political attacks
-    - Public or private harassment
-    - Publishing others' private information, such as a physical or electronic address, without explicit permission
-    - Other conduct which could reasonably be considered inappropriate in a professional setting
+   -  The use of sexualized language or imagery and unwelcome sexual attention
+      or advances
+   -  Trolling, insulting/derogatory comments, and personal or political attacks
+   -  Public or private harassment
+   -  Publishing others' private information, such as a physical or electronic
+      address, without explicit permission
+   -  Other conduct which could reasonably be considered inappropriate in a
+      professional setting
 
-********************
-Our Responsibilities
-********************
+**********************
+ Our Responsibilities
+**********************
 
 Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
 
-*****
-Scope
-*****
+*******
+ Scope
+*******
 
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community. Examples of

--- a/src/docs/sphinx/Contributors.rst
+++ b/src/docs/sphinx/Contributors.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -7,53 +8,53 @@
  Contributors
 ##############
 
-We would like to acknowledge previous and current contributors to the variorum 
-project (in alphabetical order along with their current affiliation). These include
-our academic, industrial and DOE collaborators without whose support this work 
-would not be possible. We thank them for the regular discussions, bug fixes,
-feature enhancements, testbed access and other support. 
+We would like to acknowledge previous and current contributors to the variorum
+project (in alphabetical order along with their current affiliation). These
+include our academic, industrial and DOE collaborators without whose support
+this work would not be possible. We thank them for the regular discussions, bug
+fixes, feature enhancements, testbed access and other support.
 
-    - Peter Bailey (Google)
-    - Natalie Bates (EEHPCWG)
-    - Shilpasri Bhat (IBM)
-    - Sascha Bischoff (ARM)
-    - Grayson Blanks (Apple)
-    - Chaz-Akil Browne (Oakwood University)
-    - Naveen Krishna Chatradhi (AMD)
-    - Jeff Booher-Kaeding (ARM)
-    - Stephanie Brink (LLNL)
-    - Christopher Cantalupo (Intel)
-    - Giridhar Chukkapalli (NVIDIA)  
-    - Tiffany Connors (NERSC)
-    - Rigoberto Delgado (LLNL)
-    - Jonathan Eastep (Intel) 
-    - Daniel Ellsworth (Colorado College)
-    - Dave Fox (LLNL)
-    - Neha Gholkar (Intel)
-    - Ryan Grant (Queens University, Canada)
-    - Eric Green (LLNL)
-    - Jessica Hannebert (Colorado College)
-    - Sachin Idgunji (NVIDIA)
-    - Kamil Iskra (Argonne National Laboratory)
-    - Tanzima Islam (Texas Tech University) 
-    - Siddhartha Jana (EEHPCWG/Intel)
-    - Masaaki Kondo (University of Tokyo)
-    - Eun K Lee (IBM)
-    - David Lowenthal (Univeristy of Arizona)
-    - Aniruddha Marathe (LLNL)
-    - Matthias Maiterth (TU Munich, Germany)
-    - Lauren Morita (LLNL)
-    - Frank Mueller (North Carolina State University)
-    - Swann Perarnau (Argonne National Laboratory)
-    - Tapasya Patki (LLNL)
-    - Todd Rosedahl (IBM)
-    - Barry Rountree (LLNL)
-    - Roxana Rusitoru (ARM)
-    - Ryuichi Sakamoto (University of Tokyo, Japan)
-    - Siva Sathappan (AMD)
-    - Martin Schulz (TU Munich, Germany)
-    - Kathleen Shoga (LLNL)
-    - Carsten Trinitis (TU Munich, Germany)
-    - Scott Walker (Intel)
-    - Torsten Wilde (HPE)
-    - Kazutomo Yoshii (Argonne National Laboratory)
+   -  Peter Bailey (Google)
+   -  Natalie Bates (EEHPCWG)
+   -  Shilpasri Bhat (IBM)
+   -  Sascha Bischoff (ARM)
+   -  Grayson Blanks (Apple)
+   -  Chaz-Akil Browne (Oakwood University)
+   -  Naveen Krishna Chatradhi (AMD)
+   -  Jeff Booher-Kaeding (ARM)
+   -  Stephanie Brink (LLNL)
+   -  Christopher Cantalupo (Intel)
+   -  Giridhar Chukkapalli (NVIDIA)
+   -  Tiffany Connors (NERSC)
+   -  Rigoberto Delgado (LLNL)
+   -  Jonathan Eastep (Intel)
+   -  Daniel Ellsworth (Colorado College)
+   -  Dave Fox (LLNL)
+   -  Neha Gholkar (Intel)
+   -  Ryan Grant (Queens University, Canada)
+   -  Eric Green (LLNL)
+   -  Jessica Hannebert (Colorado College)
+   -  Sachin Idgunji (NVIDIA)
+   -  Kamil Iskra (Argonne National Laboratory)
+   -  Tanzima Islam (Texas Tech University)
+   -  Siddhartha Jana (EEHPCWG/Intel)
+   -  Masaaki Kondo (University of Tokyo)
+   -  Eun K Lee (IBM)
+   -  David Lowenthal (Univeristy of Arizona)
+   -  Aniruddha Marathe (LLNL)
+   -  Matthias Maiterth (TU Munich, Germany)
+   -  Lauren Morita (LLNL)
+   -  Frank Mueller (North Carolina State University)
+   -  Swann Perarnau (Argonne National Laboratory)
+   -  Tapasya Patki (LLNL)
+   -  Todd Rosedahl (IBM)
+   -  Barry Rountree (LLNL)
+   -  Roxana Rusitoru (ARM)
+   -  Ryuichi Sakamoto (University of Tokyo, Japan)
+   -  Siva Sathappan (AMD)
+   -  Martin Schulz (TU Munich, Germany)
+   -  Kathleen Shoga (LLNL)
+   -  Carsten Trinitis (TU Munich, Germany)
+   -  Scott Walker (Intel)
+   -  Torsten Wilde (HPE)
+   -  Kazutomo Yoshii (Argonne National Laboratory)

--- a/src/docs/sphinx/EEHPC.rst
+++ b/src/docs/sphinx/EEHPC.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -7,11 +8,11 @@
  EEHPC WG
 ##########
 
- 
-The Energy Efficient High Performance Computing Working Group (EEHPC WG) is a broad
-community effort focused on sustainably supporting science through committed community action.
-It has 800+ members worldwide, which include 50% sites, 30% industry, and 20% academia. 
-With the help of 15+ teams addressing various opportunities for improving energy efficiency,
-the EEHPC WG facilitates engagement of the community in sustainable large-scale science.
-They also regularly organize workshops and BoFs at major HPC conferences. More details
-about the EEHPC WG can be found at: https://eehpcwg.llnl.gov/.  
+The Energy Efficient High Performance Computing Working Group (EEHPC WG) is a
+broad community effort focused on sustainably supporting science through
+committed community action. It has 800+ members worldwide, which include 50%
+sites, 30% industry, and 20% academia. With the help of 15+ teams addressing
+various opportunities for improving energy efficiency, the EEHPC WG facilitates
+engagement of the community in sustainable large-scale science. They also
+regularly organize workshops and BoFs at major HPC conferences. More details
+about the EEHPC WG can be found at: https://eehpcwg.llnl.gov/.

--- a/src/docs/sphinx/Examples.rst
+++ b/src/docs/sphinx/Examples.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -11,8 +12,8 @@ Variorum provides some examples in the ``examples/`` directory.
 
 .. note::
 
-    All example codes have a print and print_verbose version showcasing the
-    different printouts supported by Variorum.
+   All example codes have a print and print_verbose version showcasing the
+   different printouts supported by Variorum.
 
 *******************
  Print Power Limit
@@ -27,41 +28,41 @@ following:
 
 .. code::
 
-    _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::143
-    _PACKAGE_POWER_LIMITS Offset Host Socket Bits PowerLimit1_W TimeWindow1_sec PowerLimit2_W TimeWindow2_sec
-    _PACKAGE_POWER_LIMITS 0x610 thompson 0 0x7851000158438 135.000000 1.000000 162.000000 0.007812
-    _PACKAGE_POWER_LIMITS 0x610 thompson 1 0x7851000158438 135.000000 1.000000 162.000000 0.007812
-    _DRAM_POWER_LIMIT Offset Host Socket Bits PowerLimit_W TimeWindow_sec
-    _DRAM_POWER_LIMIT 0x618 thompson 0 0x0 0.000000 0.000977
-    _DRAM_POWER_LIMIT 0x618 thompson 1 0x0 0.000000 0.000977
-    _PACKAGE_POWER_INFO Offset Host Socket Bits MaxPower_W MinPower_W MaxTimeWindow_sec ThermPower_W
-    _PACKAGE_POWER_INFO 0x614 thompson 0 0x2f087001380438 270.000000 39.000000 40.000000 135.000000
-    _PACKAGE_POWER_INFO 0x614 thompson 1 0x2f087001380438 270.000000 39.000000 40.000000 135.000000
-    _RAPL_POWER_UNITS Offset Host Socket Bits PowerUnit_W EnergyUnit_J TimeUnit_sec
-    _RAPL_POWER_UNITS 0x606 thompson 0 0xa0e03 0.125000 0.000061 0.000977
-    _RAPL_POWER_UNITS 0x606 thompson 1 0xa0e03 0.125000 0.000061 0.000977
-    _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::165
+   _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::143
+   _PACKAGE_POWER_LIMITS Offset Host Socket Bits PowerLimit1_W TimeWindow1_sec PowerLimit2_W TimeWindow2_sec
+   _PACKAGE_POWER_LIMITS 0x610 thompson 0 0x7851000158438 135.000000 1.000000 162.000000 0.007812
+   _PACKAGE_POWER_LIMITS 0x610 thompson 1 0x7851000158438 135.000000 1.000000 162.000000 0.007812
+   _DRAM_POWER_LIMIT Offset Host Socket Bits PowerLimit_W TimeWindow_sec
+   _DRAM_POWER_LIMIT 0x618 thompson 0 0x0 0.000000 0.000977
+   _DRAM_POWER_LIMIT 0x618 thompson 1 0x0 0.000000 0.000977
+   _PACKAGE_POWER_INFO Offset Host Socket Bits MaxPower_W MinPower_W MaxTimeWindow_sec ThermPower_W
+   _PACKAGE_POWER_INFO 0x614 thompson 0 0x2f087001380438 270.000000 39.000000 40.000000 135.000000
+   _PACKAGE_POWER_INFO 0x614 thompson 1 0x2f087001380438 270.000000 39.000000 40.000000 135.000000
+   _RAPL_POWER_UNITS Offset Host Socket Bits PowerUnit_W EnergyUnit_J TimeUnit_sec
+   _RAPL_POWER_UNITS 0x606 thompson 0 0xa0e03 0.125000 0.000061 0.000977
+   _RAPL_POWER_UNITS 0x606 thompson 1 0xa0e03 0.125000 0.000061 0.000977
+   _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::165
 
 On an IBM Power9 platform, the output may look similar to:
 
 .. code::
 
-    _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::143
-    _POWERCAP Host CurrentPower_W MaxPower_W MinPower_W PSR_CPU_to_GPU_0_% PSR_CPU_to_GPU_8_%
-    _POWERCAP lassen3 3050 3050 500 100 100
-    _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::165
+   _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::143
+   _POWERCAP Host CurrentPower_W MaxPower_W MinPower_W PSR_CPU_to_GPU_0_% PSR_CPU_to_GPU_8_%
+   _POWERCAP lassen3 3050 3050 500 100 100
+   _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::165
 
-    On an Nvidia GPU platform, the output may look similar to:
+   On an Nvidia GPU platform, the output may look similar to:
 
 .. code::
 
-    _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::143
-    _GPU_POWER_LIMIT Host Socket DeviceID PowerLimit_W
-    _GPU_POWER_LIMIT lassen1 0 0 300.000
-    _GPU_POWER_LIMIT lassen1 0 1 300.000
-    _GPU_POWER_LIMIT lassen1 1 2 300.000
-    _GPU_POWER_LIMIT lassen1 1 3 300.000
-    _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::165
+   _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::143
+   _GPU_POWER_LIMIT Host Socket DeviceID PowerLimit_W
+   _GPU_POWER_LIMIT lassen1 0 0 300.000
+   _GPU_POWER_LIMIT lassen1 0 1 300.000
+   _GPU_POWER_LIMIT lassen1 1 2 300.000
+   _GPU_POWER_LIMIT lassen1 1 3 300.000
+   _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_power_limit::165
 
 ***************************
  Print Verbose Power Limit
@@ -72,39 +73,39 @@ API prints the output in verbose format that is more human-readable (with units,
 titles, etc.).
 
 .. literalinclude:: ../../examples/variorum-print-verbose-power-limit-example.c
-    :language: c
+   :language: c
 
 On an Intel platform, the output of this example should be similar to the
 following:
 
 .. code::
 
-    _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::180
-    _PACKAGE_POWER_LIMIT Offset: 0x610, Host: thompson, Socket: 0, Bits: 0x7851000158438, PowerLimit1: 135.000000 W, TimeWindow1: 1.000000 sec, PowerLimit2: 162.000000 W, TimeWindow2: 0.007812 sec
-    _PACKAGE_POWER_LIMIT Offset: 0x610, Host: thompson, Socket: 1, Bits: 0x7851000158438, PowerLimit1: 135.000000 W, TimeWindow1: 1.000000 sec, PowerLimit2: 162.000000 W, TimeWindow2: 0.007812 sec
-    _DRAM_POWER_LIMIT Offset: 0x618, Host: thompson, Socket: 0, Bits: 0x0, PowerLimit: 0.000000 W, TimeWindow: 0.000977 sec
-    _DRAM_POWER_LIMIT Offset: 0x618, Host: thompson, Socket: 1, Bits: 0x0, PowerLimit: 0.000000 W, TimeWindow: 0.000977 sec
-    _PACKAGE_POWER_INFO Offset: 0x614, Host: thompson, Socket: 0, Bits: 0x2f087001380438, MaxPower: 270.000000 W, MinPower: 39.000000 W, MaxWindow: 40.000000 sec, ThermPower: 135.000000 W
-    _PACKAGE_POWER_INFO Offset: 0x614, Host: thompson, Socket: 1, Bits: 0x2f087001380438, MaxPower: 270.000000 W, MinPower: 39.000000 W, MaxTimeWindow: 40.000000 sec, ThermPower: 135.000000 W
-    _RAPL_POWER_UNITS Offset: 0x606, Host: thompson, Socket: 0, Bits: 0xa0e03, PowerUnit: 0.125000 W, EnergyUnit: 0.000061 J, TimeUnit: 0.000977 sec
-    _RAPL_POWER_UNITS Offset: 0x606, Host: thompson, Socket: 1, Bits: 0xa0e03, PowerUnit: 0.125000 W, EnergyUnit: 0.000061 J, TimeUnit: 0.000977 sec
-    _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::202
+   _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::180
+   _PACKAGE_POWER_LIMIT Offset: 0x610, Host: thompson, Socket: 0, Bits: 0x7851000158438, PowerLimit1: 135.000000 W, TimeWindow1: 1.000000 sec, PowerLimit2: 162.000000 W, TimeWindow2: 0.007812 sec
+   _PACKAGE_POWER_LIMIT Offset: 0x610, Host: thompson, Socket: 1, Bits: 0x7851000158438, PowerLimit1: 135.000000 W, TimeWindow1: 1.000000 sec, PowerLimit2: 162.000000 W, TimeWindow2: 0.007812 sec
+   _DRAM_POWER_LIMIT Offset: 0x618, Host: thompson, Socket: 0, Bits: 0x0, PowerLimit: 0.000000 W, TimeWindow: 0.000977 sec
+   _DRAM_POWER_LIMIT Offset: 0x618, Host: thompson, Socket: 1, Bits: 0x0, PowerLimit: 0.000000 W, TimeWindow: 0.000977 sec
+   _PACKAGE_POWER_INFO Offset: 0x614, Host: thompson, Socket: 0, Bits: 0x2f087001380438, MaxPower: 270.000000 W, MinPower: 39.000000 W, MaxWindow: 40.000000 sec, ThermPower: 135.000000 W
+   _PACKAGE_POWER_INFO Offset: 0x614, Host: thompson, Socket: 1, Bits: 0x2f087001380438, MaxPower: 270.000000 W, MinPower: 39.000000 W, MaxTimeWindow: 40.000000 sec, ThermPower: 135.000000 W
+   _RAPL_POWER_UNITS Offset: 0x606, Host: thompson, Socket: 0, Bits: 0xa0e03, PowerUnit: 0.125000 W, EnergyUnit: 0.000061 J, TimeUnit: 0.000977 sec
+   _RAPL_POWER_UNITS Offset: 0x606, Host: thompson, Socket: 1, Bits: 0xa0e03, PowerUnit: 0.125000 W, EnergyUnit: 0.000061 J, TimeUnit: 0.000977 sec
+   _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::202
 
 On an IBM platform, the output may look similar to:
 
 .. code::
 
-    _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::180
-    _POWERCAP Host: lassen3, CurrentPower: 3050 W, MaxPower: 3050 W, MinPower: 500 W, PSR_CPU_to_GPU_0: 100%, PSR_CPU_to_GPU_8: 100%
-    _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::202
+   _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::180
+   _POWERCAP Host: lassen3, CurrentPower: 3050 W, MaxPower: 3050 W, MinPower: 500 W, PSR_CPU_to_GPU_0: 100%, PSR_CPU_to_GPU_8: 100%
+   _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::202
 
 On an Nvidia platform, the output may look similar to:
 
 .. code::
 
-    _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::180
-    _GPU_POWER_LIMIT Host: lassen1, Socket: 0, DeviceID: 0, PowerLimit: 300.000 W
-    _GPU_POWER_LIMIT Host: lassen1, Socket: 0, DeviceID: 1, PowerLimit: 300.000 W
-    _GPU_POWER_LIMIT Host: lassen1, Socket: 1, DeviceID: 2, PowerLimit: 300.000 W
-    _GPU_POWER_LIMIT Host: lassen1, Socket: 1, DeviceID: 3, PowerLimit: 300.000 W
-    _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::202
+   _LOG_VARIORUM_ENTER:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::180
+   _GPU_POWER_LIMIT Host: lassen1, Socket: 0, DeviceID: 0, PowerLimit: 300.000 W
+   _GPU_POWER_LIMIT Host: lassen1, Socket: 0, DeviceID: 1, PowerLimit: 300.000 W
+   _GPU_POWER_LIMIT Host: lassen1, Socket: 1, DeviceID: 2, PowerLimit: 300.000 W
+   _GPU_POWER_LIMIT Host: lassen1, Socket: 1, DeviceID: 3, PowerLimit: 300.000 W
+   _LOG_VARIORUM_EXIT:~/variorum/src/variorum/variorum.c:variorum_print_verbose_power_limit::202

--- a/src/docs/sphinx/HWArchitectures.rst
+++ b/src/docs/sphinx/HWArchitectures.rst
@@ -1,11 +1,12 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
 
-#################################
+##################################
  Supported Platform Documentation
-#################################
+##################################
 
 These are the currently supported platforms in Variorum.
 

--- a/src/docs/sphinx/IBM.rst
+++ b/src/docs/sphinx/IBM.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -7,45 +8,45 @@
  IBM Power9 Overview
 #####################
 
-IBM Power9 architecture supports in band monitoring with sensors and out of
-band power capping with OPAL. These depend on specific IBM files that we
-describe below. Permissions on these files can be modified through cgroups.
-OPAL/Skiboot is part of IBM provided firmware that is expected to be present on
-the system.
+IBM Power9 architecture supports in band monitoring with sensors and out of band
+power capping with OPAL. These depend on specific IBM files that we describe
+below. Permissions on these files can be modified through cgroups. OPAL/Skiboot
+is part of IBM provided firmware that is expected to be present on the system.
 
-************
-Requirements
-************
-Read access to ``/sys/firmware/opal/exports/occ_inband_sensors`` is required, 
-along with read-write access to 
-``/sys/firmware/opal/powercap/system_powercap/powercap_current``
-and ``/sys/firmware/opal/psr/``. This can be enabled by using group permissions.
-For example, to allow only users belonging to certain group to set the
-power cap or power shifting ratio, ``udev`` can be used as follows.
+**************
+ Requirements
+**************
 
-.. code:: bash      
+Read access to ``/sys/firmware/opal/exports/occ_inband_sensors`` is required,
+along with read-write access to
+``/sys/firmware/opal/powercap/system_powercap/powercap_current`` and
+``/sys/firmware/opal/psr/``. This can be enabled by using group permissions. For
+example, to allow only users belonging to certain group to set the power cap or
+power shifting ratio, ``udev`` can be used as follows.
 
-    $ cat /etc/udev/rules.d/99-coral.rules                                              
+.. code:: bash
 
-    KERNELS=="*", ACTION=="*", DEVPATH=="/devices/*", RUN+="/bin/chown root:coral 
-        /sys/firmware/opal/powercap/system-powercap/powercap-current 
-        /sys/firmware/opal/psr/cpu_to_gpu_0 
-        /sys/firmware/opal/psr/cpu_to_gpu_8"
- 
-The above file needs to be copied to all nodes. The administrator has to create 
-a group (for example, named ``coral`` below) and add the users to this group. 
+   $ cat /etc/udev/rules.d/99-coral.rules
+
+   KERNELS=="*", ACTION=="*", DEVPATH=="/devices/*", RUN+="/bin/chown root:coral
+       /sys/firmware/opal/powercap/system-powercap/powercap-current
+       /sys/firmware/opal/psr/cpu_to_gpu_0
+       /sys/firmware/opal/psr/cpu_to_gpu_8"
+
+The above file needs to be copied to all nodes. The administrator has to create
+a group (for example, named ``coral`` below) and add the users to this group.
 The ``udev`` rule can then be set as follows:
 
-.. code:: bash      
+.. code:: bash
 
-    $ udevadm trigger /sys/block/sda
+   $ udevadm trigger /sys/block/sda
 
-    $ ls -l /sys/firmware/opal/powercap/system-powercap/powercap-current \
-    /sys/firmware/opal/psr/cpu_to_gpu_0 /sys/firmware/opal/psr/cpu_to_gpu_8
-    
-    -rw-rw-r-- 1 root coral 65536 Jul  3 06:19 /sys/firmware/opal/powercap/system-powercap/powercap-current
-    -rw-rw-r-- 1 root coral 65536 Jul  3 06:19 /sys/firmware/opal/psr/cpu_to_gpu_0
-    -rw-rw-r-- 1 root coral 65536 Jul  3 06:19 /sys/firmware/opal/psr/cpu_to_gpu_8
+   $ ls -l /sys/firmware/opal/powercap/system-powercap/powercap-current \
+   /sys/firmware/opal/psr/cpu_to_gpu_0 /sys/firmware/opal/psr/cpu_to_gpu_8
+
+   -rw-rw-r-- 1 root coral 65536 Jul  3 06:19 /sys/firmware/opal/powercap/system-powercap/powercap-current
+   -rw-rw-r-- 1 root coral 65536 Jul  3 06:19 /sys/firmware/opal/psr/cpu_to_gpu_0
+   -rw-rw-r-- 1 root coral 65536 Jul  3 06:19 /sys/firmware/opal/psr/cpu_to_gpu_8
 
 *******************************
  Inband Sensors for Monitoring
@@ -56,7 +57,8 @@ power, temperature, CPU frequency, CPU utilization, memory bandwidth, etc. The
 sensor data is stored in OCC's SRAM and is available to the user inband through
 the sensors file listed below:
 
--  Key file for inband sensors: ``/sys/firmware/opal/exports/occ_inband_sensors``
+-  Key file for inband sensors:
+   ``/sys/firmware/opal/exports/occ_inband_sensors``
 
 OCC Sensor Data formatting is described below, and we then describe the code
 structures that were used to represent this data in the IBM port of Variorum.
@@ -68,15 +70,19 @@ structures that were used to represent this data in the IBM port of Variorum.
 OCC sensor data will use BAR2 (OCC Common is per physical drawer). Starting
 address is at offset 0x00580000 from BAR2 base address. Maximum size is 1.5MB.
 
-======================================== ============ ====== =========================
-  Start (Offset from BAR2 base address)   End          Size   Description
-======================================== ============ ====== =========================
-  0x00580000                              0x005A57FF   150kB   OCC 0 Sensor Data Block
-  0x005A5800                              0x005CAFFF   150kB   OCC 1 Sensor Data Block
-  :                                       :            :       :
-  0x00686800                              0x006ABFFF   150kB   OCC 7 Sensor Data Block
-  0x006AC000                              0x006FFFFF   336kB   Reserved
-======================================== ============ ====== =========================
++----------------------------------------+------------+------+-------------------------+
+| Start (Offset from BAR2 base address)  | End        | Size | Description             |
++========================================+============+======+=========================+
+| 0x00580000                             | 0x005A57FF | 150kB | OCC 0 Sensor Data Block |
++----------------------------------------+------------+------+-------------------------+
+| 0x005A5800                             | 0x005CAFFF | 150kB | OCC 1 Sensor Data Block |
++----------------------------------------+------------+------+-------------------------+
+| :                                      | :          | :    | :                       |
++----------------------------------------+------------+------+-------------------------+
+| 0x00686800                             | 0x006ABFFF | 150kB | OCC 7 Sensor Data Block |
++----------------------------------------+------------+------+-------------------------+
+| 0x006AC000                             | 0x006FFFFF | 336kB | Reserved                |
++----------------------------------------+------------+------+-------------------------+
 
 ****************************************
  OCC N Sensor Data Block Layout (150kB)
@@ -86,17 +92,25 @@ The sensor data block layout is the same for each OCC N. It contains
 sensor-header-block, sensor-names buffer, sensor-readings-ping buffer and
 sensor-readings-pong buffer.
 
-============================================== ============ ====== ============================
-  Start (Offset from OCC N Sensor Data Block)   End          Size   Description
-============================================== ============ ====== ============================
-  0x00000000                                    0x000003FF   1kB    Sensor Data Header Block
-  0x00000400                                    0x0000CBFF   50kB   Sensor Names
-  0x0000CC00                                    0x0000DBFF   4kB    Reserved
-  0x0000DC00                                    0x00017BFF   40kB   Sensor Readings ping buffer
-  0x00017C00                                    0x00018BFF   4kB    Reserved
-  0x00018C00                                    0x00022BFF   40kB   Sensor Readings pong buffer
-  0x00022C00                                    0x000257FF   11kB   Reserved
-============================================== ============ ====== ============================
++----------------------------------------------+------------+------+----------------------------+
+| Start (Offset from OCC N Sensor Data Block)  | End        | Size | Description                |
++==============================================+============+======+============================+
+| 0x00000000                                   | 0x000003FF | 1kB  | Sensor Data Header Block   |
++----------------------------------------------+------------+------+----------------------------+
+| 0x00000400                                   | 0x0000CBFF | 50kB | Sensor Names               |
++----------------------------------------------+------------+------+----------------------------+
+| 0x0000CC00                                   | 0x0000DBFF | 4kB  | Reserved                   |
++----------------------------------------------+------------+------+----------------------------+
+| 0x0000DC00                                   | 0x00017BFF | 40kB | Sensor Readings ping       |
+|                                              |            |      | buffer                     |
++----------------------------------------------+------------+------+----------------------------+
+| 0x00017C00                                   | 0x00018BFF | 4kB  | Reserved                   |
++----------------------------------------------+------------+------+----------------------------+
+| 0x00018C00                                   | 0x00022BFF | 40kB | Sensor Readings pong       |
+|                                              |            |      | buffer                     |
++----------------------------------------------+------------+------+----------------------------+
+| 0x00022C00                                   | 0x000257FF | 11kB | Reserved                   |
++----------------------------------------------+------------+------+----------------------------+
 
 There are eight OCC Sensor Data Blocks. Each of these has the same data block
 layout. Within each sensor data block, we have:
@@ -106,13 +120,12 @@ layout. Within each sensor data block, we have:
    format of the ping/pong buffer, this could be READING_FULL or
    READING_COUNTER).
 
--  **names block**: Written once at initialization, captured in
-   occ_sensors_name
+-  **names block**: Written once at initialization, captured in occ_sensors_name
 
 -  **readings ping buffer and readings pong buffer**: The ping/pong buffers are
    two 40kB buffers, one is being updated by the OCC and the other is available
-   for reading. Both have the same format version (defined in
-   sensor_struct_type and struct_attr).
+   for reading. Both have the same format version (defined in sensor_struct_type
+   and struct_attr).
 
 There are four enums:
 
@@ -124,8 +137,8 @@ There are four enums:
 
 There are four structs:
 
-#. **occ_sensor_data_header**: Gives us offsets to ping and pong buffers,
-   format version of the ping and pong buffers (reading_version), and offset to
+#. **occ_sensor_data_header**: Gives us offsets to ping and pong buffers, format
+   version of the ping and pong buffers (reading_version), and offset to
    location of the names buffer.
 
 #. **occ_sensor_name**: Format of the sensor. Gives us the type of sensor,
@@ -155,13 +168,13 @@ Node power caps are set by writing to the following file in Watts:
 
 Socket level power capping and memory power capping is not available.
 
-GPU power shifting ratio can be set by setting the following files in
-percentage (i.e., between 0 and 100). ``/sys/firmware/opal/psr/cpu_to_gpu_0`` and
+GPU power shifting ratio can be set by setting the following files in percentage
+(i.e., between 0 and 100). ``/sys/firmware/opal/psr/cpu_to_gpu_0`` and
 ``/sys/firmware/opal/psr/cpu_to_gpu_8``
 
 Write access to these files is needed to set node power caps and GPU ratio.
 
-The figure below depicts the ranges for IBM power caps on Power9 system 
+The figure below depicts the ranges for IBM power caps on Power9 system
 (reproduced with permission from our IBM collaborators).
 
 .. image:: images/IBM_PowerCap.png
@@ -174,9 +187,9 @@ The figure below shows the details of GPU power shifting ratio.
    :height: 300px
    :align: center
 
-**********
-References
-**********
+************
+ References
+************
 
 -  `OCC
    <https://github.com/open-power/docs/blob/master/occ/OCC_P9_FW_Interfaces.pdf>`_
@@ -184,5 +197,3 @@ References
    <https://openpowerfoundation.org/wp-content/uploads/2015/03/Smith-Stewart_OPFS2015.intro-to-OPAL.031715.pdf>`_
 -  `Skiboot <https://github.com/open-power/skiboot>`_
 -  `Inband Sensors <https://github.com/shilpasri/inband_sensors>`_
-
-

--- a/src/docs/sphinx/Intel.rst
+++ b/src/docs/sphinx/Intel.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -10,21 +11,20 @@
 Intel processors have the most sophisticated power and thermal control of any
 processor vendor we work with. While Intel's documentation remains the final
 arbiter, that format has not allowed the community of Intel users to discuss
-best practices and distribute documentation patches. For this release we
-provide below a listing of the MSRs found in Chapter 14 of volume 3B of Intel's
-SDM, plus a few related MSRs that exist elsewhere in public documentation.
-Alongside the register diagrams we note what we have learned (if anything) by
-using the registers and discussing them with our colleagues at Intel and
-elsewhere.
+best practices and distribute documentation patches. For this release we provide
+below a listing of the MSRs found in Chapter 14 of volume 3B of Intel's SDM,
+plus a few related MSRs that exist elsewhere in public documentation. Alongside
+the register diagrams we note what we have learned (if anything) by using the
+registers and discussing them with our colleagues at Intel and elsewhere.
 
-*************
+**************
  Requirements
-*************
+**************
 
 To use Variorum on Intel platforms, access to low-level registers needs to be
 enabled for non-root users. This can be enabled with the `msr-safe
-<https://github.com/llnl/msr-safe>`_ kernel driver which must be loaded 
-to enable user-level read and write of allowed MSRs.
+<https://github.com/llnl/msr-safe>`_ kernel driver which must be loaded to
+enable user-level read and write of allowed MSRs.
 
 The msr-safe driver provides the following device files:
 
@@ -55,17 +55,17 @@ The stock MSR driver provides the following device files:
 These are the most common mistakes we have seen when using these registers.
 
 -  IA32_PERF_CTL does not set clock frequency
-      -  In the distant past prior to multicore and turbo, setting
-         IA32_PERF_CTL might have had the effect of dialing in the requested
-         CPU clock frequency. In any processor since Nehalem, however, it sets
-         a frequency cap.
+      -  In the distant past prior to multicore and turbo, setting IA32_PERF_CTL
+         might have had the effect of dialing in the requested CPU clock
+         frequency. In any processor since Nehalem, however, it sets a frequency
+         cap.
 
 -  Always measure effective clock frequency using IA32_APERF and IA32_MPERF.
       -  Given the amount of performance variation within the operating system
          and within and across processors, it is easy to talk oneself into a
          story of how a particular knob relates to performance by changing the
-         clock frequency. Measuring both execution time and clock frequency
-         (and perhaps IPC as well) is an excellent filter for those stories.
+         clock frequency. Measuring both execution time and clock frequency (and
+         perhaps IPC as well) is an excellent filter for those stories.
 
 -  Do not use Linux performance governors as they have limited support.
 
@@ -344,9 +344,9 @@ These are the most common mistakes we have seen when using these registers.
    silently clipped. That value is also NDA.
 
 -  The OS and enable bits are now ignored. Both of them should always be set
-   high. Writing all-zeros to this register will not disable RAPL; the
-   processor will just try to meet a zero-watt power bound (or whatever zero is
-   clipped to).
+   high. Writing all-zeros to this register will not disable RAPL; the processor
+   will just try to meet a zero-watt power bound (or whatever zero is clipped
+   to).
 
 .. image:: images/Intel/PkgEnergyStatus.png
    :align: center
@@ -409,10 +409,9 @@ These are the most common mistakes we have seen when using these registers.
 .. image:: images/Intel/PowerCtl.png
    :align: center
 
-
-**********
-References
-**********
+************
+ References
+************
 
 -  `Intel Software Developer Manuals
    <https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html>`_

--- a/src/docs/sphinx/Licenses.rst
+++ b/src/docs/sphinx/Licenses.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT

--- a/src/docs/sphinx/Nvidia.rst
+++ b/src/docs/sphinx/Nvidia.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -9,13 +10,13 @@
 
 This page provides a detailed description of the the NVIDIA port of Variorum.
 The functionality of this port depends on NVIDIA-specific proprietary software
-stack as well as open-source software components described below. The
-high-level API provided by Variorum is read-only (i.e., monitoring-only),
-primarily because of the access limitations on our target platform.
+stack as well as open-source software components described below. The high-level
+API provided by Variorum is read-only (i.e., monitoring-only), primarily because
+of the access limitations on our target platform.
 
-*************
-Requirements
-*************
+**************
+ Requirements
+**************
 
 The NVIDIA port of Variorum depends on:
 
@@ -23,16 +24,15 @@ The NVIDIA port of Variorum depends on:
    interfaces. NVML provides standardized interfaces to the NVIDIA GPU devices
    enumerated by the proprietary NVIDIA device driver as ``/dev/nvidia[0-9]*``.
 
--  CUDA development toolkit, 10.1.243+ which delivers the
-   headers for NVML.
+-  CUDA development toolkit, 10.1.243+ which delivers the headers for NVML.
 
 -  CUDA-enabled build of the Portable Hardware Locality (hwloc) library to
    enumerate the GPU devices and their mappings to the host CPUs. This requires
    hwloc to be built with the ``HWLOC_HAVE_CUDA`` flag.
 
 To successfully use the Variorum port of NVIDIA, verify that the
-``LD_LIBRARY_PATH`` environment variable has paths for both the CUDA library
-and the CUDA-enabled hwloc library installed on the system. Also make sure that
+``LD_LIBRARY_PATH`` environment variable has paths for both the CUDA library and
+the CUDA-enabled hwloc library installed on the system. Also make sure that
 access to the NVIDIA devices (``/dev/nvidia*``) through the NVIDIA driver are
 set correctly for the user. This can be verified by running the `nvidia-smi`
 command line tool.
@@ -41,15 +41,15 @@ We have tested our NVIDIA port with CUDA 9.2 and CUDA-enabled build of hwloc
 1.11.10. The NVIDIA port has been tested on the Tesla GPU architecture (NVIDIA
 Volta SM200).
 
-********************
-Build Configuration
-********************
+*********************
+ Build Configuration
+*********************
 
 We provide an example CMake host config file, which defines the CMake build
 variables set on our test platform (Lassen supercomputer at LLNL):
 `lassen-4.14.0-ppc64le-gcc@4.9.3-cuda@10.1.243.cmake`.
 
-For your build system, you will need to enable Variorum to build with NVIDIA and 
+For your build system, you will need to enable Variorum to build with NVIDIA and
 set two path variables as described below:
 
    -  ``VARIORUM_WITH_NVIDIA=ON``
@@ -70,20 +70,20 @@ this information, it calculates the number of GPU devices associated with each
 CPU assuming sequential device assignment on the system. This method also
 initializes the internal state of NVML using the ``nvmlInit()`` API.
 
-The device handles are stored in data structures of type ``nvmlDevice_t`` defined
-in NVML. A device handle provides the logical-to-physical mapping between the
-sequential device IDs and system device handles maintained by NVML internally
-at state initialization. All NVML query and command APIs require the device
-handles to perform the specified operation on the device. While the high-level
-Variorum APIs operate over all devices, the internal routines in the NVIDIA
-port use CPU ID to perform operations on the associated GPUs.
+The device handles are stored in data structures of type ``nvmlDevice_t``
+defined in NVML. A device handle provides the logical-to-physical mapping
+between the sequential device IDs and system device handles maintained by NVML
+internally at state initialization. All NVML query and command APIs require the
+device handles to perform the specified operation on the device. While the
+high-level Variorum APIs operate over all devices, the internal routines in the
+NVIDIA port use CPU ID to perform operations on the associated GPUs.
 
 ***************************************************
  Telemetry Collection Through NVML Query Interface
 ***************************************************
 
-The NVIDIA port of Variorum leverages the device and unit query APIs provided
-by NVML to collect per-GPU telemetry. The text below describes the specific
+The NVIDIA port of Variorum leverages the device and unit query APIs provided by
+NVML to collect per-GPU telemetry. The text below describes the specific
 Variorum APIs, the corresponding NVML APIs, and the post-processing (if any)
 performed by Variorum before presenting the data to the caller.
 

--- a/src/docs/sphinx/Overview.rst
+++ b/src/docs/sphinx/Overview.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -16,27 +17,27 @@ as different generations within a particular device. More specifically,
 Variorum's flexible design supports a set of features that may exist on one
 generation of hardware, but not on another.
 
-******************
+*******************
  Design Principles
-******************
+*******************
 
 To guide the development of Variorum, we focused on a set of important
 requirements extracted from our learnings with the development of ``libmsr``.
 Here are Variorum's requirements:
 
 -  **Create device-agnostic APIs**: We do not want to require the user to have
-   to know or understand how to interface with each device. The library is
-   built for a target architecture, which may be heterogeneous, and can collect
-   data from each device through a single front-facing interface.
+   to know or understand how to interface with each device. The library is built
+   for a target architecture, which may be heterogeneous, and can collect data
+   from each device through a single front-facing interface.
 
--  **Provide a simple interface**: We want users and tool developers to not
-   only collect information from the underlying hardware, but also to have the
+-  **Provide a simple interface**: We want users and tool developers to not only
+   collect information from the underlying hardware, but also to have the
    ability to control various features.
 
 -  **Ease in extending to new devices and generations within a device**:
    Variorum makes it easy to support new features, deprecate old features among
-   generations of devices, and adapt features that may have different domains
-   of control from one generation to another (i.e., sockets, cores, threads).
+   generations of devices, and adapt features that may have different domains of
+   control from one generation to another (i.e., sockets, cores, threads).
 
 ****************
  System Diagram
@@ -45,4 +46,3 @@ Here are Variorum's requirements:
 .. image:: images/VariorumSystemDesign.png
    :height: 400px
    :align: center
-

--- a/src/docs/sphinx/PowerAPI.rst
+++ b/src/docs/sphinx/PowerAPI.rst
@@ -1,18 +1,19 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
 
-#########
+##########
  PowerAPI
-#########
+##########
 
-The Power API is a community-lead specification for an power monitoring and control API 
-that supports small scale to extreme-scale systems. It is associated with the 
-Energy-Efficient High Performance Computing Working Group (EEHPCWG) and also with
-the Exascale Computing Project (ECP). A community specification as well as a reference
-implementation of the Power API can be found on their website, https://pwrapi.github.io. 
+The Power API is a community-lead specification for an power monitoring and
+control API that supports small scale to extreme-scale systems. It is associated
+with the Energy-Efficient High Performance Computing Working Group (EEHPCWG) and
+also with the Exascale Computing Project (ECP). A community specification as
+well as a reference implementation of the Power API can be found on their
+website, https://pwrapi.github.io.
 
-Upcoming goal for the Variorum team includes supporting relevant platform- and 
+Upcoming goal for the Variorum team includes supporting relevant platform- and
 node-level APIs from the Power API community specification.
-

--- a/src/docs/sphinx/PowerStack.rst
+++ b/src/docs/sphinx/PowerStack.rst
@@ -1,22 +1,23 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
 
-##########################
+###########################
  HPC PowerStack Initiative
-##########################
+###########################
 
-The HPC PowerStack Initiative brings together experts from academia, research laboratories 
-and industry in order to design a holistic and extensible power management framework, 
-which we refer to as the PowerStack. The PowerStack explores hierarchical interfaces 
-for power management at three specific levels: batch job schedulers, job-level runtime systems, 
-and node-level managers. The HPC PowerStack community meets regularly, details of
-which can be found at: https://hpcpowerstack.github.io. 
+The HPC PowerStack Initiative brings together experts from academia, research
+laboratories and industry in order to design a holistic and extensible power
+management framework, which we refer to as the PowerStack. The PowerStack
+explores hierarchical interfaces for power management at three specific levels:
+batch job schedulers, job-level runtime systems, and node-level managers. The
+HPC PowerStack community meets regularly, details of which can be found at:
+https://hpcpowerstack.github.io.
 
-The :doc:`Argo` is one of the 
-key contributors to the HPC PowerStack Initiative. HPC PowerStack also closely 
-collaborates with the following community efforts:
+The :doc:`Argo` is one of the key contributors to the HPC PowerStack Initiative.
+HPC PowerStack also closely collaborates with the following community efforts:
 
 .. toctree::
    :maxdepth: 2
@@ -24,22 +25,23 @@ collaborates with the following community efforts:
    PowerAPI
    EEHPC
 
-Each level in the PowerStack will provide options for adaptive and dynamic power 
-management depending on requirements of the supercomputing site under consideration,
-and would be able to operate as an independent entity if needed. Site-specific 
-requirements such as cluster-level power bounds, user fairness, or job priorities 
-will be translated as inputs to the job scheduler. The job scheduler will choose 
-power-aware scheduling plugins to ensure compliance, with the primary responsibility 
-being management of allocations across multiple users and diverse workloads. 
-Such allocations (physical nodes and job-level power bounds) will serve as inputs 
-to a fine-grained, job-level runtime system to manage specific application ranks, 
-in-turn relying on vendor-agnostic node-level measurement and control mechanisms. 
+Each level in the PowerStack will provide options for adaptive and dynamic power
+management depending on requirements of the supercomputing site under
+consideration, and would be able to operate as an independent entity if needed.
+Site-specific requirements such as cluster-level power bounds, user fairness, or
+job priorities will be translated as inputs to the job scheduler. The job
+scheduler will choose power-aware scheduling plugins to ensure compliance, with
+the primary responsibility being management of allocations across multiple users
+and diverse workloads. Such allocations (physical nodes and job-level power
+bounds) will serve as inputs to a fine-grained, job-level runtime system to
+manage specific application ranks, in-turn relying on vendor-agnostic node-level
+measurement and control mechanisms.
 
-The figure below presents an overview of the envisioned PowerStack,
-which takes a holistic approach to power management. Variorum is a reference example
-that represents the vendor-agnostic node-level interface, which can integrate with
-high-levels in the PowerStack as and when needed, which we describe in :doc:`VariorumTools`. 
+The figure below presents an overview of the envisioned PowerStack, which takes
+a holistic approach to power management. Variorum is a reference example that
+represents the vendor-agnostic node-level interface, which can integrate with
+high-levels in the PowerStack as and when needed, which we describe in
+:doc:`VariorumTools`.
 
 .. image:: images/PowerStack.png
    :scale: 70 %
-

--- a/src/docs/sphinx/Powmon.rst
+++ b/src/docs/sphinx/Powmon.rst
@@ -1,11 +1,12 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
 
-##################################
+###################################
  Monitoring Binaries with Variorum
-##################################
+###################################
 
 While the Variorum API allows for detailed critical path analysis of the power
 profile of user applications as well as for integration with system software
@@ -14,40 +15,41 @@ where such annotations are not possible. In order to support such scenarios, we
 provide the ``powmon`` tool, which can monitor a binary externally with Variorum
 in a vendor-neutral manner.
 
-The ``variorum/src/powmon`` directory contains this tool, which is built along with
-the regular Variorum build. While a target executable is running, ``powmon`` collects
-time samples of power usage, power limits, energy, thermals, and other
-performance counters for all sockets in a node at a regular interval. For example,
-the command below will sample the power usage while executing a sleep for 10 seconds:
+The ``variorum/src/powmon`` directory contains this tool, which is built along
+with the regular Variorum build. While a target executable is running,
+``powmon`` collects time samples of power usage, power limits, energy, thermals,
+and other performance counters for all sockets in a node at a regular interval.
+For example, the command below will sample the power usage while executing a
+sleep for 10 seconds:
 
 .. code:: bash
 
-    $ powmon -a "sleep 10"
+   $ powmon -a "sleep 10"
 
 The resulting data is written to two files:
 
 .. code:: bash
 
-    hostname.powmon.dat
-    hostname.powmon.summary
+   hostname.powmon.dat
+   hostname.powmon.summary
 
-Here, ``hostname`` will change based on the node where the monitoring is occurring.
-The ``summary`` file contains global information such as execution time.
-The ``dat`` file contains the time sampled data, such as power, thermals, and
-performance counters in a column-delimited format. The output differs on each
-platform based on available counters. Currently, Intel and IBM platforms are
-supported with ``powmon``.
+Here, ``hostname`` will change based on the node where the monitoring is
+occurring. The ``summary`` file contains global information such as execution
+time. The ``dat`` file contains the time sampled data, such as power, thermals,
+and performance counters in a column-delimited format. The output differs on
+each platform based on available counters. Currently, Intel and IBM platforms
+are supported with ``powmon``.
 
-Additionally, we provide two other tools, ``power_wrapper_static``, and ``power_wrapper_dynamic``
-that allow users to set a static (or dynamic) power cap and then monitor their
-binary application.
+Additionally, we provide two other tools, ``power_wrapper_static``, and
+``power_wrapper_dynamic`` that allow users to set a static (or dynamic) power
+cap and then monitor their binary application.
 
 The example below will set a package-level power limit of 100W on each socket,
 and then sample the power usage while executing a sleep for 10 seconds:
 
 .. code:: bash
 
-    $ power_wrapper_static -w 100 -a "sleep 10"
+   $ power_wrapper_static -w 100 -a "sleep 10"
 
 Similarly, the example below will set an initial package-level power limit of
 100W on each socket, sample the power usage, and then dynamically adjust the
@@ -55,4 +57,4 @@ power cap step-wise every 500ms while executing a sleep for 10 seconds:
 
 .. code:: bash
 
-    $ power_wrapper_dynamic -w 100 -a "sleep 10"
+   $ power_wrapper_dynamic -w 100 -a "sleep 10"

--- a/src/docs/sphinx/Publications.rst
+++ b/src/docs/sphinx/Publications.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -15,12 +16,15 @@
  Presentations
 ***************
 
-- Introduction to Variorum, ECP Tutorial Series 2021.
+-  Introduction to Variorum, ECP Tutorial Series 2021.
 
       -  :download:`Module 1 Slides
-         <_static/2021-ecp-tutorial-series/2021_Variorum_Module1_ECPLectureSeries.pdf>` | `Module 1 Recording <https://youtu.be/fAoXsOloqwU>`_
+         <_static/2021-ecp-tutorial-series/2021_Variorum_Module1_ECPLectureSeries.pdf>`
+         | `Module 1 Recording <https://youtu.be/fAoXsOloqwU>`_
+
       -  :download:`Module 2 Slides
-         <_static/2021-ecp-tutorial-series/2021_Variorum_Module2_ECPLectureSeries.pdf>` | `Module 2 Recording <https://youtu.be/mjmRc9Xnd1o>`_
+         <_static/2021-ecp-tutorial-series/2021_Variorum_Module2_ECPLectureSeries.pdf>`
+         | `Module 2 Recording <https://youtu.be/mjmRc9Xnd1o>`_
 
 -  Managing Power Efficiency of HPC Applications with Variorum and GEOPM, ECP
    2020 Tutorial, February 4, 2020, Houston, TX.

--- a/src/docs/sphinx/QuickStart.rst
+++ b/src/docs/sphinx/QuickStart.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -34,21 +35,22 @@ Details on using host configuration files can be found `here
 
 Please ensure that the dependencies for each platform are met before building
 Variorum. These include the kernel module ``msr-safe`` for Intel systems,
-``msr``, ``amd_energy_driver`` and HSMP driver for AMD sytems, OPAL firmware
-and sensors for IBM, and NVML for NVIDIA. Details of each of these can be found
-in the respective vendor pages, see :doc:`HWArchitectures`.
+``msr``, ``amd_energy_driver`` and HSMP driver for AMD sytems, OPAL firmware and
+sensors for IBM, and NVML for NVIDIA. Details of each of these can be found in
+the respective vendor pages, see :doc:`HWArchitectures`.
 
 For more details about building and installing Variorum, see
 :doc:`BuildingVariorum`, which provides detailed information about building
 Variorum for specific hosts, Variorum's other CMake options and installing with
 ``spack``.
 
-Function-level descriptions of Variorum's APIs as well as the architectures
-that have implementations in Variorum are provided in the following sections:
+Function-level descriptions of Variorum's APIs as well as the architectures that
+have implementations in Variorum are provided in the following sections:
 
-* :doc:`api/print_functions`
-* :doc:`api/cap_functions`
-* :doc:`api/json_support_functions`
-* :doc:`api/enable_disable_functions`
+-  :doc:`api/print_functions`
+-  :doc:`api/cap_functions`
+-  :doc:`api/json_support_functions`
+-  :doc:`api/enable_disable_functions`
 
-For beginners, the `ECP Variorum Lecture Series <https://www.exascaleproject.org/event/variorum-class-series/>`_ is beneficial.
+For beginners, the `ECP Variorum Lecture Series
+<https://www.exascaleproject.org/event/variorum-class-series/>`_ is beneficial.

--- a/src/docs/sphinx/Releases.rst
+++ b/src/docs/sphinx/Releases.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -17,7 +18,7 @@ as releases occur.
 
 04/02/2021: New release adds documentation for Nvidia port, adds units to the
 tabular and JSON output formats, and finishes renaming dump and print internal
-functions to print and print_verbose, respectively.  `v0.4.1 tarball here
+functions to print and print_verbose, respectively. `v0.4.1 tarball here
 <https://github.com/LLNL/variorum/archive/v0.4.1.tar.gz>`_.
 
 ********
@@ -26,8 +27,7 @@ functions to print and print_verbose, respectively.  `v0.4.1 tarball here
 
 03/03/2021: Updated version includes support for ARM Juno architecture,
 introduction of the JSON API, and Intel support for two versions of msr-safe.
-`v0.4.0 tarball here
-<https://github.com/LLNL/variorum/archive/v0.4.0.tar.gz>`_.
+`v0.4.0 tarball here <https://github.com/LLNL/variorum/archive/v0.4.0.tar.gz>`_.
 
 ********
  v0.3.0

--- a/src/docs/sphinx/Utilities.rst
+++ b/src/docs/sphinx/Utilities.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -50,9 +51,9 @@ From the top-level Variorum directory:
    -- Valid OPAL access
 
 Invoke the script with python on the target IBM system. The ``-v`` flag enables
-verbose output, which can be helpful if your programs are running to
-permissions issues. The output of this script is helpful to send to the mailing
-list for debugging system issues.
+verbose output, which can be helpful if your programs are running to permissions
+issues. The output of this script is helpful to send to the mailing list for
+debugging system issues.
 
 The last line of the output will (verbose or not) will indicate if the IBM OPAL
 files exist and have the appropriate permissions.
@@ -70,9 +71,9 @@ successfully.
 
 This utility will check if the stock msr kernel or the msr-safe kernel are
 loaded and configured correctly with the appropriate R/W permissions. It will
-first check if the msr kernel is loaded and has appropriate permissions. If
-this fails, then it will check if the msr-safe kernel is loaded and has
-appropriate permissions.
+first check if the msr kernel is loaded and has appropriate permissions. If this
+fails, then it will check if the msr-safe kernel is loaded and has appropriate
+permissions.
 
 How do I use it?
 ================
@@ -107,8 +108,8 @@ From the top-level Variorum directory:
    -- Check if msr_safe kernel files are accessible by user: /dev/cpu/msr_batch -- yes
    -- Valid kernel loaded: msr-safe
 
-Invoke the script with python on the target Intel system. The ``-v`` flag enables
-verbose output, which can be helpful if your programs are running to
+Invoke the script with python on the target Intel system. The ``-v`` flag
+enables verbose output, which can be helpful if your programs are running to
 permissions issues. The output of this script is helpful to send to the mailing
 list for debugging system issues.
 

--- a/src/docs/sphinx/VariorumAPI.rst
+++ b/src/docs/sphinx/VariorumAPI.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -8,92 +9,90 @@
 ##############
 
 Variorum supports vendor-neutral power and energy management through its rich
-API. Please refer to the top-level API, as well as the specific descritptions
-of the JSON API and the Best Effort Power Capping API. The JSON API allows
-system software interacting with Variorum to obtain data in a portable,
-vendor-neutral manner.
+API. Please refer to the top-level API, as well as the specific descritptions of
+the JSON API and the Best Effort Power Capping API. The JSON API allows system
+software interacting with Variorum to obtain data in a portable, vendor-neutral
+manner.
 
-*************
-Top-level API
-*************
+***************
+ Top-level API
+***************
 
 The top-level API for Variorum is in the ``variorum.h`` header file.
 Function-level descriptions as well as the architectures that have
 implementations in Variorum are described in the following sections:
 
-* :doc:`api/print_functions`
-* :doc:`api/cap_functions`
-* :doc:`api/json_support_functions`
-* :doc:`api/enable_disable_functions`
+-  :doc:`api/print_functions`
+-  :doc:`api/cap_functions`
+-  :doc:`api/json_support_functions`
+-  :doc:`api/enable_disable_functions`
 
 **********
  JSON API
 **********
 
 The current JSON API depends on the JANSSON-C library and has a vendor-neutral
-format. The API has been tested on Intel, IBM and ARM
-architectures, and can be used to easily integrate with Variorum (see :doc:`VariorumTools`).
+format. The API has been tested on Intel, IBM and ARM architectures, and can be
+used to easily integrate with Variorum (see :doc:`VariorumTools`).
 
 Obtaining Power Consumption
 ===========================
 
-The API to obtain node power has the following format. It takes
-a ``json_t`` object by reference as input, and populates this JSON object with
-CPU, memory, GPU (when available), and total node power. The total node power
-is estimated as a summation of available domains if it is not directly reported
-by the underlying architecture (such as Intel).
+The API to obtain node power has the following format. It takes a ``json_t``
+object by reference as input, and populates this JSON object with CPU, memory,
+GPU (when available), and total node power. The total node power is estimated as
+a summation of available domains if it is not directly reported by the
+underlying architecture (such as Intel).
 
-The ``variorum_get_node_power_json(json_t *)`` includes the JSON object with
-the following keys:
+The ``variorum_get_node_power_json(json_t *)`` includes the JSON object with the
+following keys:
 
-* hostname (string value)
-* timestamp (integer value)
-* power_node (real value)
-* power_cpu_watts_socket* (real value)
-* power_mem_watts_socket* (real value)
-* power_gpu_watts_socket* (real value)
+-  hostname (string value)
+-  timestamp (integer value)
+-  power_node (real value)
+-  power_cpu_watts_socket* (real value)
+-  power_mem_watts_socket* (real value)
+-  power_gpu_watts_socket* (real value)
 
 The "*" here refers to Socket ID. While more than one socket is supported, our
-test systems had only 2 sockets. Note that on IBM Witherspoon platform, only
-the first socket (Chip-0) has the PWRSYS sensor, which directly reports total
-node power. Both sockets here report CPU, Memory and GPU power. On Intel
-Broadwell, total node power is not reported by hardware, thus total node power
-is estimated by adding CPU and DRAM power on both sockets. For GPU power, IBM
-Witherspoon reports a single value, which is the sum of power consumed by all
-the GPUs on a particular socket. Our JSON object captures this with a
-``power_gpu_socket_*`` interface, and does not report individual GPU power in
-the JSON object (this data is however available separately without JSON). On
-Intel Broadwell, on our system without GPUs, this value is currently set to
--1.0 to indicate that the GPU power value cannot be measured directly through
-MSRs. This has been done to ensure that the JSON object in itself is
-vendor-neutral from a tools perspective. A future extension through NVML
-integration in the JSON object will allow for this information to report
-individual GPU power as well as total GPU power per socket with a
-cross-architectural build, similar to Variorum's ``variorum_get_node_power()``
-API.
-
+test systems had only 2 sockets. Note that on IBM Witherspoon platform, only the
+first socket (Chip-0) has the PWRSYS sensor, which directly reports total node
+power. Both sockets here report CPU, Memory and GPU power. On Intel Broadwell,
+total node power is not reported by hardware, thus total node power is estimated
+by adding CPU and DRAM power on both sockets. For GPU power, IBM Witherspoon
+reports a single value, which is the sum of power consumed by all the GPUs on a
+particular socket. Our JSON object captures this with a ``power_gpu_socket_*``
+interface, and does not report individual GPU power in the JSON object (this
+data is however available separately without JSON). On Intel Broadwell, on our
+system without GPUs, this value is currently set to -1.0 to indicate that the
+GPU power value cannot be measured directly through MSRs. This has been done to
+ensure that the JSON object in itself is vendor-neutral from a tools
+perspective. A future extension through NVML integration in the JSON object will
+allow for this information to report individual GPU power as well as total GPU
+power per socket with a cross-architectural build, similar to Variorum's
+``variorum_get_node_power()`` API.
 
 Querying Power Domains
 ======================
 
 The API for querying power domains allows users to query Variorum to obtain
 information about domains that can be measured and controlled on a certain
-architecture. It also includes information on the units of measurement
-and control, as well as information on the minimum and maximum values for
-setting the controls (control_range). If a certain domain is unsupported, it is
-marked as such.
+architecture. It also includes information on the units of measurement and
+control, as well as information on the minimum and maximum values for setting
+the controls (control_range). If a certain domain is unsupported, it is marked
+as such.
 
-The query API, ``variorum_get_node_power_domain_info_json(json_t *)``, accepts
-a JSON object by reference and  includes the following vendor-neutral keys:
+The query API, ``variorum_get_node_power_domain_info_json(json_t *)``, accepts a
+JSON object by reference and includes the following vendor-neutral keys:
 
-* hostname (string value)
-* timestamp (integer value)
-* measurement (comma-separated string value)
-* control (comma-separated string value)
-* unsupported (comma-separated string value)
-* measurement_units (comma-separated string value)
-* control_units (comma-separated string value)
-* control_range (comma-separated string value)
+-  hostname (string value)
+-  timestamp (integer value)
+-  measurement (comma-separated string value)
+-  control (comma-separated string value)
+-  unsupported (comma-separated string value)
+-  measurement_units (comma-separated string value)
+-  control_units (comma-separated string value)
+-  control_range (comma-separated string value)
 
 ***************************
  Best Effort Power Capping
@@ -107,13 +106,13 @@ power cap, a best-effort power cap is determined in software to provide an
 easier interface for higher-level tools (e.g. Flux, Kokkos, etc).
 
 For example, while IBM Witherspoon inherently provides the ability to set a
-node-level power cap in watts in hardware through its OPAL infrastructure,
-Intel architectures currently do not support a direct node level power cap
-through MSRs. Instead, on Intel architectures, fine-grained CPU and DRAM level
-power caps can be dialed in using MSRs. Note that IBM Witherspoon does not
-provide fine-grained capping for CPU and DRAM level, but allows for a
-power-shifting ratio between the CPU and GPU components on a socket (see `IBM
-documentation <https://variorum.readthedocs.io/en/latest/IBM.html>`_).
+node-level power cap in watts in hardware through its OPAL infrastructure, Intel
+architectures currently do not support a direct node level power cap through
+MSRs. Instead, on Intel architectures, fine-grained CPU and DRAM level power
+caps can be dialed in using MSRs. Note that IBM Witherspoon does not provide
+fine-grained capping for CPU and DRAM level, but allows for a power-shifting
+ratio between the CPU and GPU components on a socket (see `IBM documentation
+<https://variorum.readthedocs.io/en/latest/IBM.html>`_).
 
 Our API, ``variorum_cap_best_effort_node_power_limit()``, allows us to set a
 best effort power cap on Intel architectures by taking the input power cap

--- a/src/docs/sphinx/VariorumDevel.rst
+++ b/src/docs/sphinx/VariorumDevel.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -12,8 +13,8 @@ platforms and/or microarchitectures.
 
 A **platform** refers to a hardware vendor, for example, Intel, IBM, or ARM. A
 **microarchitecture** refers to a generation of hardware within a platform, for
-example, Broadwell or Ivy Bridge for Intel Xeon processors; or Power8 and
-Power9 for IBM Power processors.
+example, Broadwell or Ivy Bridge for Intel Xeon processors; or Power8 and Power9
+for IBM Power processors.
 
 ***********************************************
  Steps to Add Support for a New Platform (pfm)
@@ -22,11 +23,11 @@ Power9 for IBM Power processors.
 #. Create a new folder under ``src/variorum/pfm``
 
 #. Create a ``config_pfm.h`` and ``config_pfm.c``. These two files implement the
-   ``detect_pfm_arch`` and ``set_pfm_func_ptrs`` functions. The former identifies
-   the new platform, and the latter sets function pointers for get/set power,
-   thermals, etc. on the new platform. These function pointers refer to
-   internal functions that are defined in microarchitecture-specific files (see
-   next section).
+   ``detect_pfm_arch`` and ``set_pfm_func_ptrs`` functions. The former
+   identifies the new platform, and the latter sets function pointers for
+   get/set power, thermals, etc. on the new platform. These function pointers
+   refer to internal functions that are defined in microarchitecture-specific
+   files (see next section).
 
 #. Add a struct listing all the microarchitectures implemented on the new
    platform in ``src/variorum/config_architecture.c``. Refer to the enum for
@@ -44,28 +45,26 @@ Power9 for IBM Power processors.
 #. Follow the steps listed above to create a new platform if the platform does
    not already exist in the Variorum source.
 
-#. For each microarchitecture, add a ``pfm_arch.h`` and ``pfm_arch.c`` file, define
-   the internal get/set functions for capturing power, thermal, performance
-   data. These need to be added as function pointers in the platform file
-   (``config_pfm.h`` and ``config_pfm.c`` files).
+#. For each microarchitecture, add a ``pfm_arch.h`` and ``pfm_arch.c`` file,
+   define the internal get/set functions for capturing power, thermal,
+   performance data. These need to be added as function pointers in the platform
+   file (``config_pfm.h`` and ``config_pfm.c`` files).
 
 #. The internal implementation will depend on the interfaces, such as sensors,
    MSRs, OPAL, IPMI, etc. If applicable, these can be re-used across
    microarchitectures (i.e., the same implementation is used for many
    microarchitectures).
 
+*********
+ Example
+*********
 
-*******
-Example
-*******
-
-As an example, to support additional NVIDIA microarchitectures: 1. Under
-the ``Nvidia/`` directory, create a ``.h`` and ``.c`` header and source file for
-the respective microarchitecture. This will contain features specific to that
+As an example, to support additional NVIDIA microarchitectures: 1. Under the
+``Nvidia/`` directory, create a ``.h`` and ``.c`` header and source file for the
+respective microarchitecture. This will contain features specific to that
 microarchitecture, which may or may not exist in previous generations.
 
 2. Modify ``Nvidia/config_nvidia.c`` to set the function pointers for the
 respective microarchitecture.
 
 3. Include the new header file in ``Nvidia/config_architecture.h``.
-

--- a/src/docs/sphinx/VariorumTools.rst
+++ b/src/docs/sphinx/VariorumTools.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -9,48 +10,56 @@
 
 Variorum is a node-level library that can be integrated easily with higher-level
 system software such as schedulers and runtime systems, to create a portable
-`HPC PowerStack <https://variorum.readthedocs.io/en/latest/PowerStack.html>`_. As part of our efforts to support a hierarchical,
-dynamic and open-source portable power management stack, we have integrated Variorum
-with various open-source system software. The `JSON API <https://variorum.readthedocs.io/en/latest/VariorumAPI.html#json-api>`_ 
-enables Variorum to interface with higher-level system software in an portable and easy manner.
+`HPC PowerStack <https://variorum.readthedocs.io/en/latest/PowerStack.html>`_.
+As part of our efforts to support a hierarchical, dynamic and open-source
+portable power management stack, we have integrated Variorum with various
+open-source system software. The `JSON API
+<https://variorum.readthedocs.io/en/latest/VariorumAPI.html#json-api>`_ enables
+Variorum to interface with higher-level system software in an portable and easy
+manner.
 
-****************
-ECP Integrations
-****************
+******************
+ ECP Integrations
+******************
 
-Current integration efforts include a `Kokkos <https://kokkos.org>`_ connector 
-for power monitoring, a `Caliper <https://software.llnl.gov/Caliper/>`_ service 
-for method-level power data, and a `Flux <http://flux-framework.org>`_ power management 
-module for scheduling. Upcoming integration also includes developing a Variorum 
-interface for `PowerAPI <https://pwrapi.github.io>`_, `Intel's GEOPM <https://geopm.github.io>`_ and 
-`Sandia's OVIS Lightweight Distributed Metric Service (LDMS) <https://github.com/ovis-hpc/ovis-wiki/wiki>`_.
+Current integration efforts include a `Kokkos <https://kokkos.org>`_ connector
+for power monitoring, a `Caliper <https://software.llnl.gov/Caliper/>`_ service
+for method-level power data, and a `Flux <http://flux-framework.org>`_ power
+management module for scheduling. Upcoming integration also includes developing
+a Variorum interface for `PowerAPI <https://pwrapi.github.io>`_, `Intel's GEOPM
+<https://geopm.github.io>`_ and `Sandia's OVIS Lightweight Distributed Metric
+Service (LDMS) <https://github.com/ovis-hpc/ovis-wiki/wiki>`_.
 
-Links to Variorum's integrations with each of these frameworks can be found below. 
-Note that these integrations are in early development stages and are expected to
-be updated to support more features and tests.
+Links to Variorum's integrations with each of these frameworks can be found
+below. Note that these integrations are in early development stages and are
+expected to be updated to support more features and tests.
 
-   -  `Variorum Kokkos connector <https://github.com/kokkos/kokkos-tools/tree/develop/profiling/variorum-connector>`_
-   -  `Variorum Caliper service <https://github.com/LLNL/Caliper/tree/master/src/services/variorum>`_
-   -  `Flux System Power Manager Module with Variorum <https://github.com/flux-framework/flux-power-mgr>`_
+   -  `Variorum Kokkos connector
+      <https://github.com/kokkos/kokkos-tools/tree/develop/profiling/variorum-connector>`_
+   -  `Variorum Caliper service
+      <https://github.com/LLNL/Caliper/tree/master/src/services/variorum>`_
+   -  `Flux System Power Manager Module with Variorum
+      <https://github.com/flux-framework/flux-power-mgr>`_
 
-***********************************
-Contributing Integrations with JSON
-***********************************
+*************************************
+ Contributing Integrations with JSON
+*************************************
 
 In order for tools to interact with Variorum, a simple JANSSON based parser is
-sufficient. Our existing integration implementations, which are linked 
-`here <https://variorum.readthedocs.io/en/latest/VariorumTools.html#ecp-integrations>`_, 
-are a good starting point. 
+sufficient. Our existing integration implementations, which are linked `here
+<https://variorum.readthedocs.io/en/latest/VariorumTools.html#ecp-integrations>`_,
+are a good starting point.
 
-The format of the JSON object has been documented in :doc:`VariorumAPI` and includes
-total node power, as well as CPU, Memory, and GPU power (current assumption is
-that of two sockets per node). It also includes the hostname and the timestamp.
+The format of the JSON object has been documented in :doc:`VariorumAPI` and
+includes total node power, as well as CPU, Memory, and GPU power (current
+assumption is that of two sockets per node). It also includes the hostname and
+the timestamp.
 
 We describe a simple example of how the data from the JSON object can be
-extracted from Variorum in the client tool below, and we point developers to
-the Kokkos and Flux integration links shown above for more detailed examples.
-We have used the JANSSON library for our purposes, but the JSON object can also
-be retrieved in a similar manner by other JSON libraries and supporting tools.
+extracted from Variorum in the client tool below, and we point developers to the
+Kokkos and Flux integration links shown above for more detailed examples. We
+have used the JANSSON library for our purposes, but the JSON object can also be
+retrieved in a similar manner by other JSON libraries and supporting tools.
 
 .. code:: c
 

--- a/src/docs/sphinx/index.rst
+++ b/src/docs/sphinx/index.rst
@@ -1,4 +1,5 @@
-.. # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+..
+   # Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
    # Variorum Project Developers. See the top-level LICENSE file for details.
    #
    # SPDX-License-Identifier: MIT
@@ -9,21 +10,21 @@
 
 Variorum is an extensible, vendor-neutral library for exposing power and
 performance capabilities of low-level hardware knobs across diverse
-architectures in a user-friendly manner. It is part of the :doc:`Argo`, and is
-a key component for node-level power management in the :doc:`PowerStack`.
-Variorum provides vendor-neutral APIs such that the user can query or control
-hardware knobs without needing to know the underlying vendor's implementation
-(for example, model-specific registers or sensor interfaces). These APIs enable
+architectures in a user-friendly manner. It is part of the :doc:`Argo`, and is a
+key component for node-level power management in the :doc:`PowerStack`. Variorum
+provides vendor-neutral APIs such that the user can query or control hardware
+knobs without needing to know the underlying vendor's implementation (for
+example, model-specific registers or sensor interfaces). These APIs enable
 application developers to gain a better understanding of power, energy, and
 performance through various metrics. Additionally, the APIs may enable system
 software to control hardware knobs to optimize for a particular goal. Variorum
 focuses on ease of use and reduced integration burden in applications, which it
 accomplishes by providing:
 
--  Examples which demonstrate how to use Variorum in a stand-alone
-   program.
--  A performance analysis sampler that runs alongside the
-   application.
+-  Examples which demonstrate how to use Variorum in a stand-alone program.
+
+-  A performance analysis sampler that runs alongside the application.
+
 -  A JSON API to allow integration with higher-level system software, such as
    job schedulers, distributed monitoring frameworks, or application-level
    runtime systems.
@@ -32,18 +33,15 @@ accomplishes by providing:
  Variorum Project Resources
 ****************************
 
-**Online Documentation**
-https://variorum.readthedocs.io/
+**Online Documentation** https://variorum.readthedocs.io/
 
-**Github Source Repo**
-http://github.com/llnl/variorum
+**Github Source Repo** http://github.com/llnl/variorum
 
-**Issue Tracker**
-http://github.com/llnl/variorum/issues
+**Issue Tracker** http://github.com/llnl/variorum/issues
 
-****************
+*****************
  Lead Developers
-****************
+*****************
 
 -  Stephanie Brink (LLNL)
 -  Aniruddha Marathe (LLNL)
@@ -51,16 +49,21 @@ http://github.com/llnl/variorum/issues
 -  Barry Rountree (LLNL)
 -  Kathleen Shoga (LLNL)
 
-****************
-Code Of Conduct
-****************
+*****************
+ Code Of Conduct
+*****************
 
 See :doc:`CodeOfConduct`.
 
-****************
+*****************
  Acknowledgments
-****************
-This research was supported by the Exascale Computing Project (17-SC-20-SC), a joint project of the U.S. Department of Energy's Office of Science and National Nuclear Security Administration, responsible for delivering a capable exascale ecosystem, including software, applications, and hardware technology, to support the nation's exascale computing imperative.
+*****************
+
+This research was supported by the Exascale Computing Project (17-SC-20-SC), a
+joint project of the U.S. Department of Energy's Office of Science and National
+Nuclear Security Administration, responsible for delivering a capable exascale
+ecosystem, including software, applications, and hardware technology, to support
+the nation's exascale computing imperative.
 
 ************************
  Variorum Documentation
@@ -87,7 +90,7 @@ This research was supported by the Exascale Computing Project (17-SC-20-SC), a j
 .. toctree::
    :maxdepth: 2
    :caption: API Docs
-   
+
    api/print_functions
    api/cap_functions
    api/json_support_functions


### PR DESCRIPTION
# Description

Uses `rstfmt` to automatically format RST documentation files. Also adds a unit test for checking for RST code format compliance.

Fixes #262 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass with my changes