### PR TITLE
fix path to gcc on corona

### DIFF
--- a/host-configs/corona-4.18.0toss-x86_64-gcc@10.3.1-rocm@5.2.cmake
+++ b/host-configs/corona-4.18.0toss-x86_64-gcc@10.3.1-rocm@5.2.cmake
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: MIT
 
 # c compiler
-set(CMAKE_C_COMPILER "/usr/tce/packages/gcc-tce/gcc-10.2.1/bin/gcc" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gcc" CACHE PATH "")
 
 # cpp compiler
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc-tce/gcc-10.2.1/bin/g++" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc-tce/gcc-10.3.1/bin/g++" CACHE PATH "")
 
 # fortran compiler
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc-tce/gcc-10.2.1/bin/gfortran" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gfortran" CACHE PATH "")
 
 set(ENABLE_MPI OFF CACHE BOOL "")
 set(ENABLE_OPENMP OFF CACHE BOOL "")


### PR DESCRIPTION
# Description

Fixes path to gcc binaries in corona host-config. File named appropriately, but gcc 10.2.1 no longer exists.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Build/CI update

# How Has This Been Tested?

- [x] Corona

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [x] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [x] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes
