### PR TITLE
bump gcc version for quartz and catalyst host configs

### DIFF
--- a/host-configs/catalyst-toss_3_x86_64_ib-gcc@8.3.1.cmake
+++ b/host-configs/catalyst-toss_3_x86_64_ib-gcc@8.3.1.cmake
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: MIT
 
 # c compiler
-set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gcc" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc" CACHE PATH "")
 
 # cpp compiler
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/g++" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/g++" CACHE PATH "")
 
 # fortran compiler
-set(CMAKE_Fortran_COMPILER  "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER  "/usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran" CACHE PATH "")
 
 set(USE_MSR_SAFE_BEFORE_1_5_0 ON CACHE BOOL "")
 

--- a/host-configs/quartz-toss_3_x86_64_ib-gcc@8.3.1.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-gcc@8.3.1.cmake
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: MIT
 
 # c compiler
-set(CMAKE_C_COMPILER "gcc" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc" CACHE PATH "")
 
 # cpp compiler
-set(CMAKE_CXX_COMPILER "g++" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/g++" CACHE PATH "")
 
 # fortran compiler
-set(CMAKE_Fortran_COMPILER  "gfortran" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER  "/usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran" CACHE PATH "")
 
 set(USE_MSR_SAFE_BEFORE_1_5_0 ON CACHE BOOL "")
 


### PR DESCRIPTION
# Description

`BUILD_TESTS=ON` requires gcc>=5, this will allow GitLab CI tests to build successfully

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Build/CI update

# How Has This Been Tested?

- [x] Quartz with `-DBUILD_TESTS=ON`
- [x] Catalyst with `-DBUILD_TESTS=ON`

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [x] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [x] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass with my changes