### PR TITLE
Add power capping API for NVIDIA, AMD and Intel GPUs

### DIFF
--- a/host-configs/chameleon-epyc-x86_64-gcc@9.4.0-rocm@5.2.cmake
+++ b/host-configs/chameleon-epyc-x86_64-gcc@9.4.0-rocm@5.2.cmake
@@ -1,0 +1,39 @@
+# Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+# Variorum Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+# c compiler
+set(CMAKE_C_COMPILER "/usr/bin/gcc" CACHE PATH "")
+
+# cpp compiler
+set(CMAKE_CXX_COMPILER "/usr/bin/g++" CACHE PATH "")
+
+# fortran compiler
+set(CMAKE_Fortran_COMPILER "/usr/bin/gfortran" CACHE PATH "")
+
+set(ENABLE_MPI OFF CACHE BOOL "")
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(BUILD_DOCS OFF CACHE BOOL "")
+set(BUILD_TESTS OFF CACHE BOOL "")
+
+set(VARIORUM_DEBUG OFF CACHE BOOL "")
+
+set(VARIORUM_WITH_AMD_CPU OFF CACHE BOOL "")
+set(VARIORUM_WITH_AMD_GPU ON CACHE BOOL "")
+set(VARIORUM_WITH_ARM_CPU OFF CACHE BOOL "")
+set(VARIORUM_WITH_IBM_CPU OFF CACHE BOOL "")
+set(VARIORUM_WITH_INTEL_CPU OFF CACHE BOOL "")
+set(VARIORUM_WITH_NVIDIA_GPU OFF CACHE BOOL "")
+
+set(CMAKE_SHARED_LINKER_FLAGS "-L/opt/rocm-5.2.0/lib -lrocm_smi64" CACHE PATH "")
+
+# Path to the global hwloc install
+set(HWLOC_DIR "/usr/lib/hwloc-2.8.0/" CACHE PATH "")
+
+# Path to the global ROCm 5.2.0 install
+set(ROCM_DIR "/opt/rocm-5.2.0/" CACHE PATH "")
+
+# Path to the global Jansson install
+set(JANSSON_DIR "/usr/lib/jansson/" CACHE PATH "")

--- a/src/docs/sphinx/AMD.rst
+++ b/src/docs/sphinx/AMD.rst
@@ -157,6 +157,9 @@ information for GPUs. These ROCm-SMI APIs are described below.
 -  ``rsmi_utilization_count_get``: Get coarse grain utilization counter of the
    specified GPU device, including graphics and memory activity counters.
 
+-  ``rsmi_dev_power_cap_set``: Set the GPU device power cap for the
+   specified GPU device in microwatts.
+
 ************
  References
 ************

--- a/src/docs/sphinx/AMD.rst
+++ b/src/docs/sphinx/AMD.rst
@@ -157,8 +157,8 @@ information for GPUs. These ROCm-SMI APIs are described below.
 -  ``rsmi_utilization_count_get``: Get coarse grain utilization counter of the
    specified GPU device, including graphics and memory activity counters.
 
--  ``rsmi_dev_power_cap_set``: Set the GPU device power cap for the
-   specified GPU device in microwatts.
+-  ``rsmi_dev_power_cap_set``: Set the GPU device power cap for the specified
+   GPU device in microwatts.
 
 ************
  References

--- a/src/docs/sphinx/IntelGPU.rst
+++ b/src/docs/sphinx/IntelGPU.rst
@@ -114,8 +114,7 @@ using the corresponding APMIDG APIs.
 Power control
 =============
 
-Variorum provides an API to cap the power usage of an Intel Discrete GPU
-device. To set the power cap, Variorum uses the ``apmidg_setpwrlim()``
+In Variorum's GPU power capping API, Variorum uses the ``apmidg_setpwrlim()``
 API of APMIDG which takes as input the GPU device ID, the power domain ID
 and the power cap in milliwatts.
 

--- a/src/docs/sphinx/IntelGPU.rst
+++ b/src/docs/sphinx/IntelGPU.rst
@@ -108,15 +108,15 @@ execusion unit in MHz and integer precision. It leverages the
 *******************
 
 The Intel Discrete GPU port of Variorum leverages the device-level control APIs
-provided by APMIDG. Variorum implements the following device control APIs
-using the corresponding APMIDG APIs.
+provided by APMIDG. Variorum implements the following device control APIs using
+the corresponding APMIDG APIs.
 
 Power control
 =============
 
 In Variorum's GPU power capping API, Variorum uses the ``apmidg_setpwrlim()``
-API of APMIDG which takes as input the GPU device ID, the power domain ID
-and the power cap in milliwatts.
+API of APMIDG which takes as input the GPU device ID, the power domain ID and
+the power cap in milliwatts.
 
 ************
  References

--- a/src/docs/sphinx/IntelGPU.rst
+++ b/src/docs/sphinx/IntelGPU.rst
@@ -103,6 +103,22 @@ Variorum provides an API to report instantaneous clock speed of the Intel GPU's
 execusion unit in MHz and integer precision. It leverages the
 ``apmidg_readfreq()`` APMIDG API to report the instantaneous clock speed.
 
+*******************
+ Control Interface
+*******************
+
+The Intel Discrete GPU port of Variorum leverages the device-level control APIs
+provided by APMIDG. Variorum implements the following device control APIs
+using the corresponding APMIDG APIs.
+
+Power control
+=============
+
+Variorum provides an API to cap the power usage of an Intel Discrete GPU
+device. To set the power cap, Variorum uses the ``apmidg_setpwrlim()``
+API of APMIDG which takes as input the GPU device ID, the power domain ID
+and the power cap in milliwatts.
+
 ************
  References
 ************

--- a/src/docs/sphinx/Nvidia.rst
+++ b/src/docs/sphinx/Nvidia.rst
@@ -126,6 +126,15 @@ rate) in a fixed time window. It leverages the
 ``nvmlDeviceGetUtilizationRates()`` API of NVML to report the device utilization
 rate as a percentage in integer precision.
 
+Power capping
+=============
+
+Variorum provides an API to cap GPU device power. The API applies the power cap
+equally to all GPU devices on the system. It leverages the
+``nvmlDeviceSetPowerManagementLimit()`` API of NVML to set the power cap to the
+device after converting the specified power cap into milliwatts. This API
+requires root/administrator privileges.
+
 ************
  References
 ************

--- a/src/docs/sphinx/api/cap_functions.rst
+++ b/src/docs/sphinx/api/cap_functions.rst
@@ -18,7 +18,7 @@ Defined in ``variorum/variorum.h``.
 
 .. doxygenfunction:: variorum_cap_gpu_power_ratio
 
-.. doxygenfunction:: variorum_cap_gpu_power_limit
+.. doxygenfunction:: variorum_cap_each_gpu_power_limit
 
 .. doxygenfunction:: variorum_cap_each_core_frequency_limit
 

--- a/src/docs/sphinx/api/cap_functions.rst
+++ b/src/docs/sphinx/api/cap_functions.rst
@@ -18,6 +18,8 @@ Defined in ``variorum/variorum.h``.
 
 .. doxygenfunction:: variorum_cap_gpu_power_ratio
 
+.. doxygenfunction:: variorum_cap_gpu_power_limit
+
 .. doxygenfunction:: variorum_cap_each_core_frequency_limit
 
 .. doxygenfunction:: variorum_cap_socket_frequency_limit

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -13,6 +13,7 @@ set(BASIC_EXAMPLES
     variorum-cap-gpu-power-ratio-example
     variorum-cap-socket-frequency-limit-example
     variorum-cap-socket-power-limit-example
+    variorum-cap-gpu-power-limit-example
     variorum-disable-turbo-example
     variorum-enable-turbo-example
     variorum-get-node-power-json-example

--- a/src/examples/variorum-cap-gpu-power-limit-example.c
+++ b/src/examples/variorum-cap-gpu-power-limit-example.c
@@ -1,0 +1,60 @@
+// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <variorum.h>
+
+int main(int argc, char **argv)
+{
+    int ret = 0;
+    int gpu_power_limit = 0;
+
+    const char *usage = "Usage: %s [-h] [-v] -l power_lim_watts\n";
+    int opt;
+
+    while ((opt = getopt(argc, argv, "hvl:")) != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
+                return 0;
+            case 'l':
+                gpu_power_limit = atoi(optarg);
+                break;
+            default:
+                printf(usage, argv[0]);
+                return -1;
+        }
+    }
+    if (argc == 1)
+    {
+        printf(usage, argv[0]);
+        return -1;
+    }
+
+    printf("Capping GPU power limit to %dW\n", gpu_power_limit);
+
+    ret = variorum_cap_gpu_power_limit(gpu_power_limit);
+    if (ret != 0)
+    {
+        printf("Cap GPU power limit failed!\n");
+        return ret;
+    }
+    printf("\n");
+    ret = variorum_print_verbose_power_limit();
+    if (ret != 0)
+    {
+        printf("Print power limits failed!\n");
+        return ret;
+    }
+    return ret;
+}

--- a/src/examples/variorum-cap-gpu-power-limit-example.c
+++ b/src/examples/variorum-cap-gpu-power-limit-example.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
 
     printf("Capping GPU power limit to %dW\n", gpu_power_limit);
 
-    ret = variorum_cap_gpu_power_limit(gpu_power_limit);
+    ret = variorum_cap_each_gpu_power_limit(gpu_power_limit);
     if (ret != 0)
     {
         printf("Cap GPU power limit failed!\n");

--- a/src/variorum/AMD_GPU/config_amd_gpu.c
+++ b/src/variorum/AMD_GPU/config_amd_gpu.c
@@ -33,6 +33,10 @@ int set_amd_gpu_func_ptrs(int idx)
         g_platform[idx].variorum_print_power_limit     = instinctGPU_get_power_limit;
         g_platform[idx].variorum_print_gpu_utilization =
             instinctGPU_get_gpu_utilization;
+
+        /* Initialize control interfaces */
+        g_platform[idx].variorum_cap_gpu_power_limit   =
+            instinctGPU_cap_gpu_power_limit;
     }
     else
     {

--- a/src/variorum/AMD_GPU/config_amd_gpu.c
+++ b/src/variorum/AMD_GPU/config_amd_gpu.c
@@ -33,10 +33,9 @@ int set_amd_gpu_func_ptrs(int idx)
         g_platform[idx].variorum_print_power_limit     = instinctGPU_get_power_limit;
         g_platform[idx].variorum_print_gpu_utilization =
             instinctGPU_get_gpu_utilization;
-
         /* Initialize control interfaces */
-        g_platform[idx].variorum_cap_gpu_power_limit   =
-            instinctGPU_cap_gpu_power_limit;
+        g_platform[idx].variorum_cap_each_gpu_power_limit   =
+            instinctGPU_cap_each_gpu_power_limit;
     }
     else
     {

--- a/src/variorum/AMD_GPU/instinctGPU.c
+++ b/src/variorum/AMD_GPU/instinctGPU.c
@@ -113,7 +113,7 @@ int instinctGPU_get_gpu_utilization(int verbose)
     return 0;
 }
 
-int instinctGPU_cap_gpu_power_limit(unsigned int powerlimit)
+int instinctGPU_cap_each_gpu_power_limit(unsigned int powerlimit)
 {
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
@@ -126,7 +126,7 @@ int instinctGPU_cap_gpu_power_limit(unsigned int powerlimit)
     variorum_get_topology(&nsockets, NULL, NULL, P_AMD_GPU_IDX);
     for (iter = 0; iter < nsockets; iter++)
     {
-        cap_gpu_power_limit(iter, nsockets, powerlimit);
+        cap_each_gpu_power_limit(iter, nsockets, powerlimit);
     }
     return 0;
 }

--- a/src/variorum/AMD_GPU/instinctGPU.c
+++ b/src/variorum/AMD_GPU/instinctGPU.c
@@ -112,3 +112,21 @@ int instinctGPU_get_gpu_utilization(int verbose)
     }
     return 0;
 }
+
+int instinctGPU_cap_gpu_power_limit(unsigned int powerlimit)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    unsigned iter = 0;
+    unsigned nsockets;
+    variorum_get_topology(&nsockets, NULL, NULL, P_AMD_GPU_IDX);
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        cap_gpu_power_limit(iter, nsockets, powerlimit);
+    }
+    return 0;
+}

--- a/src/variorum/AMD_GPU/instinctGPU.h
+++ b/src/variorum/AMD_GPU/instinctGPU.h
@@ -11,6 +11,6 @@ int instinctGPU_get_power_limit(int verbose);
 int instinctGPU_get_thermals(int verbose);
 int instinctGPU_get_clocks(int verbose);
 int instinctGPU_get_gpu_utilization(int verbose);
-int instinctGPU_cap_gpu_power_limit(unsigned int powerlimit);
+int instinctGPU_cap_each_gpu_power_limit(unsigned int powerlimit);
 
 #endif

--- a/src/variorum/AMD_GPU/instinctGPU.h
+++ b/src/variorum/AMD_GPU/instinctGPU.h
@@ -11,5 +11,6 @@ int instinctGPU_get_power_limit(int verbose);
 int instinctGPU_get_thermals(int verbose);
 int instinctGPU_get_clocks(int verbose);
 int instinctGPU_get_gpu_utilization(int verbose);
+int instinctGPU_cap_gpu_power_limit(unsigned int powerlimit);
 
 #endif

--- a/src/variorum/AMD_GPU/power_features.c
+++ b/src/variorum/AMD_GPU/power_features.c
@@ -488,7 +488,8 @@ void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
     }
 }
 
-void cap_gpu_power_limit(int chipid, int total_sockets, unsigned int powerlimit)
+void cap_each_gpu_power_limit(int chipid, int total_sockets,
+                              unsigned int powerlimit)
 {
     rsmi_status_t ret;
     uint32_t num_devices;

--- a/src/variorum/AMD_GPU/power_features.c
+++ b/src/variorum/AMD_GPU/power_features.c
@@ -487,3 +487,77 @@ void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
                                __LINE__);
     }
 }
+
+void cap_gpu_power_limit(int chipid, int total_sockets, unsigned int powerlimit)
+{
+    rsmi_status_t ret;
+    uint32_t num_devices;
+    int gpus_per_socket;
+    char hostname[1024];
+    static int init = 0;
+    static struct timeval start;
+    struct timeval now;
+    unsigned int powerlimit_uwatts = powerlimit * 1000000;
+
+    gethostname(hostname, 1024);
+
+    ret = rsmi_init(0);
+    if (ret != RSMI_STATUS_SUCCESS)
+    {
+        variorum_error_handler("Could not initialize RSMI",
+                               VARIORUM_ERROR_PLATFORM_ENV,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                               __LINE__);
+        exit(-1);
+    }
+
+    ret = rsmi_num_monitor_devices(&num_devices);
+    if (ret != RSMI_STATUS_SUCCESS)
+    {
+        variorum_error_handler("Could not get number of GPU devices",
+                               VARIORUM_ERROR_PLATFORM_ENV,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                               __LINE__);
+    }
+
+    gpus_per_socket = num_devices / total_sockets;
+
+    if (!init)
+    {
+        init = 1;
+        gettimeofday(&start, NULL);
+    }
+
+    gettimeofday(&now, NULL);
+
+    for (int i = chipid * gpus_per_socket;
+         i < (chipid + 1) * gpus_per_socket; i++)
+    {
+        ret = rsmi_dev_power_cap_set(i, 0, powerlimit_uwatts);
+        if (ret != RSMI_STATUS_SUCCESS)
+        {
+            if (ret == RSMI_STATUS_PERMISSION)
+            {
+                variorum_error_handler(
+                    "Insufficient permissions to set the GPU power limit",
+                    VARIORUM_ERROR_PLATFORM_ENV, getenv("HOSTNAME"),
+                    __FILE__, __FUNCTION__, __LINE__);
+            }
+            else
+            {
+                variorum_error_handler(
+                    "Could not set the specified GPU power limit",
+                    VARIORUM_ERROR_PLATFORM_ENV, getenv("HOSTNAME"),
+                    __FILE__, __FUNCTION__, __LINE__);
+            }
+        }
+    }
+    ret = rsmi_shut_down();
+    if (ret != RSMI_STATUS_SUCCESS)
+    {
+        variorum_error_handler("Could not shutdown RSMI",
+                               VARIORUM_ERROR_PLATFORM_ENV,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                               __LINE__);
+    }
+}

--- a/src/variorum/AMD_GPU/power_features.h
+++ b/src/variorum/AMD_GPU/power_features.h
@@ -19,7 +19,7 @@ void get_thermals_data(int chipid, int total_sockets, int verbose,
 void get_clocks_data(int chipid, int total_sockets, int verbose, FILE *output);
 void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
                               FILE *output);
-void cap_gpu_power_limit(int chipid, int total_sockets,
-                         unsigned int powerlimit);
+void cap_each_gpu_power_limit(int chipid, int total_sockets,
+                              unsigned int powerlimit);
 
 #endif

--- a/src/variorum/AMD_GPU/power_features.h
+++ b/src/variorum/AMD_GPU/power_features.h
@@ -19,5 +19,7 @@ void get_thermals_data(int chipid, int total_sockets, int verbose,
 void get_clocks_data(int chipid, int total_sockets, int verbose, FILE *output);
 void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
                               FILE *output);
+void cap_gpu_power_limit(int chipid, int total_sockets,
+                         unsigned int powerlimit);
 
 #endif

