### PR TITLE
Checks for minimum g++ version for googletests.

### DIFF
--- a/src/CMake/Setup3rdParty.cmake
+++ b/src/CMake/Setup3rdParty.cmake
@@ -33,6 +33,14 @@ if(BUILD_TESTS)
     # Enable GTest
     ################################
 
+    # g++ v4.9.3 no longer compiles googletest.
+    # g++ v6.1.0 and later are known to work.
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.1)
+            message(FATAL_ERROR "Minimum GNU g++ version is 6.1.0, found ${CMAKE_CXX_COMPILER_VERSION}")
+        endif()
+    endif()
+
     #
     # We always want to build gtest as a static lib, however
     # it shares our "BUILD_SHARED_LIBS" option, so we need


### PR DESCRIPTION
# Description

Out-of-box compilation in the LC environment fails due to gcc-4.9.3 still (!) being the default c++ compiler.  Googletests no longer works with this version of g++.  gcc-6.1.0 works fine.

This PR adds a minimum gcc version test to the Setup3rdParty.cmake file.

Fixes #357 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Build/CI update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please provide hardware architecture specs and
instructions so we can reproduce.

Tested on cztb2 at LLNL against gcc v4.9.3, v6.1.0 and v10.2.1

# Checklist:

- [n/a] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [n/a] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [n/a] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [n/a] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
