### PR TITLE
use python 3.7 for code format checks in CI

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -324,7 +324,11 @@ jobs:
           ./ep.W.x
 
   check-code-format:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.7]
 
     steps:
       # Checkout variorum repository under $GITHUB_WORKSPACE
@@ -347,11 +351,12 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          python -m pip install --upgrade pip flake8 rstfmt
+          python -m pip install --upgrade pip rstfmt
 
       - name: Update Black
         run: |
-          pip install --upgrade black
+          pip install black==21.12b0
+          pip install flake8==4.0.1
 
       - name: Style check python files
         run: |


### PR DESCRIPTION
# Description

Pins python version in CI stage for checking code format. This will use python 3.7 and pins black and flake8 versions as well.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Build/CI update

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my C/C++ code follows the style guidelines of variorum
- [x] I have run `flake8` and `black --check --diff` and confirm my python code follows the style guidelines of variorum
- [x] I have run `./scripts/check-rst-format.sh` and confirm my documentation follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes