### PR TITLE
replace #if defined with #ifdef

### DIFF
--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -143,17 +143,17 @@ int variorum_detect_arch(void)
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
     {
-#if defined(VARIORUM_WITH_INTEL)
+#ifdef VARIORUM_WITH_INTEL
         printf("Intel Model: 0x%lx\n", *g_platform.intel_arch);
 #endif
-#if defined(VARIORUM_WITH_IBM)
+#ifdef VARIORUM_WITH_IBM
         printf("IBM Model: 0x%lx\n", *g_platform.ibm_arch);
 #endif
-#if defined(VARIORUM_WITH_AMD)
+#ifdef VARIORUM_WITH_AMD
         printf("AMD Family: 0x%lx, Model: 0x%lx\n",
                (*g_platform.amd_arch >> 8) & 0xFF, *g_platform.amd_arch & 0xFF);
 #endif
-#if defined(VARIORUM_WITH_AMD_GPU)
+#ifdef VARIORUM_WITH_AMD_GPU
         printf("AMD GPU Model: MI-%ld\n", *g_platform.amd_gpu_arch);
 #endif
     }


### PR DESCRIPTION
# Description

Replace last of `#if defined()` with `#ifdef`. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update
- [x] Internal update

## How Has This Been Tested?

- [x] Catalyst (Sandy Bridge)
- [x] Lassen (CPU-only)
- [x] Comus (Broadwell)
- [x] Thompson (Haswell)
- [x] Alehouse (Power9)
- [x] Rhetoric (Skylake, single socket)
- [x] ARM Juno r2
- [x] Corona AMD GPU
- [x] Lassen (GPU-only)

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [x] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [x] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes