### PR TITLE
Fix AMD build errors: add missing headers, undefined variables, etc.

### DIFF
--- a/src/variorum/AMD/energy_feature.c
+++ b/src/variorum/AMD/energy_feature.c
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -531,9 +531,10 @@ int epyc_get_node_power_json(char **get_power_obj_str)
     /* AMD authors declared this as uint32_t and typecast it to double,
      * not sure why. Just following their lead from the get_power function*/
     uint32_t current_power;
-    double node_power;
-    int i, ret =0;
-    int sockID;
+    double node_power = 0.0;
+    int i, ret = 0;
+    int sockID_len = 12;
+    char sockID[sockID_len];
     json_t *get_power_obj = json_object();
 
     gethostname(hostname, 1024);
@@ -548,7 +549,7 @@ int epyc_get_node_power_json(char **get_power_obj_str)
         char mem_str[36] = "power_mem_watts_socket_";
         char gpu_str[36] = "power_gpu_watts_socket_";
 
-        snprintf(sockID, "%d", i);
+        snprintf(sockID, sockID_len, "%d", i);
         strcat(cpu_str, sockID);
         strcat(mem_str, sockID);
         strcat(gpu_str, sockID);
@@ -575,7 +576,7 @@ int epyc_get_node_power_json(char **get_power_obj_str)
         // memory power yet.
         json_object_set_new(get_power_obj, mem_str, json_real(-1.0));
 
-        node_power += (double)current_power / 1000;
+        node_power += ((double)current_power / 1000);
     }
 
     // Set the node power key with pwrnode value.
@@ -607,7 +608,10 @@ int epyc_get_node_power_domain_info_json(char **get_domain_obj_str)
     //Assuming minimum is 50 W.
     ret = esmi_socket_power_cap_max_get(0, &max_power);
 
-    snprintf(range_str, sizeof range_str, "%s%d",
+    // Convert to Watts
+    max_power = max_power / 1000;
+
+    snprintf(range_str, sizeof range_str, "%s%d%s%d%s",
              "[{min: ", 50,
              ", max: ", max_power, "}]");
 

--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/time.h>
 
@@ -530,6 +531,9 @@ int epyc_get_node_power_json(char **get_power_obj_str)
     /* AMD authors declared this as uint32_t and typecast it to double,
      * not sure why. Just following their lead from the get_power function*/
     uint32_t current_power;
+    double node_power;
+    int i, ret =0;
+    int sockID;
     json_t *get_power_obj = json_object();
 
     gethostname(hostname, 1024);
@@ -544,7 +548,7 @@ int epyc_get_node_power_json(char **get_power_obj_str)
         char mem_str[36] = "power_mem_watts_socket_";
         char gpu_str[36] = "power_gpu_watts_socket_";
 
-        snprintf(sockID, sockID_len, "%d", i);
+        snprintf(sockID, "%d", i);
         strcat(cpu_str, sockID);
         strcat(mem_str, sockID);
         strcat(gpu_str, sockID);
@@ -560,7 +564,7 @@ int epyc_get_node_power_json(char **get_power_obj_str)
         else
         {
             json_object_set_new(get_power_obj, cpu_str,
-                                json_real((double)current_power / 1000);
+                                json_real((double)current_power / 1000));
         }
 
         // GPU power set to -1.0 for vendor neutrality and first cut, as we


### PR DESCRIPTION
# Description

Fixes AMD CPU build errors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please provide hardware architecture specs and
instructions so we can reproduce.

- [x] Tioga, AMD Trento

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [x] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [x] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes
