### PR TITLE
Fix for multiplatform build (ARM+NVIDIA) error/warnings (issue #376)

### DIFF
--- a/host-configs/nvhpc1-4.18.0-aarch64-gcc@8.5.0-cuda@525.60.13-both.cmake
+++ b/host-configs/nvhpc1-4.18.0-aarch64-gcc@8.5.0-cuda@525.60.13-both.cmake
@@ -1,0 +1,27 @@
+# Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+# Variorum Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+# c compiler
+set(CMAKE_C_COMPILER "/usr/bin/gcc" CACHE PATH "")
+
+# cpp compiler
+set(CMAKE_CXX_COMPILER "/usr/bin/g++" CACHE PATH "")
+
+set(BUILD_DOCS OFF CACHE BOOL "")
+set(BUILD_TESTS OFF CACHE BOOL "")
+
+set(VARIORUM_WITH_ARM_CPU ON CACHE BOOL "")
+set(VARIORUM_WITH_NVIDIA_GPU ON CACHE BOOL "")
+set(VARIORUM_WITH_AMD_CPU OFF CACHE BOOL "")
+set(VARIORUM_WITH_AMD_GPU OFF CACHE BOOL "")
+set(VARIORUM_WITH_IBM_CPU OFF CACHE BOOL "")
+set(VARIORUM_WITH_INTEL_CPU OFF CACHE BOOL "")
+
+set(CMAKE_SHARED_LINKER_FLAGS "-L/usr/local/lib -L/opt/nvidia/hpc_sdk/Linux_aarch64/22.1/cuda/11.5/targets/sbsa-linux/lib/stubs/ -lnvidia-ml" CACHE PATH "")
+
+# path to global hwloc install
+set(HWLOC_DIR "/usr/local" CACHE PATH "")
+
+set(NVML_DIR "/opt/nvidia/hpc_sdk/Linux_aarch64/22.1/cuda/11.5/targets/sbsa-linux/" CACHE PATH "")

--- a/src/variorum/ARM/config_arm.c
+++ b/src/variorum/ARM/config_arm.c
@@ -8,8 +8,8 @@
 
 #include <config_arm.h>
 #include <config_architecture.h>
-#include "power_features_Juno_r2.h"
-#include "power_features_Neoverse_N1.h"
+#include <power_features_Juno_r2.h>
+#include <power_features_Neoverse_N1.h>
 #include <ARM_Juno_r2.h>
 #include <ARM_Neoverse_N1.h>
 #include <variorum_error.h>

--- a/src/variorum/ARM/power_features_Juno_r2.c
+++ b/src/variorum/ARM/power_features_Juno_r2.c
@@ -12,8 +12,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <inttypes.h>
-
-#include "power_features_Juno_r2.h"
+#include <power_features_Juno_r2.h>
 #include <variorum_error.h>
 #include <variorum_timers.h>
 
@@ -296,7 +295,6 @@ int arm_cpu_juno_r2_cap_socket_frequency(int socketid, int new_freq)
     return 0;
 }
 
-
 int arm_cpu_juno_r2_json_get_power_data(json_t *get_power_obj)
 {
     char hostname[1024];
@@ -388,7 +386,6 @@ int arm_cpu_juno_r2_json_get_power_data(json_t *get_power_obj)
                         json_real((double)(gpu_power_val) / 1000000.0f));
     return 0;
 }
