### PR TITLE
Fix arm port warnings

### DIFF
--- a/src/variorum/ARM/ARM.c
+++ b/src/variorum/ARM/ARM.c
@@ -17,7 +17,8 @@
 
 int arm_get_power(int long_ver)
 {
-    int ret;
+    int ret = 0;
+
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
     {
@@ -25,12 +26,14 @@ int arm_get_power(int long_ver)
     }
 
     ret = get_power_data(long_ver, stdout);
+
     return ret;
 }
 
 int arm_get_thermals(int long_ver)
 {
-    int ret;
+    int ret = 0;
+
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
     {
@@ -38,70 +41,78 @@ int arm_get_thermals(int long_ver)
     }
 
     ret = get_thermal_data(long_ver, stdout);
+
     return ret;
 }
 
 int arm_get_clocks(int long_ver)
 {
+    int ret =0;
+    unsigned iter = 0;
+    unsigned nsockets;
+
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
     {
         printf("Running %s\n", __FUNCTION__);
     }
 
-    unsigned iter = 0;
-    unsigned nsockets;
-    int ret;
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
         ret = get_clocks_data(iter, long_ver, stdout);
     }
+
     return ret;
 }
 
 int arm_get_frequencies(void)
 {
+    int ret = 0;
+    unsigned iter = 0;
+    unsigned nsockets;
+
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
     {
         printf("Running %s\n", __FUNCTION__);
     }
 
-    unsigned iter = 0;
-    unsigned nsockets;
-    int ret;
     variorum_get_topology(&nsockets, NULL, NULL);
     for (iter = 0; iter < nsockets; iter++)
     {
         ret = get_frequencies(iter, stdout);
     }
+
     return ret;
 }
 
 int arm_cap_socket_frequency(int cpuid, int freq)
 {
+    int ret = 0;
+    unsigned nsockets;
+ 
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
     {
         printf("Running %s\n", __FUNCTION__);
     }
 
-    unsigned iter = 0;
-    unsigned nsockets;
     variorum_get_topology(&nsockets, NULL, NULL);
-    if (cpuid < 0 || cpuid >= nsockets)
+    if (cpuid < 0 || cpuid >= int(nsockets))
     {
         fprintf(stdout, "The specified CPU ID does not exist\n");
         return -1;
     }
-    int ret = cap_socket_frequency(cpuid, freq);
+    ret = cap_socket_frequency(cpuid, freq);
+
     return ret;
 }
 
 int arm_get_power_json(char **get_power_obj_str)
 {
-    int ret;
+    int ret = 0;
+
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
     {
@@ -120,7 +131,8 @@ int arm_get_power_json(char **get_power_obj_str)
 
 int arm_get_power_domain_info_json(char **get_domain_obj_str)
 {
-    int ret;
+    int ret = 0;
+
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
     {

--- a/src/variorum/ARM/ARM.c
+++ b/src/variorum/ARM/ARM.c
@@ -99,7 +99,7 @@ int arm_cap_socket_frequency(int cpuid, int freq)
     }
 
     variorum_get_topology(&nsockets, NULL, NULL);
-    if (cpuid < 0 || cpuid >= int(nsockets))
+    if (cpuid < 0 || cpuid >= (int)nsockets)
     {
         fprintf(stdout, "The specified CPU ID does not exist\n");
         return -1;

--- a/src/variorum/ARM/ARM.c
+++ b/src/variorum/ARM/ARM.c
@@ -47,7 +47,7 @@ int arm_get_thermals(int long_ver)
 
 int arm_get_clocks(int long_ver)
 {
-    int ret =0;
+    int ret = 0;
     unsigned iter = 0;
     unsigned nsockets;
 
@@ -91,7 +91,7 @@ int arm_cap_socket_frequency(int cpuid, int freq)
 {
     int ret = 0;
     unsigned nsockets;
- 
+
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
     {

--- a/src/variorum/ARM/power_features.c
+++ b/src/variorum/ARM/power_features.c
@@ -30,6 +30,8 @@ int read_file_ui64(const int file, uint64_t *val)
         return 0;
     }
     sscanf(buf, "%"SCNu64, val);
+
+    return bytes_read;
 }
 
 int write_file_ui64(const int file, uint64_t val)
@@ -41,14 +43,20 @@ int write_file_ui64(const int file, uint64_t val)
     {
         return 0;
     }
+
+    return bytes_written;
 }
 
 int read_array_ui64(const int fd, uint64_t **array)
 {
-    int num_freq = 0;
     int iter = 0;
     char buf[4096];
-    int rd = read(fd, buf, 4096);
+    int bytes_read = read(fd, buf, 4096);
+
+    if (bytes_read == 0)
+    {
+        return 0;
+    }
 
     int nfreq = 0;
     char *fptr = buf;
@@ -293,7 +301,6 @@ int get_clocks_data(int chipid, int verbose, FILE *output)
 
 int get_frequencies(int chipid, FILE *output)
 {
-    static int init_output = 0;
     char freq_fname[4096];
     char *freq_path = "/sys/devices/system/cpu/cpufreq/policy";
     int freq_fd;
@@ -334,8 +341,6 @@ int get_frequencies(int chipid, FILE *output)
 
 int cap_socket_frequency(int socketid, int new_freq)
 {
-    static int init_output = 0;
-    uint64_t freq_val;
     char freq_fname[4096];
     char *freq_path = "/sys/devices/system/cpu/cpufreq/policy";
     sprintf(freq_fname, "%s%d/scaling_setspeed", freq_path, socketid);
@@ -428,7 +433,7 @@ int json_get_power_data(json_t *get_power_obj)
        and GPU power exists only on socket 0.
        The value for m_num_package has been obtained in the init_arm() call. */
 
-    for (i = 0; i < m_num_package; i++)
+    for (i = 0; i < (int)m_num_package; i++)
     {
         char mem_str[36] = "power_mem_watts_socket_";
         char gpu_str[36] = "power_gpu_watts_socket_";


### PR DESCRIPTION
# Description

Fix warnings that came with ARM port with -DENABLE_WARNINGS=ON.

Fixes #309 

## Type of change

- [x] Internal update

# How Has This Been Tested?

- [x] Tested on Juno r2 node, works as expected. 

```
$ ./variorum-print-power-example 
_ARM_POWER Host Sys_mW Big_mW Little_mW GPU_mW
_ARM_POWER genericarmv8 800.44 605.55 82.72 90.78
_ARM_POWER genericarmv8 852.35 131.68 99.99 90.72


genericarmv8:/mnt/ssd/shared-patki1/variorum/build-juno/examples$ ./variorum-print-thermals-example 
_ARM_TEMPERATURE Host Sys_C Big_C Little_C GPU_C
_ARM_TEMPERATURE genericarmv8 32.85 22.71 24.00 24.65

genericarmv8:/mnt/ssd/shared-patki1/variorum/build-juno/examples$ ./variorum-print-gpu-utilization-example 
(null):/mnt/ssd/shared-patki1/variorum/src/variorum/variorum.c:variorum_print_gpu_utilization():689: _ERROR_VARIORUM_FEATURE_NOT_IMPLEMENTED: Feature not yet implemented or is not supported

genericarmv8:/mnt/ssd/shared-patki1/variorum/build-juno/examples$ ./variorum-print-verbose-frequency-example 
_ARM_CLOCKS Host: genericarmv8, CPU: Big, Socket: 0, Clock: 450 MHz
_ARM_CLOCKS Host: genericarmv8, CPU: Little, Socket: 1, Clock: 1200 MHz
_ARM_CLOCKS Host: genericarmv8, CPU: Big, Socket: 0, Clock: 450 MHz
_ARM_CLOCKS Host: genericarmv8, CPU: Little, Socket: 1, Clock: 1200 MHz

genericarmv8:/mnt/ssd/shared-patki1/variorum/build-juno/examples$ ./variorum-print-frequency-example         
_ARM_CLOCKS Host CPU Socket Clock_MHz
_ARM_CLOCKS genericarmv8 Big 0 450
_ARM_CLOCKS genericarmv8 Little 1 1200
```
# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [NA] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [ NA] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [NA] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
