### PR TITLE
Check missing non-optional arguments in some examples

### DIFF
--- a/src/examples/variorum-cap-best-effort-node-power-limit-example.c
+++ b/src/examples/variorum-cap-best-effort-node-power-limit-example.c
@@ -35,6 +35,11 @@ int main(int argc, char **argv)
                 return -1;
         }
     }
+    if (optind == 1)
+    {
+        printf(usage, argv[0]);
+        return -1;
+    }
 
     printf("Capping node to %dW.\n", node_pow_lim_watts);
 

--- a/src/examples/variorum-cap-each-core-frequency-limit-example.c
+++ b/src/examples/variorum-cap-each-core-frequency-limit-example.c
@@ -34,6 +34,11 @@ int main(int argc, char **argv)
                 return -1;
         }
     }
+    if (optind == 1)
+    {
+        printf(usage, argv[0]);
+        return -1;
+    }
 
     printf("Capping each CPU to %d MHz.\n", cpu_freq_mhz);
 

--- a/src/examples/variorum-cap-gpu-power-ratio-example.c
+++ b/src/examples/variorum-cap-gpu-power-ratio-example.c
@@ -34,6 +34,11 @@ int main(int argc, char **argv)
                 return -1;
         }
     }
+    if (optind == 1)
+    {
+        printf(usage, argv[0]);
+        return -1;
+    }
 
     printf("Capping GPU power ratio to %d percent.\n", gpu_power_ratio_pct);
 

--- a/src/examples/variorum-cap-socket-frequency-limit-example.c
+++ b/src/examples/variorum-cap-socket-frequency-limit-example.c
@@ -38,6 +38,11 @@ int main(int argc, char **argv)
                 return -1;
         }
     }
+    if (optind == 1)
+    {
+        printf(usage, argv[0]);
+        return -1;
+    }
 
     printf("Capping CPU %d to %d MHz.\n", cpu_id, cpu_freq_mhz);
 

--- a/src/examples/variorum-cap-socket-power-limit-example.c
+++ b/src/examples/variorum-cap-socket-power-limit-example.c
@@ -34,6 +34,11 @@ int main(int argc, char **argv)
                 return -1;
         }
     }
+    if (optind == 1)
+    {
+        printf(usage, argv[0]);
+        return -1;
+    }
 
     printf("Capping each socket to %dW.\n", pkg_pow_lim_watts);
 


### PR DESCRIPTION
Check missing non-optional arguments in examples demonstrating control APIs with non-optional arguments.

# Description

Some examples incorrectly handle missing non-optional arguments that are used as input for control APIs. The list of example programs is as follows:

variorum-cap-best-effort-node-power-limit-example.c
variorum-cap-each-core-frequency-limit-example.c
variorum-cap-gpu-power-ratio-example.c
variorum-cap-socket-frequency-limit-example.c
variorum-cap-socket-power-limit-example.c

After the fix, the examples output usage when invoked with missing non-optional arguments:

```
$ ./variorum-cap-best-effort-node-power-limit-example
Usage: ./variorum-cap-best-effort-node-power-limit-example [-h] [-v] -l watts

$ ./variorum-cap-gpu-power-ratio-example
Usage: ./variorum-cap-gpu-power-ratio-example [-h] [-v] -r percent

$ ./variorum-cap-socket-frequency-limit-example
Usage: ./variorum-cap-socket-frequency-limit-example [-h] [-v] -i socket -f MHz

$ ./variorum-cap-socket-power-limit-example
Usage: ./variorum-cap-socket-power-limit-example [-h] [-v] -l power_lim_watts

$ ./variorum-cap-each-core-frequency-limit-example
Usage: ./variorum-cap-each-core-frequency-limit-example [-h] [-v] -f MHz
```

Fixes #367