-
 
 int arm_cpu_juno_r2_json_get_power_domain_info(json_t *get_domain_obj)
 {

--- a/src/variorum/Nvidia_GPU/Volta.c
+++ b/src/variorum/Nvidia_GPU/Volta.c
@@ -9,7 +9,7 @@
 #include <Volta.h>
 #include <config_architecture.h>
 #include <variorum_error.h>
-#include "power_features.h"
+#include <power_features.h>
 
 int volta_get_power(int long_ver)
 {

--- a/src/variorum/Nvidia_GPU/Volta.c
+++ b/src/variorum/Nvidia_GPU/Volta.c
@@ -9,7 +9,7 @@
 #include <Volta.h>
 #include <config_architecture.h>
 #include <variorum_error.h>
-#include <power_features.h>
+#include "power_features.h"
 
 int volta_get_power(int long_ver)
 {
@@ -24,7 +24,7 @@ int volta_get_power(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
     for (iter = 0; iter < nsockets; iter++)
     {
-        get_power_data(iter, long_ver, stdout);
+        nvidia_gpu_get_power_data(iter, long_ver, stdout);
     }
     return 0;
 }
@@ -42,7 +42,7 @@ int volta_get_thermals(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
     for (iter = 0; iter < nsockets; iter++)
     {
-        get_thermal_data(iter, long_ver, stdout);
+        nvidia_gpu_get_thermal_data(iter, long_ver, stdout);
     }
     return 0;
 }
@@ -60,7 +60,7 @@ int volta_get_clocks(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
     for (iter = 0; iter < nsockets; iter++)
     {
-        get_clocks_data(iter, long_ver, stdout);
+        nvidia_gpu_get_clocks_data(iter, long_ver, stdout);
     }
     return 0;
 }
@@ -78,7 +78,7 @@ int volta_get_power_limits(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
     for (iter = 0; iter < nsockets; iter++)
     {
-        get_power_limits(iter, long_ver, stdout);
+        nvidia_gpu_get_power_limits_data(iter, long_ver, stdout);
     }
     return 0;
 }
@@ -96,7 +96,7 @@ int volta_get_gpu_utilization(int long_ver)
     variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
     for (iter = 0; iter < nsockets; iter++)
     {
-        get_gpu_utilization(iter, long_ver, stdout);
+        nvidia_gpu_get_gpu_utilization_data(iter, long_ver, stdout);
     }
     return 0;
 }

--- a/src/variorum/Nvidia_GPU/config_nvidia.h
+++ b/src/variorum/Nvidia_GPU/config_nvidia.h
@@ -8,7 +8,7 @@
 
 #include <inttypes.h>
 
-#include "power_features.h"
+#include <power_features.h>
 #include <Volta.h>
 
 uint64_t *detect_gpu_arch(void);

--- a/src/variorum/Nvidia_GPU/config_nvidia.h
+++ b/src/variorum/Nvidia_GPU/config_nvidia.h
@@ -8,7 +8,7 @@
 
 #include <inttypes.h>
 
-#include <power_features.h>
+#include "power_features.h"
 #include <Volta.h>
 
 uint64_t *detect_gpu_arch(void);

--- a/src/variorum/Nvidia_GPU/power_features.c
+++ b/src/variorum/Nvidia_GPU/power_features.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include "power_features.h"
+#include <power_features.h>
 #include <config_architecture.h>
 #include <variorum_error.h>
 #include <variorum_timers.h>

--- a/src/variorum/Nvidia_GPU/power_features.c
+++ b/src/variorum/Nvidia_GPU/power_features.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <power_features.h>
+#include "power_features.h"
 #include <config_architecture.h>
 #include <variorum_error.h>
 #include <variorum_timers.h>
@@ -48,7 +48,7 @@ void shutdownNVML(void)
     nvmlShutdown();
 }
 
-void get_power_data(int chipid, int verbose, FILE *output)
+void nvidia_gpu_get_power_data(int chipid, int verbose, FILE *output)
 {
     unsigned int power;
     double value = 0.0;
@@ -81,7 +81,7 @@ void get_power_data(int chipid, int verbose, FILE *output)
     }
 }
 
-void get_thermal_data(int chipid, int verbose, FILE *output)
+void nvidia_gpu_get_thermal_data(int chipid, int verbose, FILE *output)
 {
     unsigned gpu_temp;
     int d;
@@ -115,7 +115,7 @@ void get_thermal_data(int chipid, int verbose, FILE *output)
     /*!@todo: Print GPU memory temperature */
 }
 
