### PR TITLE
Fix issues coming up with DENABLE_WARNINGS=On on AMD CPU port

### DIFF
--- a/src/variorum/AMD/energy_feature.c
+++ b/src/variorum/AMD/energy_feature.c
@@ -60,7 +60,7 @@ static int rapl_storage(struct rapl_data **data)
     return 0;
 }
 
-static int read_rapl_data(off_t msr_rapl_unit, off_t msr_core_energy_status)
+static int read_rapl_data(off_t msr_core_energy_status)
 {
     static struct rapl_data *rapl = NULL;
     static int init = 0;
@@ -127,7 +127,7 @@ int print_energy_data(FILE *writedest, off_t msr_rapl_unit,
 
     variorum_get_topology(NULL, &ncores, NULL);
 
-    read_rapl_data(msr_rapl_unit, msr_core_energy_status);
+    read_rapl_data(msr_core_energy_status);
 
     if (!init)
     {

--- a/src/variorum/AMD/energy_feature.c
+++ b/src/variorum/AMD/energy_feature.c
@@ -18,7 +18,7 @@
 static void create_rapl_data_batch(struct rapl_data *rapl,
                                    off_t msr_core_energy_status)
 {
-    int ncores;
+    unsigned ncores;
     variorum_get_topology(NULL, &ncores, NULL);
 
     allocate_batch(RAPL_DATA, 2UL * ncores);
@@ -31,7 +31,7 @@ static void create_rapl_data_batch(struct rapl_data *rapl,
 static int rapl_storage(struct rapl_data **data)
 {
     static struct rapl_data *rapl = NULL;
-    static int ncores = 0;
+    static unsigned ncores = 0;
     static int init = 0;
 
     if (!init)
@@ -64,7 +64,7 @@ static int read_rapl_data(off_t msr_rapl_unit, off_t msr_core_energy_status)
 {
     static struct rapl_data *rapl = NULL;
     static int init = 0;
-    static int ncores = 0;
+    static unsigned ncores = 0;
     int i;
 
     if (!init)
@@ -75,7 +75,7 @@ static int read_rapl_data(off_t msr_rapl_unit, off_t msr_core_energy_status)
             return -1;
         }
         create_rapl_data_batch(rapl, msr_core_energy_status);
-        for (i = 0; i < ncores; i++)
+        for (i = 0; i < (int)ncores; i++)
         {
             rapl->core_joules[i] = 0;
         }
@@ -111,8 +111,11 @@ int print_energy_data(FILE *writedest, off_t msr_rapl_unit,
 {
     static struct rapl_data *rapl = NULL;
     static int init = 0;
-    int ncores = 0;
-    char hostname[1024];
+    unsigned ncores = 0;
+    // TODO: We can't test this API yet due to privile issues. We need to
+    // update the printing format here to include hostname and prefix
+    // _AMDENERGY once we have ability to test.
+    // char hostname[1024];
     int i, batchfd;
     double val;
 
@@ -134,10 +137,10 @@ int print_energy_data(FILE *writedest, off_t msr_rapl_unit,
 
     get_rapl_unit(msr_rapl_unit, &val);
 
-    fprintf(stdout, " Core   | Energy (J)   |\n");
-    for (i = 0; i < ncores; i++)
+    fprintf(writedest, " Core   | Energy (J)   |\n");
+    for (i = 0; i < (int)ncores; i++)
     {
-        fprintf(stdout, "%6d  | %10f  |\n", i, (*rapl->core_bits[i]) * val);
+        fprintf(writedest, "%6d  | %10f  |\n", i, (*rapl->core_bits[i]) * val);
     }
     return 0;
 }

--- a/src/variorum/AMD/energy_feature.c
+++ b/src/variorum/AMD/energy_feature.c
@@ -112,7 +112,7 @@ int print_energy_data(FILE *writedest, off_t msr_rapl_unit,
     static struct rapl_data *rapl = NULL;
     static int init = 0;
     unsigned ncores = 0;
-    // TODO: We can't test this API yet due to privile issues. We need to
+    // TODO: We can't test this API yet due to privilege issues. We need to
     // update the printing format here to include hostname and prefix
     // _AMDENERGY once we have ability to test.
     // char hostname[1024];

--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -189,7 +189,7 @@ int epyc_set_and_verify_best_effort_node_power_limit(int pcap_new)
     {
         pcap_test = 0;
         ret = esmi_socket_power_cap_max_get(i, &max_power);
-        if ((ret == 0) && (pcap_new > max_power))
+        if ((ret == 0) && (pcap_new > (int)max_power))
         {
             printf("Input power is more than max limit,"
                    " So sets to default max %.3f Watts\n\n",
@@ -225,7 +225,7 @@ int epyc_set_and_verify_best_effort_node_power_limit(int pcap_new)
                 (double)pcap_new / 1000, (double)pcap_test / 1000);
 #endif
 
-        if (pcap_new != pcap_test)
+        if (pcap_new != (int)pcap_test)
         {
             fprintf(stdout, "Could not verify if the power cap "
                     "was set correctly.\n");
@@ -261,7 +261,7 @@ int epyc_set_socket_power_limit(int pcap_new)
     for (i = 0; i < g_platform.num_sockets; i++)
     {
         ret = esmi_socket_power_cap_max_get(i, &max_power);
-        if ((ret == 0) && (pcap_new > max_power))
+        if ((ret == 0) && (pcap_new > (int)max_power))
         {
             printf("Input power is more than max limit,"
                    " So sets to default max %.3f Watts\n\n",
@@ -396,7 +396,6 @@ int epyc_set_each_core_boostlimit(int boostlimit)
     }
 
     int i, ret;
-    uint32_t core_boost_lim = 0;
 
     for (i = 0; i < g_platform.total_cores; i++)
     {
@@ -492,8 +491,6 @@ int epyc_set_socket_boostlimit(int socket, int boostlimit)
         printf("Running %s with value %u\n\n", __FUNCTION__, boostlimit);
     }
     int ret;
-    uint32_t blimit = 0;
-    uint32_t online_core;
 
     ret = esmi_socket_boostlimit_set(socket, boostlimit);
     if (ret != 0)
@@ -524,7 +521,6 @@ int epyc_get_node_power_json(char **get_power_obj_str)
     {
         printf("Running %s\n", __FUNCTION__);
     }
-    unsigned nsockets;
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
@@ -607,7 +603,12 @@ int epyc_get_node_power_domain_info_json(char **get_domain_obj_str)
     //E-SMI doesn't expose minimum yet, something we need AMD to help with.
     //Assuming minimum is 50 W.
     ret = esmi_socket_power_cap_max_get(0, &max_power);
-
+    if (ret != 0)
+    {
+        fprintf(stdout, "Failed to get maximum socket power, "
+                "Err[%d]:%s\n", ret, esmi_get_err_msg(ret));
+        return ret;
+    }
     // Convert to Watts
     max_power = max_power / 1000;
 

--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -603,6 +603,7 @@ int epyc_get_node_power_domain_info_json(char **get_domain_obj_str)
     //E-SMI doesn't expose minimum yet, something we need AMD to help with.
     //Assuming minimum is 50 W.
     ret = esmi_socket_power_cap_max_get(0, &max_power);
+
     if (ret != 0)
     {
         fprintf(stdout, "Failed to get maximum socket power, "


### PR DESCRIPTION
# Description

Fix signed/unsigned comparison errors, and few other issues that came up with `-DENABLE_WARNINGS=On` on the AMD CPU port. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested on Tioga

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [ ] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [ ] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