--- a/src/variorum/Intel_GPU/GPU.c
+++ b/src/variorum/Intel_GPU/GPU.c
@@ -72,8 +72,6 @@ int intel_gpu_get_power_limit(int long_ver)
     return 0;
 }
 
-
-
 int intel_cap_gpu_power_limit(unsigned int powerlimit)
 {
     char *val = getenv("VARIORUM_LOG");

--- a/src/variorum/Intel_GPU/GPU.c
+++ b/src/variorum/Intel_GPU/GPU.c
@@ -56,3 +56,21 @@ int intel_gpu_get_clocks(int long_ver)
     }
     return 0;
 }
+
+int intel_cap_gpu_power_limit(unsigned int powerlimit)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    unsigned iter = 0;
+    unsigned nsockets;
+    variorum_get_topology(&nsockets, NULL, NULL, P_INTEL_GPU_IDX);
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        cap_gpu_power_limit(iter, powerlimit);
+    }
+    return 0;
+}

--- a/src/variorum/Intel_GPU/GPU.c
+++ b/src/variorum/Intel_GPU/GPU.c
@@ -57,7 +57,7 @@ int intel_gpu_get_clocks(int long_ver)
     return 0;
 }
 
-int intel_cap_gpu_power_limit(unsigned int powerlimit)
+int intel_cap_each_gpu_power_limit(unsigned int powerlimit)
 {
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
@@ -70,7 +70,7 @@ int intel_cap_gpu_power_limit(unsigned int powerlimit)
     variorum_get_topology(&nsockets, NULL, NULL, P_INTEL_GPU_IDX);
     for (iter = 0; iter < nsockets; iter++)
     {
-        cap_gpu_power_limit(iter, powerlimit);
+        cap_each_gpu_power_limit(iter, powerlimit);
     }
     return 0;
 }

--- a/src/variorum/Intel_GPU/GPU.c
+++ b/src/variorum/Intel_GPU/GPU.c
@@ -57,6 +57,23 @@ int intel_gpu_get_clocks(int long_ver)
     return 0;
 }
 
+int intel_gpu_get_power_limit(int long_ver)
+{
+#ifdef VARIORUM_LOG
+    printf("Running %s\n", __FUNCTION__);
+#endif
+    unsigned iter = 0;
+    unsigned nsockets;
+    variorum_get_topology(&nsockets, NULL, NULL, P_INTEL_GPU_IDX);
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        get_power_limit_data(iter, long_ver, stdout);
+    }
+    return 0;
+}
+
+
+
 int intel_cap_gpu_power_limit(unsigned int powerlimit)
 {
     char *val = getenv("VARIORUM_LOG");

--- a/src/variorum/Intel_GPU/GPU.c
+++ b/src/variorum/Intel_GPU/GPU.c
@@ -57,21 +57,6 @@ int intel_gpu_get_clocks(int long_ver)
     return 0;
 }
 
-int intel_gpu_get_power_limit(int long_ver)
-{
-#ifdef VARIORUM_LOG
-    printf("Running %s\n", __FUNCTION__);
-#endif
-    unsigned iter = 0;
-    unsigned nsockets;
-    variorum_get_topology(&nsockets, NULL, NULL, P_INTEL_GPU_IDX);
-    for (iter = 0; iter < nsockets; iter++)
-    {
-        get_power_limit_data(iter, long_ver, stdout);
-    }
-    return 0;
-}
-
 int intel_cap_gpu_power_limit(unsigned int powerlimit)
 {
     char *val = getenv("VARIORUM_LOG");

--- a/src/variorum/Intel_GPU/GPU.h
+++ b/src/variorum/Intel_GPU/GPU.h
@@ -12,6 +12,6 @@ extern int intel_gpu_get_thermals(int long_ver);
 
 extern int intel_gpu_get_clocks(int long_ver);
 
-extern int intel_cap_gpu_power_limit(unsigned int powerlimit);
+extern int intel_cap_each_gpu_power_limit(unsigned int powerlimit);
 
 #endif

--- a/src/variorum/Intel_GPU/GPU.h
+++ b/src/variorum/Intel_GPU/GPU.h
@@ -12,4 +12,6 @@ extern int intel_gpu_get_thermals(int long_ver);
 
 extern int intel_gpu_get_clocks(int long_ver);
 
+extern int intel_cap_gpu_power_limit(unsigned int powerlimit);
+
 #endif

--- a/src/variorum/Intel_GPU/GPU.h
+++ b/src/variorum/Intel_GPU/GPU.h
@@ -12,6 +12,8 @@ extern int intel_gpu_get_thermals(int long_ver);
 
 extern int intel_gpu_get_clocks(int long_ver);
 
+extern int intel_gpu_get_power_limit(int long_ver);
+
 extern int intel_cap_gpu_power_limit(unsigned int powerlimit);
 
 #endif

--- a/src/variorum/Intel_GPU/GPU.h
+++ b/src/variorum/Intel_GPU/GPU.h
@@ -12,8 +12,6 @@ extern int intel_gpu_get_thermals(int long_ver);
 
 extern int intel_gpu_get_clocks(int long_ver);
 
-extern int intel_gpu_get_power_limit(int long_ver);
-
 extern int intel_cap_gpu_power_limit(unsigned int powerlimit);
 
 #endif

--- a/src/variorum/Intel_GPU/config_intel_gpu.c
+++ b/src/variorum/Intel_GPU/config_intel_gpu.c
@@ -27,6 +27,8 @@ int set_intel_gpu_func_ptrs(int idx)
         g_platform[idx].variorum_print_thermals        = intel_gpu_get_thermals;
         g_platform[idx].variorum_print_frequency       = intel_gpu_get_clocks;
         // g_platform.variorum_print_power_limit    = ; // implement this later
+
+        g_platform[idx].variorum_cap_gpu_power_limit   = intel_cap_gpu_power_limit;
     }
     else
     {

--- a/src/variorum/Intel_GPU/config_intel_gpu.c
+++ b/src/variorum/Intel_GPU/config_intel_gpu.c
@@ -23,11 +23,12 @@ int set_intel_gpu_func_ptrs(int idx)
 
     if (*g_platform[idx].arch_id == 1)
     {
-        g_platform[idx].variorum_print_power           = intel_gpu_get_power;
-        g_platform[idx].variorum_print_thermals        = intel_gpu_get_thermals;
-        g_platform[idx].variorum_print_frequency       = intel_gpu_get_clocks;
-        g_platform[idx].variorum_print_power_limit     = intel_gpu_get_power_limit;
-        g_platform[idx].variorum_cap_gpu_power_limit   = intel_cap_gpu_power_limit;
+        g_platform[idx].variorum_print_power                = intel_gpu_get_power;
+        g_platform[idx].variorum_print_thermals             = intel_gpu_get_thermals;
+        g_platform[idx].variorum_print_frequency            = intel_gpu_get_clocks;
+        g_platform[idx].variorum_print_power_limit          = intel_gpu_get_power_limit;
+        g_platform[idx].variorum_cap_each_gpu_power_limit   =
+            intel_cap_each_gpu_power_limit;
     }
     else
     {

--- a/src/variorum/Intel_GPU/config_intel_gpu.c
+++ b/src/variorum/Intel_GPU/config_intel_gpu.c
@@ -26,7 +26,6 @@ int set_intel_gpu_func_ptrs(int idx)
         g_platform[idx].variorum_print_power                = intel_gpu_get_power;
         g_platform[idx].variorum_print_thermals             = intel_gpu_get_thermals;
         g_platform[idx].variorum_print_frequency            = intel_gpu_get_clocks;
-        g_platform[idx].variorum_print_power_limit          = intel_gpu_get_power_limit;
         g_platform[idx].variorum_cap_each_gpu_power_limit   =
             intel_cap_each_gpu_power_limit;
     }

--- a/src/variorum/Intel_GPU/config_intel_gpu.c
+++ b/src/variorum/Intel_GPU/config_intel_gpu.c
@@ -26,8 +26,7 @@ int set_intel_gpu_func_ptrs(int idx)
         g_platform[idx].variorum_print_power           = intel_gpu_get_power;
         g_platform[idx].variorum_print_thermals        = intel_gpu_get_thermals;
         g_platform[idx].variorum_print_frequency       = intel_gpu_get_clocks;
-        // g_platform.variorum_print_power_limit    = ; // implement this later
-
+        g_platform[idx].variorum_print_power_limit     = intel_gpu_get_power_limit;
         g_platform[idx].variorum_cap_gpu_power_limit   = intel_cap_gpu_power_limit;
     }
     else

