### PR TITLE
JSON API for GPU power telemetry

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -17,6 +17,7 @@ set(BASIC_EXAMPLES
     variorum-disable-turbo-example
     variorum-enable-turbo-example
     variorum-get-node-power-json-example
+    variorum-get-gpu-power-json-example
     variorum-get-node-power-domain-info-json-example
     variorum-integration-using-json-example
     variorum-get-topology-info-example

--- a/src/examples/variorum-get-gpu-power-json-example.c
+++ b/src/examples/variorum-get-gpu-power-json-example.c
@@ -1,0 +1,50 @@
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <variorum.h>
+
+int main(int argc, char **argv)
+{
+    int ret;
+    char *s = NULL;
+
+    const char *usage = "Usage: %s [-h] [-v]\n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
+                return 0;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
+
+    ret = variorum_get_gpu_power_json(&s);
+    if (ret != 0)
+    {
+        printf("JSON get GPU  power failed!\n");
+        free(s);
+        exit(-1);
+    }
+
+    /* Print the entire JSON object */
+    puts(s);
+
+    /* Deallocate the string */
+    free(s);
+
+    return ret;
+}

--- a/src/variorum/AMD_GPU/instinctGPU.c
+++ b/src/variorum/AMD_GPU/instinctGPU.c
@@ -142,3 +142,21 @@ int amd_gpu_instinct_cap_each_gpu_power_limit(unsigned int powerlimit)
     }
     return 0;
 }
+
+int amd_gpu_instinct_get_power_json(char **get_power_obj_str)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    json_t *get_power_obj = json_object();
+
+    amd_gpu_get_json_power_data(get_power_obj);
+
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
+
+    return 0;
+}

--- a/src/variorum/AMD_GPU/instinctGPU.h
+++ b/src/variorum/AMD_GPU/instinctGPU.h
@@ -12,5 +12,6 @@ int amd_gpu_instinct_get_thermals(int verbose);
 int amd_gpu_instinct_get_clocks(int verbose);
 int amd_gpu_instinct_get_gpu_utilization(int verbose);
 int amd_gpu_instinct_cap_each_gpu_power_limit(unsigned int powerlimit);
+int amd_gpu_instinct_get_power_json(char **get_power_obj_str);
 
 #endif

--- a/src/variorum/Nvidia_GPU/Volta.c
+++ b/src/variorum/Nvidia_GPU/Volta.c
@@ -132,7 +132,7 @@ int volta_cap_each_gpu_power_limit(unsigned int powerlimit)
     return 0;
 }
 
-int volta_get_power_json(char **get_power_obj_str)
+int volta_get_gpu_power_json(char **get_power_obj_str)
 {
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)

--- a/src/variorum/Nvidia_GPU/Volta.c
+++ b/src/variorum/Nvidia_GPU/Volta.c
@@ -130,3 +130,22 @@ int volta_cap_each_gpu_power_limit(unsigned int powerlimit)
     }
     return 0;
 }
+
+int volta_get_power_json(char **get_power_obj_str)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+    /*
+        unsigned iter = 0;
+        unsigned nsockets;
+        variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
+        for (iter = 0; iter < nsockets; iter++)
+        {
+            get_power_data(iter, long_ver, stdout);
+        }
+    */
+    return 0;
+}

--- a/src/variorum/Nvidia_GPU/Volta.c
+++ b/src/variorum/Nvidia_GPU/Volta.c
@@ -10,6 +10,7 @@
 #include <config_architecture.h>
 #include <variorum_error.h>
 #include <nvidia_gpu_power_features.h>
+#include <jansson.h>
 
 int volta_get_power(int long_ver)
 {
@@ -138,14 +139,13 @@ int volta_get_power_json(char **get_power_obj_str)
     {
         printf("Running %s\n", __FUNCTION__);
     }
-    /*
-        unsigned iter = 0;
-        unsigned nsockets;
-        variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
-        for (iter = 0; iter < nsockets; iter++)
-        {
-            get_power_data(iter, long_ver, stdout);
-        }
-    */
+
+    json_t *get_power_obj = json_object();
+
+    nvidia_gpu_get_json_power_data(get_power_obj);
+
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
+
     return 0;
 }

--- a/src/variorum/Nvidia_GPU/Volta.c
+++ b/src/variorum/Nvidia_GPU/Volta.c
@@ -144,7 +144,7 @@ int volta_get_gpu_power_json(char **get_power_obj_str)
 
     nvidia_gpu_get_json_power_data(get_power_obj);
 
-    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    *get_power_obj_str = json_dumps(get_power_obj, JSON_INDENT(4));
     json_decref(get_power_obj);
 
     return 0;

--- a/src/variorum/Nvidia_GPU/Volta.h
+++ b/src/variorum/Nvidia_GPU/Volta.h
@@ -18,4 +18,6 @@ int volta_get_gpu_utilization(int long_ver);
 
 int volta_cap_each_gpu_power_limit(unsigned int powerlimit);
 
+int volta_get_power_json(char **get_power_obj_str);
+
 #endif

--- a/src/variorum/Nvidia_GPU/Volta.h
+++ b/src/variorum/Nvidia_GPU/Volta.h
@@ -18,6 +18,6 @@ int volta_get_gpu_utilization(int long_ver);
 
 int volta_cap_each_gpu_power_limit(unsigned int powerlimit);
 
-int volta_get_power_json(char **get_power_obj_str);
+int volta_get_gpu_power_json(char **get_power_obj_str);
 
 #endif

--- a/src/variorum/Nvidia_GPU/config_nvidia.c
+++ b/src/variorum/Nvidia_GPU/config_nvidia.c
@@ -33,6 +33,7 @@ int set_nvidia_func_ptrs(int idx)
         /* Initialize control interfaces */
         g_platform[idx].variorum_cap_each_gpu_power_limit   =
             volta_cap_each_gpu_power_limit;
+        g_platform[idx].variorum_get_gpu_power_json    = volta_get_gpu_power_json;
     }
     else
     {

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -245,20 +245,30 @@ void nvidia_gpu_get_json_power_data(json_t *get_power_obj)
     struct timeval tv;
     uint64_t ts;
     unsigned nsockets;
-    static size_t devIDlen = 12; // Long enough to avoid format truncation.
+    static size_t devIDlen = 24; // Long enough to avoid format truncation.
     char devID[devIDlen];
+	char socketID[24];
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);
     ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
-    json_object_set_new(get_power_obj, "host", json_string(hostname));
-    json_object_set_new(get_power_obj, "timestamp", json_integer(ts));
-    json_object_set_new(get_power_obj, "num_gpus",
+
+	json_t *node_obj = json_object();
+    json_object_set_new(get_power_obj, hostname, node_obj);
+    json_object_set_new(node_obj, "timestamp", json_integer(ts));
+    json_object_set_new(node_obj, "num_gpus",
                         json_integer(m_total_unit_devices));
 
     variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
     for (chipid = 0; chipid < nsockets; chipid++)
     {
+		snprintf(socketID, 24, "Socket_%d", chipid);
+		json_t *socket_obj = json_object();
+		json_object_set_new(node_obj, socketID, socket_obj);
+		json_t *gpu_obj = json_object();
+		json_object_set_new(socket_obj, "GPU", gpu_obj);
+		json_object_set_new(gpu_obj, "units", json_string("Watts") );
+
         //Iterate over all GPU device handles for this socket and update object
         for (d = chipid * (int)m_gpus_per_socket;
              d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
@@ -266,10 +276,8 @@ void nvidia_gpu_get_json_power_data(json_t *get_power_obj)
             nvmlDeviceGetPowerUsage(m_unit_devices_file_desc[d], &power);
             value = (double)power * 0.001f;
 
-            char gpu_str[36] = "power_gpu_watts_device_";
-            snprintf(devID, devIDlen, "%d", d);
-            strcat(gpu_str, devID);
-            json_object_set_new(get_power_obj, gpu_str, json_real(value));
+            snprintf(devID, devIDlen, "Device_%d", d);
+            json_object_set_new(gpu_obj, devID, json_real(value));
         }
     }
 }

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -253,6 +253,8 @@ void nvidia_gpu_get_json_power_data(json_t *get_power_obj)
     ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
     json_object_set_new(get_power_obj, "host", json_string(hostname));
     json_object_set_new(get_power_obj, "timestamp", json_integer(ts));
+    json_object_set_new(get_power_obj, "num_gpus",
+                        json_integer(m_total_unit_devices));
 
     variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
     for (chipid = 0; chipid < nsockets; chipid++)

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -239,13 +239,14 @@ void nvidia_gpu_get_json_power_data(json_t *get_power_obj)
     unsigned int power;
     double value = 0.0;
     int d;
+    int chipid;
 
     char hostname[1024];
     struct timeval tv;
     uint64_t ts;
     unsigned nsockets;
-    char devID[4];
-    char gpu_str[36] = "power_gpu_watts_device_";
+    static size_t devIDlen = 12; // Long enough to avoid format truncation.
+    char devID[devIDlen];
 
     gethostname(hostname, 1024);
     gettimeofday(&tv, NULL);
@@ -263,10 +264,10 @@ void nvidia_gpu_get_json_power_data(json_t *get_power_obj)
             nvmlDeviceGetPowerUsage(m_unit_devices_file_desc[d], &power);
             value = (double)power * 0.001f;
 
-            sprintf(devID, "%d", d);
-            strcat(cpu_str, devID);
-            json_object_set_new(get_power_obj, gpu_str, value);
+            char gpu_str[36] = "power_gpu_watts_device_";
+            snprintf(devID, devIDlen, "%d", d);
+            strcat(gpu_str, devID);
+            json_object_set_new(get_power_obj, gpu_str, json_real(value));
         }
     }
-}
 }

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.h
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.h
@@ -10,6 +10,7 @@
 #include <stdio.h>
 
 #include <nvml.h>
+#include <jansson.h>
 
 unsigned m_total_unit_devices;
 nvmlDevice_t *m_unit_devices_file_desc;
