### PR TITLE
bugfix: fix Intel DRAM overflow issue

### DIFF
--- a/src/variorum/Intel/intel_power_features.c
+++ b/src/variorum/Intel/intel_power_features.c
@@ -1061,12 +1061,13 @@ int delta_rapl_data(off_t msr_rapl_unit)
         if ((double)*rapl->dram_bits[i] - (double)rapl->old_dram_bits[i] < 0)
         {
             rapl->dram_delta_bits[i] = (uint64_t)((*rapl->dram_bits[i] +
-                                                  (uint64_t)max_joules) - rapl->old_dram_bits[i]);
+                                                   (uint64_t)max_joules) - rapl->old_dram_bits[i]);
             translate(i, &rapl->dram_delta_bits[i], &rapl->dram_delta_joules[i],
                       BITS_TO_JOULES, msr_rapl_unit);
 #ifdef VARIORUM_DEBUG
-            fprintf(stderr, "OVF dram%d new=0x%lx old=0x%lx -> %lf\n", i, *rapl->dram_bits[i],
-                    rapl->old_dram_bits[i], rapl->dram_delta_joules[i]);
+            fprintf(stderr, "OVF dram%d new=0x%lx old=0x%lx -> %lf\n", i,
+                    *rapl->dram_bits[i], rapl->old_dram_bits[i],
+                    rapl->dram_delta_joules[i]);
 #endif
         }
         else

--- a/src/variorum/Intel/intel_power_features.c
+++ b/src/variorum/Intel/intel_power_features.c
@@ -324,15 +324,16 @@ static void create_rapl_data_batch(struct rapl_data *rapl,
     rapl->old_pkg_bits = (uint64_t *) calloc(nsockets, sizeof(uint64_t));
     rapl->old_pkg_joules = (double *) calloc(nsockets, sizeof(double));
     rapl->pkg_delta_joules = (double *) calloc(nsockets, sizeof(double));
-    rapl->pkg_delta_bits = (uint64_t *) calloc(nsockets, sizeof(double));
+    rapl->pkg_delta_bits = (uint64_t *) calloc(nsockets, sizeof(uint64_t));
     rapl->pkg_watts = (double *) calloc(nsockets, sizeof(double));
     load_socket_batch(msr_pkg_energy_status, rapl->pkg_bits, RAPL_DATA);
 
     rapl->dram_bits = (uint64_t **) calloc(nsockets, sizeof(uint64_t *));
-    rapl->old_dram_bits = (uint64_t *) calloc(nsockets, sizeof(uint64_t));
     rapl->dram_joules = (double *) calloc(nsockets, sizeof(double));
+    rapl->old_dram_bits = (uint64_t *) calloc(nsockets, sizeof(uint64_t));
     rapl->old_dram_joules = (double *) calloc(nsockets, sizeof(double));
     rapl->dram_delta_joules = (double *) calloc(nsockets, sizeof(double));
+    rapl->dram_delta_bits = (uint64_t *) calloc(nsockets, sizeof(uint64_t));
     rapl->dram_watts = (double *) calloc(nsockets, sizeof(double));
     load_socket_batch(msr_dram_energy_status, rapl->dram_bits, RAPL_DATA);
 
@@ -1057,7 +1058,7 @@ int delta_rapl_data(off_t msr_rapl_unit)
         }
 
         /* Check to see if there was wraparound and use corresponding translation. */
-        if ((double)*rapl->dram_bits[i] - (double)rapl->dram_pkg_bits[i] < 0)
+        if ((double)*rapl->dram_bits[i] - (double)rapl->old_dram_bits[i] < 0)
         {
             rapl->dram_delta_bits[i] = (uint64_t)((*rapl->dram_bits[i] +
                                                   (uint64_t)max_joules) - rapl->old_dram_bits[i]);

--- a/src/variorum/Intel/intel_power_features.c
+++ b/src/variorum/Intel/intel_power_features.c
@@ -1062,8 +1062,10 @@ int delta_rapl_data(off_t msr_rapl_unit)
         {
             rapl->dram_delta_bits[i] = (uint64_t)((*rapl->dram_bits[i] +
                                                    (uint64_t)max_joules) - rapl->old_dram_bits[i]);
+#ifdef VARIORUM_WITH_INTEL_CPU
             translate(i, &rapl->dram_delta_bits[i], &rapl->dram_delta_joules[i],
-                      BITS_TO_JOULES, msr_rapl_unit);
+                      BITS_TO_JOULES, msr_rapl_unit, P_INTEL_CPU_IDX);
+#endif
 #ifdef VARIORUM_DEBUG
             fprintf(stderr, "OVF dram%d new=0x%lx old=0x%lx -> %lf\n", i,
                     *rapl->dram_bits[i], rapl->old_dram_bits[i],

--- a/src/variorum/Intel/intel_power_features.h
+++ b/src/variorum/Intel/intel_power_features.h
@@ -159,6 +159,7 @@ struct rapl_data
     double *old_dram_joules;
     /// @brief Difference in DRAM energy usage between two data measurements.
     double *dram_delta_joules;
+    uint64_t *dram_delta_bits;
     /// @brief DRAM power consumption (in Watts) derived by dividing difference
     /// in DRAM energy usage by time elapsed between data measurements.
     double *dram_watts;


### PR DESCRIPTION
# Description

This patch fixes an overflow problem with Intel's DRAM energy register. Code now checks if the difference in the raw bits is negative, instead of the difference in the joule value.

This still needs testing on a long running application to confirm the problem is resolved. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

- [ ] Comus, spin loop

# Checklist:

- [ ] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [ ] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [ ] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [ ] I have added comments in my code
- [ ] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [ ] New and existing unit tests pass with my changes