--- a/src/variorum/Intel_GPU/power_features.c
+++ b/src/variorum/Intel_GPU/power_features.c
@@ -135,40 +135,6 @@ void get_clocks_data(int chipid, int verbose, FILE *output)
     }
 }
 
-void get_power_limit_data(int chipid, int verbose, FILE *output)
-{
-    int d;
-    static int init_output = 0;
-
-    /* Iterate over all GPU device handles and print GPU clock */
-    for (d = chipid * (int)m_gpus_per_socket;
-         d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
-    {
-        int current_powerlimit_mwatts = 0;
-        int pi = 0; // only report the global power domain
-
-        apmidg_getpwrlim(d, pi, &current_powerlimit_mwatts);
-
-        if (verbose)
-        {
-            fprintf(output,
-                    "_INTEL_GPU_POWER_LIMIT Host: %s, Socket: %d, DeviceID: %d, GPU_Power_limit: %d mW\n",
-                    m_hostname, chipid, d, current_powerlimit_mwatts);
-        }
-        else
-        {
-            if (!init_output)
-            {
-                fprintf(output,
-                        "_INTEL_GPU_POWER_LIMIT Host Socket DeviceID GPU_Power_limit_mW\n");
-                init_output = 1;
-            }
-            fprintf(output, "_INTEL_GPU_POWER_LIMIT %s %d %d %d\n",
-                    m_hostname, chipid, d, current_powerlimit_mwatts);
-        }
-    }
-}
-
 void cap_each_gpu_power_limit(int chipid, unsigned int powerlimit)
 {
     int powerlimit_mwatts = powerlimit * 1000;

--- a/src/variorum/Intel_GPU/power_features.c
+++ b/src/variorum/Intel_GPU/power_features.c
@@ -169,9 +169,7 @@ void get_power_limit_data(int chipid, int verbose, FILE *output)
     }
 }
 
-
-
-void cap_gpu_power_limit(int chipid, unsigned int powerlimit)
+void cap_each_gpu_power_limit(int chipid, unsigned int powerlimit)
 {
     int powerlimit_mwatts = powerlimit * 1000;
     int d;

--- a/src/variorum/Intel_GPU/power_features.c
+++ b/src/variorum/Intel_GPU/power_features.c
@@ -134,3 +134,26 @@ void get_clocks_data(int chipid, int verbose, FILE *output)
         }
     }
 }
