### PR TITLE
Update PR template to include rstfmt and black related checklist items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,9 @@ instructions so we can reproduce.
 
 # Checklist:
 
-- [ ] I have run `./scripts/check-code-format.sh` and confirm my code follows the style guidelines of variorum
+- [ ] I have run `./scripts/check-code-format.sh` and confirm my C code follows the style guidelines of variorum
+- [ ] I have run `black --check --diff` and confirm my python code follows the style guidelines of variorum
+- [ ] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
 - [ ] I have added comments in my code
 - [ ] My changes generate no new warnings
 - [ ] New and existing unit tests pass with my changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,8 +24,8 @@ instructions so we can reproduce.
 
 # Checklist:
 
-- [ ] I have run `./scripts/check-code-format.sh` and confirm my C code follows the style guidelines of variorum
-- [ ] I have run `black --check --diff` and confirm my python code follows the style guidelines of variorum
+- [ ] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
+- [ ] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
 - [ ] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
 - [ ] I have added comments in my code
 - [ ] My changes generate no new warnings


### PR DESCRIPTION
# Description

Updates the PR template to include an item to check for black and `check-rst-code.sh`.

Fixes #280 

## Type of change

- [x] Documentation update

# How Has This Been Tested?

N/A.

# Checklist:

N/A.

- [ ] I have run `./scripts/check-code-format.sh` and confirm my code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