-void get_power_limits(int chipid, int verbose, FILE *output)
+void nvidia_gpu_get_power_limits_data(int chipid, int verbose, FILE *output)
 {
     unsigned int power_limit;
     double value = 0.0;
@@ -149,7 +149,7 @@ void get_power_limits(int chipid, int verbose, FILE *output)
     /*!@todo: Seperate interface for default power limits? */
 }
 
-void get_clocks_data(int chipid, int verbose, FILE *output)
+void nvidia_gpu_get_clocks_data(int chipid, int verbose, FILE *output)
 {
     unsigned int gpu_clock;
     int d;
@@ -181,7 +181,7 @@ void get_clocks_data(int chipid, int verbose, FILE *output)
     }
 }
 
-void get_gpu_utilization(int chipid, int verbose, FILE *output)
+void nvidia_gpu_get_gpu_utilization_data(int chipid, int verbose, FILE *output)
 {
     nvmlUtilization_t util;
     int d;

--- a/src/variorum/Nvidia_GPU/power_features.h
+++ b/src/variorum/Nvidia_GPU/power_features.h
@@ -20,15 +20,15 @@ void initNVML(void);
 
 void shutdownNVML(void);
 
-void get_power_data(int chipid, int verbose, FILE *output);
+void nvidia_gpu_get_power_data(int chipid, int verbose, FILE *output);
 
-void get_thermal_data(int chipid, int verbose, FILE *output);
+void nvidia_gpu_get_thermal_data(int chipid, int verbose, FILE *output);
 
-void get_clocks_data(int chipid, int verbose, FILE *output);
+void nvidia_gpu_get_clocks_data(int chipid, int verbose, FILE *output);
 
-void get_power_limits(int chipid, int verbose, FILE *output);
+void nvidia_gpu_get_power_limits_data(int chipid, int verbose, FILE *output);
 
-void get_gpu_utilization(int chipid, int verbose, FILE *output);
+void nvidia_gpu_get_gpu_utilization_data(int chipid, int verbose, FILE *output);
 
 void cap_each_gpu_power_limit(int chipid, unsigned int powerlimit);
 


### PR DESCRIPTION
# Description (edited)

This PR provides a working solution to fix issue #376. I'm submitting this just to get the discussion started and track ideas/comments. The changes are limited to ARM (CPU) and NVIDIA GPU ports (tested on `nvhpc1`) as the issue does not occur on the combination of other vendor/platform on the test systems available to us. Once we agree on the approach, it should be straightforward to extend it for the remaining platforms. 

The PR introduces the following changes to address the issue:

1. Forces build to prioritize the use of local `<CMAKE_CURRENT_SOURCE_DIR>/power_features.h` over the first `power_features.h` specified in the path picked up by CMake by changing angled brackets to double quotes. If this issue needs to be resolved in the CMake config instead, I suspect we'd need to refactor the CMake config to split the target into separate target object file --one for each platform -- and then build the (composite) library target. 
2. Added `[vendor]_[device]_` prefix to each low-level function in the `ARM/` (e.g. `arm_cpu_get_thermal_data`) and `Nvidia_GPU/` (e.g. `nvidia_gpu_get_thermal_data`) codebase. This makes of the function names quite long, so if there's a better way to automatically add those prefixes in the compiler pre-processing stage without making the code look ugly, that'd be interesting.
3. Added the hostfile that I'm using on the nvhpc1 system for reference.


Edit 1: This changes to the definitions of the json_* APIs but those haven't been tested on `nvhpc1`.

# How Has This Been Tested?

The changes have been tested on `nvhpc1` system. Example:

```
$ examples/variorum-print-thermals-example
_NVIDIA_GPU_TEMPERATURE Host Socket DeviceID Temperature_C
_NVIDIA_GPU_TEMPERATURE nvhpc1 0 0 34
_NVIDIA_GPU_TEMPERATURE nvhpc1 0 1 30
_ARM_TEMPERATURE Host Sys_C Big_C Little_C GPU_C
_ARM_TEMPERATURE nvhpc1 37.00 37.00 37.00 37.00
```

Builds without errors or warnings.

# Checklist:

-- None as this is a draft PR.

Fixes #376.