+
+void cap_gpu_power_limit(int chipid, unsigned int powerlimit)
+{
+    unsigned int powerlimit_mwatts = powerlimit * 1000;
+    int d;
+    int retval = 0;
+
+    //Iterate over all GPU device handles for this socket and print power
+    for (d = chipid * (int)m_gpus_per_socket;
+         d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
+    {
+        /* Set power cap: please invoke the OneAPI call to set GPU power limit below */
+        /* retval = [ OneAPI call here ]
+        if (retval != 0)
+        {
+            variorum_error_handler("Could not set the specified GPU power limit",
+                                   VARIORUM_ERROR_PLATFORM_ENV, getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                                   __LINE__);
+        }
+        */
+    }
+}
+

--- a/src/variorum/Intel_GPU/power_features.c
+++ b/src/variorum/Intel_GPU/power_features.c
@@ -144,10 +144,10 @@ void get_power_limit_data(int chipid, int verbose, FILE *output)
     for (d = chipid * (int)m_gpus_per_socket;
          d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
-	int current_powerlimit_mwatts=0;
+        int current_powerlimit_mwatts = 0;
         int pi = 0; // only report the global power domain
 
-	apmidg_getpwrlim(d, pi, &current_powerlimit_mwatts);
+        apmidg_getpwrlim(d, pi, &current_powerlimit_mwatts);
 
         if (verbose)
         {
@@ -159,7 +159,8 @@ void get_power_limit_data(int chipid, int verbose, FILE *output)
         {
             if (!init_output)
             {
-                fprintf(output, "_INTEL_GPU_POWER_LIMIT Host Socket DeviceID GPU_Power_limit_mW\n");
+                fprintf(output,
+                        "_INTEL_GPU_POWER_LIMIT Host Socket DeviceID GPU_Power_limit_mW\n");
                 init_output = 1;
             }
             fprintf(output, "_INTEL_GPU_POWER_LIMIT %s %d %d %d\n",
@@ -180,9 +181,9 @@ void cap_gpu_power_limit(int chipid, unsigned int powerlimit)
          d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
         int pi = 0; // check the power domain
-	int current_powerlimit_mwatts=0;
+        int current_powerlimit_mwatts = 0;
         apmidg_setpwrlim(d, pi, powerlimit_mwatts);
-	apmidg_getpwrlim(d, pi, &current_powerlimit_mwatts);
+        apmidg_getpwrlim(d, pi, &current_powerlimit_mwatts);
 
 
         if (powerlimit_mwatts != current_powerlimit_mwatts)

--- a/src/variorum/Intel_GPU/power_features.h
+++ b/src/variorum/Intel_GPU/power_features.h
@@ -16,6 +16,7 @@ void shutdownAPMIDG(void);
 void get_power_data(int chipid, int verbose, FILE *output);
 void get_thermal_data(int chipid, int verbose, FILE *output);
 void get_clocks_data(int chipid, int verbose, FILE *output);
+void get_power_limit_data(int chipid, int verbose, FILE *output);
 void cap_gpu_power_limit(int chipid, unsigned int powerlimit);
 
 #endif

--- a/src/variorum/Intel_GPU/power_features.h
+++ b/src/variorum/Intel_GPU/power_features.h
@@ -16,5 +16,6 @@ void shutdownAPMIDG(void);
 void get_power_data(int chipid, int verbose, FILE *output);
 void get_thermal_data(int chipid, int verbose, FILE *output);
 void get_clocks_data(int chipid, int verbose, FILE *output);
+void cap_gpu_power_limit(int chipid, unsigned int powerlimit);
 
 #endif

--- a/src/variorum/Intel_GPU/power_features.h
+++ b/src/variorum/Intel_GPU/power_features.h
@@ -17,6 +17,6 @@ void get_power_data(int chipid, int verbose, FILE *output);
 void get_thermal_data(int chipid, int verbose, FILE *output);
 void get_clocks_data(int chipid, int verbose, FILE *output);
 void get_power_limit_data(int chipid, int verbose, FILE *output);
-void cap_gpu_power_limit(int chipid, unsigned int powerlimit);
+void cap_each_gpu_power_limit(int chipid, unsigned int powerlimit);
 
 #endif

--- a/src/variorum/Intel_GPU/power_features.h
+++ b/src/variorum/Intel_GPU/power_features.h
@@ -16,7 +16,6 @@ void shutdownAPMIDG(void);
 void get_power_data(int chipid, int verbose, FILE *output);
 void get_thermal_data(int chipid, int verbose, FILE *output);
 void get_clocks_data(int chipid, int verbose, FILE *output);
-void get_power_limit_data(int chipid, int verbose, FILE *output);
 void cap_each_gpu_power_limit(int chipid, unsigned int powerlimit);
 
 #endif

--- a/src/variorum/Nvidia_GPU/Volta.c
+++ b/src/variorum/Nvidia_GPU/Volta.c
@@ -100,3 +100,21 @@ int volta_get_gpu_utilization(int long_ver)
     }
     return 0;
 }
+
+int volta_cap_gpu_power_limit(unsigned int powerlimit)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    unsigned iter = 0;
+    unsigned nsockets;
+    variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        cap_gpu_power_limit(iter, powerlimit);
+    }
+    return 0;
+}

--- a/src/variorum/Nvidia_GPU/Volta.c
+++ b/src/variorum/Nvidia_GPU/Volta.c
@@ -101,7 +101,7 @@ int volta_get_gpu_utilization(int long_ver)
     return 0;
 }
 
-int volta_cap_gpu_power_limit(unsigned int powerlimit)
+int volta_cap_each_gpu_power_limit(unsigned int powerlimit)
 {
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)
@@ -114,7 +114,7 @@ int volta_cap_gpu_power_limit(unsigned int powerlimit)
     variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
     for (iter = 0; iter < nsockets; iter++)
     {
-        cap_gpu_power_limit(iter, powerlimit);
+        cap_each_gpu_power_limit(iter, powerlimit);
     }
     return 0;
 }

--- a/src/variorum/Nvidia_GPU/Volta.h
+++ b/src/variorum/Nvidia_GPU/Volta.h
@@ -16,6 +16,6 @@ int volta_get_power_limits(int long_ver);
 
 int volta_get_gpu_utilization(int long_ver);
 
-int volta_cap_gpu_power_limit(unsigned int powerlimit);
+int volta_cap_each_gpu_power_limit(unsigned int powerlimit);
 
 #endif

--- a/src/variorum/Nvidia_GPU/Volta.h
+++ b/src/variorum/Nvidia_GPU/Volta.h
@@ -16,4 +16,6 @@ int volta_get_power_limits(int long_ver);
 
 int volta_get_gpu_utilization(int long_ver);
 
+int volta_cap_gpu_power_limit(unsigned int powerlimit);
+
 #endif

--- a/src/variorum/Nvidia_GPU/config_nvidia.c
+++ b/src/variorum/Nvidia_GPU/config_nvidia.c
@@ -30,6 +30,9 @@ int set_nvidia_func_ptrs(int idx)
         g_platform[idx].variorum_print_frequency       = volta_get_clocks;
         g_platform[idx].variorum_print_power_limit     = volta_get_power_limits;
         g_platform[idx].variorum_print_gpu_utilization = volta_get_gpu_utilization;
+
+        /* Initialize control interfaces */
+        g_platform[idx].variorum_cap_gpu_power_limit   = volta_cap_gpu_power_limit;
     }
     else
     {

--- a/src/variorum/Nvidia_GPU/config_nvidia.c
+++ b/src/variorum/Nvidia_GPU/config_nvidia.c
@@ -25,14 +25,14 @@ int set_nvidia_func_ptrs(int idx)
     if (*g_platform[idx].arch_id == VOLTA)
     {
         /* Initialize monitoring interfaces */
-        g_platform[idx].variorum_print_power           = volta_get_power;
-        g_platform[idx].variorum_print_thermals        = volta_get_thermals;
-        g_platform[idx].variorum_print_frequency       = volta_get_clocks;
-        g_platform[idx].variorum_print_power_limit     = volta_get_power_limits;
-        g_platform[idx].variorum_print_gpu_utilization = volta_get_gpu_utilization;
-
+        g_platform[idx].variorum_print_power                = volta_get_power;
+        g_platform[idx].variorum_print_thermals             = volta_get_thermals;
+        g_platform[idx].variorum_print_frequency            = volta_get_clocks;
+        g_platform[idx].variorum_print_power_limit          = volta_get_power_limits;
+        g_platform[idx].variorum_print_gpu_utilization      = volta_get_gpu_utilization;
         /* Initialize control interfaces */
-        g_platform[idx].variorum_cap_gpu_power_limit   = volta_cap_gpu_power_limit;
+        g_platform[idx].variorum_cap_each_gpu_power_limit   =
+            volta_cap_each_gpu_power_limit;
     }
     else
     {

--- a/src/variorum/Nvidia_GPU/power_features.c
+++ b/src/variorum/Nvidia_GPU/power_features.c
@@ -213,7 +213,7 @@ void get_gpu_utilization(int chipid, int verbose, FILE *output)
     }
 }
 
-void cap_gpu_power_limit(int chipid, unsigned int powerlimit)
+void cap_each_gpu_power_limit(int chipid, unsigned int powerlimit)
 {
     unsigned int powerlimit_mwatts = powerlimit * 1000;
     int d;
@@ -232,4 +232,3 @@ void cap_gpu_power_limit(int chipid, unsigned int powerlimit)
         }
     }
 }
-

--- a/src/variorum/Nvidia_GPU/power_features.c
+++ b/src/variorum/Nvidia_GPU/power_features.c
@@ -212,3 +212,24 @@ void get_gpu_utilization(int chipid, int verbose, FILE *output)
         }
     }
 }
+
+void cap_gpu_power_limit(int chipid, unsigned int powerlimit)
+{
+    unsigned int powerlimit_mwatts = powerlimit * 1000;
+    int d;
+    static int init_output = 0;
+
+    //Iterate over all GPU device handles for this socket and print power
+    for (d = chipid * (int)m_gpus_per_socket;
+         d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
+    {
+        if (NVML_SUCCESS != nvmlDeviceSetPowerManagementLimit(
+                m_unit_devices_file_desc[d], powerlimit_mwatts))
+        {
+            variorum_error_handler("Could not set the specified GPU power limit",
+                                   VARIORUM_ERROR_PLATFORM_ENV, getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                                   __LINE__);
+        }
+    }
+}
+

--- a/src/variorum/Nvidia_GPU/power_features.h
+++ b/src/variorum/Nvidia_GPU/power_features.h
@@ -30,6 +30,6 @@ void get_power_limits(int chipid, int verbose, FILE *output);
 
 void get_gpu_utilization(int chipid, int verbose, FILE *output);
 
-void cap_gpu_power_limit(int chipid, unsigned int powerlimit);
+void cap_each_gpu_power_limit(int chipid, unsigned int powerlimit);
 
 #endif

--- a/src/variorum/Nvidia_GPU/power_features.h
+++ b/src/variorum/Nvidia_GPU/power_features.h
@@ -30,4 +30,6 @@ void get_power_limits(int chipid, int verbose, FILE *output);
 
 void get_gpu_utilization(int chipid, int verbose, FILE *output);
 
+void cap_gpu_power_limit(int chipid, unsigned int powerlimit);
+
 #endif

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -345,7 +345,7 @@ void variorum_init_func_ptrs()
         g_platform[i].variorum_cap_each_socket_power_limit = NULL;
         g_platform[i].variorum_cap_each_core_frequency_limit = NULL;
         g_platform[i].variorum_print_available_frequencies = NULL;
-        g_platform[i].variorum_cap_gpu_power_ratio = NULL;
+        g_platform[i].variorum_cap_each_gpu_power_limit = NULL;
         g_platform[i].variorum_print_features = NULL;
         g_platform[i].variorum_print_thermals = NULL;
         g_platform[i].variorum_print_counters = NULL;

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -171,11 +171,9 @@ struct platform
     ///
     /// @param [in] gpu_power_limit Desired power limit in watts for each GPU
     ///             on the node.
-    /// @param [in] gpu_power_limit Desired power ratio (percent) for the
-    ///        processor and GPU.
     ///
     /// @return 0 if successful, otherwise -1
-    int (*variorum_cap_gpu_power_limit)(unsigned int gpu_power_limit);
+    int (*variorum_cap_each_gpu_power_limit)(unsigned int gpu_power_limit);
 
     /// @brief Function pointer to print the feature set.
     ///

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -167,6 +167,16 @@ struct platform
 
     int (*variorum_cap_each_core_frequency_limit)(int core_freq_mhz);
 
+    /// @brief Cap the power usage identically of each GPU on the node.
+    ///
+    /// @param [in] gpu_power_limit Desired power limit in watts for each GPU
+    ///             on the node.
+    /// @param [in] gpu_power_limit Desired power ratio (percent) for the
+    ///        processor and GPU.
+    ///
+    /// @return 0 if successful, otherwise -1
+    int (*variorum_cap_gpu_power_limit)(unsigned int gpu_power_limit);
+
     /// @brief Function pointer to print the feature set.
     ///
     /// @return Error code.

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -421,7 +421,7 @@ int variorum_cap_socket_frequency_limit(int socketid, int socket_freq_mhz)
     return err;
 }
 
