### PR TITLE
add cztb2 runner to gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -260,3 +260,14 @@ build-corona:
    - echo -e "PWD:" ${PWD}
    - make VERBOSE=1 FFLAGS+=-fallow-invalid-boz
    - ./ep.W.x
+
+# build across power lab
+build-cztb2:
+ tags:
+   - shell
+   - cztb2
+ stage: build
+ script:
+   - git clone $VARIORUM_ANSIBLE
+   - cd variorum-ansible-setup
+   - ansible-playbook variorum-powerlab-playbook.yml


### PR DESCRIPTION
# Description

Adds cztb2 runner to gitlab CI pipeline.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Build/CI update

# How Has This Been Tested?

- [x] cztb2

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [x] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [x] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes
