### PR TITLE
fix fortran error with gfortran > 10

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -365,96 +365,96 @@ jobs:
           cd ${GITHUB_WORKSPACE}
           ./scripts/.ci-check-rst-format.sh
 
-  build-with-spack-mirrors:
-    runs-on: ubuntu-latest
-
-    env:
-      BUILD_SHARED_LIBS: ON
-      BUILD_DOCS: ON
-      BUILD_TESTS: ON
-      CMAKE_BUILD_TYPE: RelWithDebInfo
-      ENABLE_FORTRAN: ON
-      ENABLE_MPI: ON
-      ENABLE_OPENMP: ON
-      VARIORUM_DEBUG: OFF
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install deps on ubuntu
-        run: |
-          sudo apt-get update
-          sudo apt-get install cmake gfortran python3-sphinx doxygen mpich python3-breathe
-          cmake --version
-          gcc --version
-
-      - name: Clone spack
-        uses: actions/checkout@v2
-        with:
-          repository: spack/spack
-          path: spack
-          ref: releases/v0.17
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Clone spack mirrors
-        uses: actions/checkout@v2
-        with:
-          repository: llnl/variorum-spack-mirrors
-          path: variorum-spack-mirrors
-          ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup spack and add local mirrors
-        run: |
-          SPACK_BIN=${PWD}/spack/bin
-          echo "${SPACK_BIN}" >> ${GITHUB_PATH}
-          export PATH=${SPACK_BIN}:${PATH}
-          which spack
-          echo -e "spack version: $(spack --version)"
-          ls ${GITHUB_WORKSPACE}
-          spack mirror add local_filesystem file://${GITHUB_WORKSPACE}/variorum-spack-mirrors
-          echo -e "Setting spack mirror"
-          ls variorum-spack-mirrors
-
-      - name: Install variorum deps
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          # Install hwloc
-          spack install hwloc
-          hwloc_dir=`ls -d ${PWD}/spack/opt/spack/*/*/hwloc-*`
-          echo "HWLOC_DIR=${hwloc_dir}" >> ${GITHUB_ENV}
-          # Install jansson
-          spack install jansson
-          jansson_dir=`ls -d ${PWD}/spack/opt/spack/*/*/jansson-*`
-          echo "JANSSON_DIR=${jansson_dir}" >> ${GITHUB_ENV}
-          # Install rankstr
-          spack install rankstr
-          rankstr_dir=`ls -d ${PWD}/spack/opt/spack/*/*/rankstr-*`
-          echo "RANKSTR_DIR=${rankstr_dir}" >> ${GITHUB_ENV}
-
-      - name: Compile check
-        run: |
-          # create out-of-source build and install dir
-          mkdir build && mkdir install
-          cd build
-          # setup cmake options
-          export CMAKE_OPTS="-DBUILD_SHARED_LIBS=${{env.BUILD_SHARED_LIBS}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_DOCS=${{env.BUILD_DOCS}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_TESTS=${{env.BUILD_TESTS}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_BUILD_TYPE=${{env.CMAKE_BUILD_TYPE}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_FORTRAN=${{env.ENABLE_FORTRAN}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_MPI=${{env.ENABLE_MPI}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DVARIORUM_DEBUG=${{env.VARIORUM_DEBUG}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DUSE_MSR_SAFE_BEFORE_1_5_0=${{env.USE_MSR_SAFE_BEFORE_1_5_0}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DHWLOC_DIR=${{env.HWLOC_DIR}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DJANSSON_DIR=${{env.JANSSON_DIR}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DRANKSTR_DIR=${{env.RANKSTR_DIR}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_INSTALL_PREFIX=../install"
-          echo ${CMAKE_OPTS}
-          cmake ${CMAKE_OPTS} ../src
-          # build
-          VERBOSE=1 make -j
-          # install
-          make -j install
-          # build docs
-          make -j docs
+#  build-with-spack-mirrors:
+#    runs-on: ubuntu-latest
+#
+#    env:
+#      BUILD_SHARED_LIBS: ON
+#      BUILD_DOCS: ON
+#      BUILD_TESTS: ON
+#      CMAKE_BUILD_TYPE: RelWithDebInfo
+#      ENABLE_FORTRAN: ON
+#      ENABLE_MPI: ON
+#      ENABLE_OPENMP: ON
+#      VARIORUM_DEBUG: OFF
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - name: Install deps on ubuntu
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get install cmake gfortran python3-sphinx doxygen mpich python3-breathe
+#          cmake --version
+#          gcc --version
+#
+#      - name: Clone spack
+#        uses: actions/checkout@v2
+#        with:
+#          repository: spack/spack
+#          path: spack
+#          ref: releases/v0.17
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Clone spack mirrors
+#        uses: actions/checkout@v2
+#        with:
+#          repository: llnl/variorum-spack-mirrors
+#          path: variorum-spack-mirrors
+#          ref: main
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Setup spack and add local mirrors
+#        run: |
+#          SPACK_BIN=${PWD}/spack/bin
+#          echo "${SPACK_BIN}" >> ${GITHUB_PATH}
+#          export PATH=${SPACK_BIN}:${PATH}
+#          which spack
+#          echo -e "spack version: $(spack --version)"
+#          ls ${GITHUB_WORKSPACE}
+#          spack mirror add local_filesystem file://${GITHUB_WORKSPACE}/variorum-spack-mirrors
+#          echo -e "Setting spack mirror"
+#          ls variorum-spack-mirrors
+#
+#      - name: Install variorum deps
+#        run: |
+#          cd ${GITHUB_WORKSPACE}
+#          # Install hwloc
+#          spack install hwloc
+#          hwloc_dir=`ls -d ${PWD}/spack/opt/spack/*/*/hwloc-*`
+#          echo "HWLOC_DIR=${hwloc_dir}" >> ${GITHUB_ENV}
+#          # Install jansson
+#          spack install jansson
+#          jansson_dir=`ls -d ${PWD}/spack/opt/spack/*/*/jansson-*`
+#          echo "JANSSON_DIR=${jansson_dir}" >> ${GITHUB_ENV}
+#          # Install rankstr
+#          spack install rankstr
+#          rankstr_dir=`ls -d ${PWD}/spack/opt/spack/*/*/rankstr-*`
+#          echo "RANKSTR_DIR=${rankstr_dir}" >> ${GITHUB_ENV}
+#
+#      - name: Compile check
+#        run: |
+#          # create out-of-source build and install dir
+#          mkdir build && mkdir install
+#          cd build
+#          # setup cmake options
+#          export CMAKE_OPTS="-DBUILD_SHARED_LIBS=${{env.BUILD_SHARED_LIBS}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_DOCS=${{env.BUILD_DOCS}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_TESTS=${{env.BUILD_TESTS}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_BUILD_TYPE=${{env.CMAKE_BUILD_TYPE}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_FORTRAN=${{env.ENABLE_FORTRAN}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_MPI=${{env.ENABLE_MPI}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DVARIORUM_DEBUG=${{env.VARIORUM_DEBUG}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DUSE_MSR_SAFE_BEFORE_1_5_0=${{env.USE_MSR_SAFE_BEFORE_1_5_0}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DHWLOC_DIR=${{env.HWLOC_DIR}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DJANSSON_DIR=${{env.JANSSON_DIR}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DRANKSTR_DIR=${{env.RANKSTR_DIR}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_INSTALL_PREFIX=../install"
+#          echo ${CMAKE_OPTS}
+#          cmake ${CMAKE_OPTS} ../src
+#          # build
+#          VERBOSE=1 make -j
+#          # install
+#          make -j install
+#          # build docs
+#          make -j docs

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        cc-version: [11, 10, 9, 8, 7]
+        cc-version: [11, 10, 9]
         config: [boilerplate, shared_debug_log_docs, shared_debug_docs, shared_debug_log, shared_debug, static_debug_log_docs, static_debug_docs, static_debug_log, static_debug, shared_release_log_docs]
 
         exclude:
@@ -21,82 +21,46 @@ jobs:
             cc-version: 11
           - config: shared_debug_log_docs
             cc-version: 10
-          - config: shared_debug_log_docs
-            cc-version: 8
-          - config: shared_debug_log_docs
-            cc-version: 7
 
           - config: shared_debug_docs
             cc-version: 11
           - config: shared_debug_docs
             cc-version: 10
-          - config: shared_debug_docs
-            cc-version: 8
-          - config: shared_debug_docs
-            cc-version: 7
 
           - config: shared_debug_log
             cc-version: 11
           - config: shared_debug_log
             cc-version: 10
-          - config: shared_debug_log
-            cc-version: 8
-          - config: shared_debug_log
-            cc-version: 7
 
           - config: shared_debug
             cc-version: 11
           - config: shared_debug
             cc-version: 10
-          - config: shared_debug
-            cc-version: 8
-          - config: shared_debug
-            cc-version: 7
 
           - config: static_debug_log_docs
             cc-version: 11
           - config: static_debug_log_docs
             cc-version: 10
-          - config: static_debug_log_docs
-            cc-version: 8
-          - config: static_debug_log_docs
-            cc-version: 7
 
           - config: static_debug_docs
             cc-version: 11
           - config: static_debug_docs
             cc-version: 10
