### PR TITLE
refactor formatting scripts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,9 +24,7 @@ instructions so we can reproduce.
 
 # Checklist:
 
-- [ ] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
-- [ ] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
-- [ ] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
+- [ ] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
 - [ ] I have added comments in my code
 - [ ] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
 - [ ] New and existing unit tests pass with my changes

--- a/scripts/check-code-format.sh
+++ b/scripts/check-code-format.sh
@@ -8,30 +8,43 @@
 # check format for all *.cpp, *.h, and *.c files in src/ directory
 #   exclude files in thirdparty_builtin/ (gtest source files)
 #   exclude files in fortran/ (EP source files)
-FILES=$(find src -type f  \( -name "*.[ch]" -o -name *.cpp \) \
-        | grep -v thirdparty_builtin \
-        | grep -v fortran)
+function check_format_files_cpp_c_h {
+    if ! command -v astyle &> /dev/null; then
+        echo -e "'astyle' not found: see https://astyle.sourceforge.net/ for installation info"
+        exit
+    fi
+    echo -e "Checking format of cpp/c/h files using astyle"
 
-astyle --errors-to-stdout \
-       --preserve-date \
-       --style=allman \
-       --indent=spaces=4 \
-       --convert-tabs \
-       --attach-extern-c \
-       --indent-col1-comments \
-       --min-conditional-indent=0 \
-       --max-instatement-indent=40 \
-       --pad-oper \
-       --pad-header \
-       --unpad-paren \
-       --align-pointer=name \
-       --align-reference=name \
-       --break-closing-brackets \
-       --keep-one-line-blocks \
-       --keep-one-line-statements \
-       --max-code-length=80 \
-       --break-after-logical \
-       --indent-switches \
-       ${FILES}
+    ./scripts/check-cpp-c-format.sh
+}
+
+function check_format_files_rst {
+    if ! command -v rstfmt &> /dev/null; then
+        echo -e "'rstfmt' not found: this package can be installed using pip"
+        exit
+    fi
+    echo -e "Checking format of rst documentation using rstfmt"
+
+    ./scripts/check-rst-format.sh
+}
+
+function check_format_files_python {
+    if ! command -v flake8 &> /dev/null; then
+        echo -e "'flake8' not found: this package can be installed using pip"
+        exit
+    fi
+    if ! command -v black &> /dev/null; then
+        echo -e "'black' not found: this package can be installed using pip"
+        exit
+    fi
+    echo -e "Checking format of python files using flake and black"
+
+    flake8
+    black --diff --check --exclude "/(src/thirdparty_builtin/googletest|build|src/docs)/" .
+}
+
+check_format_files_cpp_c_h
+check_format_files_rst
+check_format_files_python
 
 #

--- a/scripts/check-cpp-c-format.sh
+++ b/scripts/check-cpp-c-format.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+# Variorum Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+# check format for all *.cpp, *.h, and *.c files in src/ directory
+#   exclude files in thirdparty_builtin/ (gtest source files)
+#   exclude files in fortran/ (EP source files)
+FILES=$(find src -type f  \( -name "*.[ch]" -o -name *.cpp \) \
+        | grep -v thirdparty_builtin \
+        | grep -v fortran)
+
+astyle --errors-to-stdout \
+       --preserve-date \
+       --style=allman \
+       --indent=spaces=4 \
+       --convert-tabs \
+       --attach-extern-c \
+       --indent-col1-comments \
+       --min-conditional-indent=0 \
+       --max-instatement-indent=40 \
+       --pad-oper \
+       --pad-header \
+       --unpad-paren \
+       --align-pointer=name \
+       --align-reference=name \
+       --break-closing-brackets \
+       --keep-one-line-blocks \
+       --keep-one-line-statements \
+       --max-code-length=80 \
+       --break-after-logical \
+       --indent-switches \
+       --formatted \
+       ${FILES}
+
+#


### PR DESCRIPTION
# Description

Refactors formatting scripts used to check code formatting in CI tests. Previously this was 3 different steps to check (1) cpp/c files, (2) rst files, and (3) python files, this PR proposes a single top-level script that calls these checks automatically. Additionally, we check for astyle, rstfmt, and flake8/black binaries.

- update PR template checklist
- create new top-level script to launch checks for cpp/c, rst, and python files

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Build/CI update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please provide hardware architecture specs and
instructions so we can reproduce.

- [ ] Test A: Hardware architecture, machine name, example/test run
- [ ] Test B: Hardware architecture, machine name, example/test run
- [ ] ...

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [x] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [x] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes