### PR TITLE
fix license header in butte host CPU config

### DIFF
--- a/host-configs/butte-4.14.0-ppc64le-gcc@4.9.3.cmake
+++ b/host-configs/butte-4.14.0-ppc64le-gcc@4.9.3.cmake
@@ -1,4 +1,4 @@
-#Copyright 2019-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
 # Variorum Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
# Description

Fixes license header in butte host config for the CPU to be compliant with license check script.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass with my changes