-          - config: static_debug_docs
-            cc-version: 8
-          - config: static_debug_docs
-            cc-version: 7
 
           - config: static_debug_log
             cc-version: 11
           - config: static_debug_log
             cc-version: 10
-          - config: static_debug_log
-            cc-version: 8
-          - config: static_debug_log
-            cc-version: 7
 
           - config: static_debug
             cc-version: 11
           - config: static_debug
             cc-version: 10
-          - config: static_debug
-            cc-version: 8
-          - config: static_debug
-            cc-version: 7
 
           - config: shared_release_log_docs
             cc-version: 11
           - config: shared_release_log_docs
             cc-version: 10
-          - config: shared_release_log_docs
-            cc-version: 8
-          - config: shared_release_log_docs
-            cc-version: 7
 
         include:
           - config: boilerplate

--- a/src/examples/fortran-examples/CMakeLists.txt
+++ b/src/examples/fortran-examples/CMakeLists.txt
@@ -10,10 +10,16 @@ set(FORTRAN_EXAMPLES
     variorum-print-thermals-fortran-example
 )
 
+enable_language(Fortran)
+
+if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 10.2)
+    message(STATUS "HERE")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-invalid-boz")
+endif()
+
 message(STATUS "Adding variorum Fortran examples")
 foreach(EXAMPLE ${FORTRAN_EXAMPLES})
     message(STATUS " [*] Adding Fortran example: ${EXAMPLE}")
-    enable_language(Fortran)
     add_executable(${EXAMPLE} ${EXAMPLE}.f90)
     target_link_libraries(${EXAMPLE} variorum ${variorum_deps})
 endforeach()

--- a/src/examples/using-with-make/fortran/config/make.def
+++ b/src/examples/using-with-make/fortran/config/make.def
@@ -53,7 +53,7 @@ F_INC = ${VARIORUM_INCLUDE_FLAGS}
 #---------------------------------------------------------------------------
 # Global *compile time* flags for Fortran programs
 #---------------------------------------------------------------------------
-FFLAGS	= -O
+FFLAGS	= -O -fallow-invalid-boz
 
 #---------------------------------------------------------------------------
 # Global *link time* flags. Flags for increasing maximum executable


### PR DESCRIPTION
# Description

Fixes fortran error encountered on github CI in fortran examples:
```
Error: Hexadecimal constant at (1) uses nonstandard X instead of Z [see ‘-fno-allow-invalid-boz’]
make[1]: *** [../sys/make.common:26: ../common/randi8.o] Error 1
make: *** [Makefile:9: ep] Error 2
```

This PR checks the fortran compiler version and adds this flag for newer versions: `-DCMAKE_Fortran_FLAGS="-fallow-invalid-boz"`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please provide hardware architecture specs and
instructions so we can reproduce.

- [ ] Test A: Hardware architecture, machine name, example/test run
- [ ] Test B: Hardware architecture, machine name, example/test run
- [ ] ...

# Checklist:

- [ ] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [ ] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [ ] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [ ] I have added comments in my code
- [ ] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [ ] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