-int variorum_cap_gpu_power_limit(int gpu_power_limit)
+int variorum_cap_each_gpu_power_limit(int gpu_power_limit)
 {
     int err = 0;
     int i;
@@ -432,7 +432,7 @@ int variorum_cap_gpu_power_limit(int gpu_power_limit)
     }
     for (i = 0; i < P_NUM_PLATFORMS; i++)
     {
-        if (g_platform[i].variorum_cap_gpu_power_limit == NULL)
+        if (g_platform[i].variorum_cap_each_gpu_power_limit == NULL)
         {
             variorum_error_handler("Feature not yet implemented or is not supported",
                                    VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
@@ -440,7 +440,7 @@ int variorum_cap_gpu_power_limit(int gpu_power_limit)
                                    __FUNCTION__, __LINE__);
             return 0;
         }
-        err = g_platform[i].variorum_cap_gpu_power_limit(gpu_power_limit);
+        err = g_platform[i].variorum_cap_each_gpu_power_limit(gpu_power_limit);
         if (err)
         {
             return -1;

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -421,6 +421,39 @@ int variorum_cap_socket_frequency_limit(int socketid, int socket_freq_mhz)
     return err;
 }
 
+int variorum_cap_gpu_power_limit(int gpu_power_limit)
+{
+    int err = 0;
+    int i;
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    for (i = 0; i < P_NUM_PLATFORMS; i++)
+    {
+        if (g_platform[i].variorum_cap_gpu_power_ratio == NULL)
+        {
+            variorum_error_handler("Feature not yet implemented or is not supported",
+                                   VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                                   getenv("HOSTNAME"), __FILE__,
+                                   __FUNCTION__, __LINE__);
+            return 0;
+        }
+        err = g_platform[i].variorum_cap_gpu_power_limit(gpu_power_limit);
+        if (err)
+        {
+            return -1;
+        }
+    }
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}
+
 int variorum_print_features(void)
 {
     int err = 0;

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -432,7 +432,7 @@ int variorum_cap_gpu_power_limit(int gpu_power_limit)
     }
     for (i = 0; i < P_NUM_PLATFORMS; i++)
     {
-        if (g_platform[i].variorum_cap_gpu_power_ratio == NULL)
+        if (g_platform[i].variorum_cap_gpu_power_limit == NULL)
         {
             variorum_error_handler("Feature not yet implemented or is not supported",
                                    VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -145,14 +145,15 @@ int variorum_cap_socket_frequency_limit(int socketid, int socket_freq_mhz);
 /// @brief Cap the power usage identically of each GPU on the node.
 ///
 /// @supparch
-/// - NVIDIA Volta and later
-/// - WIP: AMD
+/// - NVIDIA Volta, Ampere
+/// - AMD Instinct (MI-50 onwards)
+//  - Intel Discrete GPU
 ///
 /// @param [in] gpu_power_limit Desired power limit in watts for each GPU
 ///             on the node.
 ///
 /// @return 0 if successful, otherwise -1
-int variorum_cap_gpu_power_limit(int gpu_power_limit);
+int variorum_cap_each_gpu_power_limit(int gpu_power_limit);
 
 /*******************/
 /* Print Functions */

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -129,13 +129,6 @@ int variorum_cap_gpu_power_ratio(int gpu_power_ratio);
 /// not supported, otherwise -1
 int variorum_cap_each_core_frequency_limit(int cpu_freq_mhz);
 
-///// @brief Cap the power limit of the GPU domain.
-/////
-///// @param [in] gpu_power_limit Desired power limit for each GPU.
-/////
-///// @return Error code.
-//int cap_each_gpu_power_limit(int gpu_power_limit);
-
 /// @brief Cap the frequency of the target processor.
 ///
 /// @supparch
@@ -148,6 +141,18 @@ int variorum_cap_each_core_frequency_limit(int cpu_freq_mhz);
 /// @return 0 if successful or if feature has not been implemented or is
 /// not supported, otherwise -1
 int variorum_cap_socket_frequency_limit(int socketid, int socket_freq_mhz);
+
+/// @brief Cap the power usage identically of each GPU on the node.
+///
+/// @supparch
+/// - NVIDIA Volta and later
+/// - WIP: AMD
+///
+/// @param [in] gpu_power_limit Desired power limit in watts for each GPU
+///             on the node.
+///
+/// @return 0 if successful, otherwise -1
+int variorum_cap_gpu_power_limit(int gpu_power_limit);
 
 /*******************/
 /* Print Functions */


### PR DESCRIPTION
# Description

This is a PR to add Variorum API to enable GPU power capping for NVIDIA, AMD and Intel GPUs. This PR fixes #316. 

## Type of change

- New feature/architecture support: Cap power usage of NVIDIA, AMD and Intel GPUs wherever supported.
  - [x] Nvidia
  - [x] AMD
  - [x] Intel
- [x] Documentation update
- [x] Build/CI update

# Testing: 

The contributions in this PR have been successfully tested on the following GPU platforms:

- NVIDIA: Volta GPUs on Lassen and Alehouse (internal system)
- AMD: Instinct MI-100 on Chameleon Cluster  (www.chameleoncloud.org)
- Intel GPU: Intel DGPU system at Argonne National Laboratory. 

----
Log:
- Continuation of old PR #365 with updated name for the originating branch