@@ -31,5 +32,7 @@ void nvidia_gpu_get_power_limits_data(int chipid, int verbose, FILE *output);
 void nvidia_gpu_get_gpu_utilization_data(int chipid, int verbose, FILE *output);
 
 void cap_each_gpu_power_limit(int chipid, unsigned int powerlimit);
+
+void nvidia_gpu_get_json_power_data(json_t *get_power_obj);
 
 #endif

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.h
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.h
@@ -8,6 +8,8 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/time.h>
 
 #include <nvml.h>
 #include <jansson.h>

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -359,6 +359,7 @@ void variorum_init_func_ptrs()
         g_platform[i].variorum_monitoring = NULL;
         g_platform[i].variorum_get_node_power_json = NULL;
         g_platform[i].variorum_get_node_power_domain_info_json = NULL;
+        g_platform[i].variorum_get_gpu_power_json = NULL;
         g_platform[i].variorum_print_energy = NULL;
     }
 }

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -245,6 +245,11 @@ struct platform
     /// @return Error code.
     int (*variorum_get_node_power_domain_info_json)(char **get_domain_obj_str);
 
+    /// @brief Function pointer to get JSON object for per-GPU power data.
+    ///
+    /// @return Error code.
+    int (*variorum_get_gpu_power_json)(char **get_power_obj_str);
+
     /// @brief Function pointer to get list of available frequencies.
     ///
     /// @return Error code.

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1074,6 +1074,66 @@ int variorum_get_node_power_domain_info_json(char **get_domain_obj_str)
     return err;
 }
 
+int variorum_get_gpu_power_json(char **get_power_obj_str)
+{
+    int err = 0;
+    int i;
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+
+    // Obtain the index corresponding to the primary platform.
+    for (i = 0; i < P_NUM_PLATFORMS; i++)
+    {
+#ifdef VARIORUM_WITH_NVIDIA_GPU
+        i = P_NVIDIA_GPU_IDX;
+        break;
+#endif
+#ifdef VARIORUM_WITH_AMD_GPU
+        i = P_AMD_GPU_IDX;
+        break;
+#endif
+        // Deal with this later
+        /*
+        #ifdef VARIORUM_WITH_INTEL_GPU
+                i = P_INTEL_GPU_IDX;
+                break;
+        #endif
+        // Juno board is an exception, where we don't have a special GPU platform IDX.
+        #ifdef VARIORUM_WITH_ARM_CPU
+                i = P_ARM_CPU_IDX;
+                break;
+        #endif
+        */
+    }
+
+    if (g_platform[i].variorum_get_gpu_power_json == NULL)
+    {
+        variorum_error_handler("Feature not yet implemented or is not supported",
+                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                               getenv("HOSTNAME"), __FILE__,
+                               __FUNCTION__, __LINE__);
+        // For the JSON functions, we return a -1 here, so users don't need
+        // to explicitly check for NULL strings.
+        return -1;
+    }
+
+    err = g_platform[i].variorum_get_gpu_power_json(get_power_obj_str);
+    if (err)
+    {
+        return -1;
+    }
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
+
+
 int variorum_print_available_frequencies(void)
 {
     int err = 0;

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -564,6 +564,21 @@ int variorum_get_node_power_json(char **get_power_obj_str);
 /// check for NULL strings.
 int variorum_get_node_power_domain_info_json(char **get_domain_obj_str);
 
+
+/// @brief Populate a string in JSON format with per GPU power.
+///
+/// @supparch
+/// - NVIDIA Volta
+/// - AMD Radeon Instinct GPUs (MI50 onwards)
+///
+/// @param [out] output String (passed by reference) that contains the per-GPU
+/// power information.
+///
+/// @return 0 if successful, otherwise -1. Note that feature not implemented
+/// returns a -1 for the JSON APIs so that users don't have to explicitly
+/// check for NULL strings.
+int variorum_get_gpu_power_json(char **get_power_obj_str);
+
 /// @brief Returns Variorum version as a constant string.
 ///
 /// @supparch


### PR DESCRIPTION
# Description

Adds a new `variorum_get_gpu_power_json` API for users, as well for multi-platform builds where the primary JSON string (node-level API of `variorum_get_node_power_json`) can utilize the values obtained from calling this function (reports individual GPU power that can be aggregated at socket level for node-level stats). 

Fixes #350.

## Type of change

- [x] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please provide hardware architecture specs and
instructions so we can reproduce.

- [x] Lassen: GPU build only
- [ ] Corona: GPU build only
- [ ] Tioga: GPU build only

```
Lassen output: 

$ ./variorum-get-gpu-power-json-example 
{"host": "lassen27", "timestamp": 1689030066865381, "num_gpus": 4, "power_gpu_watts_device_0": 36.231001720880158, "power_gpu_watts_device_1": 36.751001745578833, "power_gpu_watts_device_2": 36.751001745578833, "power_gpu_watts_device_3": 36.278001723112538}
```

# Checklist:

- [ ] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [ ] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [ ] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [ ] I have added comments in my code
- [ ] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [ ] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
