### PR TITLE
docs: add missing 0.5.0 release

### DIFF
--- a/src/docs/sphinx/Releases.rst
+++ b/src/docs/sphinx/Releases.rst
@@ -15,11 +15,11 @@ branch, which contains our latest features.
  v0.5.0
 ********
 
-06/22/2022: Major release adds support for new architectures, AMD CPUs and Intel Ice Lake CPU,
-adds examples for integrating Variorum into OpenMP and MPI programs, adds
-dependency on rankstr library for MPI examples (optional), renames clock_speed
-to frequency and power_limits to power_limit throughout Variorum API,
-deprecates set_and_verify API. `v0.5.0 tarball here
+06/22/2022: Major release adds support for new architectures, AMD CPUs and Intel
+Ice Lake CPU, adds examples for integrating Variorum into OpenMP and MPI
+programs, adds dependency on rankstr library for MPI examples (optional),
+renames clock_speed to frequency and power_limits to power_limit throughout
+Variorum API, deprecates set_and_verify API. `v0.5.0 tarball here
 <https://github.com/LLNL/variorum/archive/v0.5.0.tar.gz>`_.
 
 ********

--- a/src/docs/sphinx/Releases.rst
+++ b/src/docs/sphinx/Releases.rst
@@ -9,8 +9,18 @@
 ##########
 
 Variorum is under constant development. So, we recommend using our ``dev``
-branch, which contains our latest features. The ``main`` branch will be updated
-as releases occur.
+branch, which contains our latest features.
+
+********
+ v0.5.0
+********
+
+06/22/2022: Major release adds support for new architectures, AMD CPUs and Intel Ice Lake CPU,
+adds examples for integrating Variorum into OpenMP and MPI programs, adds
+dependency on rankstr library for MPI examples (optional), renames clock_speed
+to frequency and power_limits to power_limit throughout Variorum API,
+deprecates set_and_verify API. `v0.5.0 tarball here
+<https://github.com/LLNL/variorum/archive/v0.5.0.tar.gz>`_.
 
 ********
  v0.4.1


### PR DESCRIPTION
# Description

Adds note about 0.5.0 release to Releases page on RTD.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Build/CI update

# Checklist:

- [x] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum