### PR TITLE
Replaced existing RSMI API call with the correct API to get GPU busy %

### DIFF
--- a/src/variorum/AMD_GPU/power_features.c
+++ b/src/variorum/AMD_GPU/power_features.c
@@ -436,7 +436,7 @@ void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
         if (verbose == 0)
         {
             fprintf(output,
-                    "_AMD_GPU_UTILIZATION Host Socket DeviceID GFX_Util Mem_Util Timestamp_sec\n");
+                    "_AMD_GPU_UTILIZATION Host Socket DeviceID Util\n");
         }
     }
 
@@ -445,15 +445,9 @@ void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
     for (int i = chipid * gpus_per_socket;
          i < (chipid + 1) * gpus_per_socket; i++)
     {
-        rsmi_utilization_counter_t util_ctr[2];
-        uint64_t ts; //Timestamp returned by RSMI API that we don't currently use.
+        uint32_t utilpercent; //Percentage of time the GPU was busy
 
-        // This requests ROCM GPU GFX Activity.
-        util_ctr[0].type = RSMI_UTILIZATION_COUNTER_FIRST;
-        // This requests ROCM GPU Memory Activity.
-        util_ctr[1].type = RSMI_COARSE_GRAIN_MEM_ACTIVITY;
-
-        ret = rsmi_utilization_count_get(i, util_ctr, 2, &ts);
+        ret = rsmi_dev_busy_percent_get(i, &utilpercent);
         if (ret != RSMI_STATUS_SUCCESS)
         {
             variorum_error_handler("RSMI API was not successful",
@@ -466,15 +460,13 @@ void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
         {
             fprintf(output,
                     "_AMD_GPU_UTILIZATION Host: %s, Socket: %d, DeviceID: %d,"
-                    "GFX_Util: %ld%%, Mem_Util: %ld%%, Timestamp: %lf sec\n",
-                    hostname, chipid, i, util_ctr[0].value, util_ctr[1].value,
-                    (now.tv_usec - start.tv_usec) / 1000000.0);
+                    "Util: %d%%\n",
+                    hostname, chipid, i, utilpercent);
         }
         else
         {
-            fprintf(output, "_AMD_GPU_UTILIZATION %s %d %d %ld %ld %lf\n",
-                    hostname, chipid, i, util_ctr[0].value, util_ctr[1].value,
-                    (now.tv_usec - start.tv_usec) / 1000000.0);
+            fprintf(output, "_AMD_GPU_UTILIZATION %s %d %d %d\n",
+                    hostname, chipid, i, utilpercent);
         }
 
     }

--- a/src/variorum/AMD_GPU/power_features.c
+++ b/src/variorum/AMD_GPU/power_features.c
@@ -445,7 +445,7 @@ void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
     for (int i = chipid * gpus_per_socket;
          i < (chipid + 1) * gpus_per_socket; i++)
     {
-        uint32_t utilpercent; //Percentage of time the GPU was busy
+        uint32_t utilpercent; // Percentage of time the GPU was busy
 
         ret = rsmi_dev_busy_percent_get(i, &utilpercent);
         if (ret != RSMI_STATUS_SUCCESS)
@@ -460,8 +460,7 @@ void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
         {
             fprintf(output,
                     "_AMD_GPU_UTILIZATION Host: %s, Socket: %d, DeviceID: %d,"
-                    "Util: %d%%\n",
-                    hostname, chipid, i, utilpercent);
+                    "Util: %d%%\n", hostname, chipid, i, utilpercent);
         }
         else
         {


### PR DESCRIPTION
# Description

This PR fixes the GPU utilization reporting functionality of Variorum on AMD GPUs. The fix replaces the `rsmi_utilization_count_get()` RSMI API with the `rsmi_dev_busy_percent_get()` API in RSMI to get the instantaneous GPU utilization. 

Fixes #388 

Has been tested on Tioga with no workload. Needs further testing with continuously running workload. Optionally needs testing on one other system available to us (Corona, Chameleon).

## Testing

### Tioga 

No workload running

```
$ examples/variorum-print-gpu-utilization-example
_AMD_GPU_UTILIZATION Host Socket DeviceID Util
_AMD_GPU_UTILIZATION tioga23 0 0 0
_AMD_GPU_UTILIZATION tioga23 0 1 0
_AMD_GPU_UTILIZATION tioga23 0 2 0
_AMD_GPU_UTILIZATION tioga23 0 3 0
_AMD_GPU_UTILIZATION tioga23 0 4 0
_AMD_GPU_UTILIZATION tioga23 0 5 0
_AMD_GPU_UTILIZATION tioga23 0 6 0
_AMD_GPU_UTILIZATION tioga23 0 7 0
```

HIP GPU Burn

```
[marathe1@tioga22:build5]$ examples/variorum-print-gpu-utilization-example
_AMD_GPU_UTILIZATION Host Socket DeviceID Util
_AMD_GPU_UTILIZATION tioga22 0 0 100
_AMD_GPU_UTILIZATION tioga22 0 1 100
_AMD_GPU_UTILIZATION tioga22 0 2 100
_AMD_GPU_UTILIZATION tioga22 0 3 100
_AMD_GPU_UTILIZATION tioga22 0 4 100
_AMD_GPU_UTILIZATION tioga22 0 5 100
_AMD_GPU_UTILIZATION tioga22 0 6 100
_AMD_GPU_UTILIZATION tioga22 0 7 100
[marathe1@tioga22:build5]$ examples/variorum-print-verbose-gpu-utilization-example
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 0,Util: 100%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 1,Util: 100%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 2,Util: 100%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 3,Util: 100%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 4,Util: 100%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 5,Util: 100%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 6,Util: 100%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 7,Util: 100%
```

HIP GPU stream (single GPU)

```
[marathe1@tioga22:build5]$ examples/variorum-print-gpu-utilization-example
_AMD_GPU_UTILIZATION Host Socket DeviceID Util
_AMD_GPU_UTILIZATION tioga22 0 0 100
_AMD_GPU_UTILIZATION tioga22 0 1 0
_AMD_GPU_UTILIZATION tioga22 0 2 0
_AMD_GPU_UTILIZATION tioga22 0 3 0
_AMD_GPU_UTILIZATION tioga22 0 4 0
_AMD_GPU_UTILIZATION tioga22 0 5 0
_AMD_GPU_UTILIZATION tioga22 0 6 0
_AMD_GPU_UTILIZATION tioga22 0 7 0
[marathe1@tioga22:build5]$ examples/variorum-print-verbose-gpu-utilization-example
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 0,Util: 100%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 1,Util: 0%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 2,Util: 0%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 3,Util: 0%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 4,Util: 0%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 5,Util: 0%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 6,Util: 0%
_AMD_GPU_UTILIZATION Host: tioga22, Socket: 0, DeviceID: 7,Util: 0%
```

### Chameleon Mi-100 node

No workload running

```
cc@amd-mi-100:~/variorum/build3$ examples/variorum-print-gpu-utilization-example
_AMD_GPU_UTILIZATION Host Socket DeviceID Util
_AMD_GPU_UTILIZATION amd-mi-100 0 0 0
_AMD_GPU_UTILIZATION amd-mi-100 1 1 0
cc@amd-mi-100:~/variorum/build3$ examples/variorum-print-verbose-gpu-utilization-example
_AMD_GPU_UTILIZATION Host: amd-mi-100, Socket: 0, DeviceID: 0,Util: 0%
_AMD_GPU_UTILIZATION Host: amd-mi-100, Socket: 1, DeviceID: 1,Util: 0%
```

HIP GPU Burn

```
cc@amd-mi-100:~/bm/corona-tests/HIP-Examples/gpu-burn$ ~/variorum/build3/examples/variorum-print-gpu-utilization-example
_AMD_GPU_UTILIZATION Host Socket DeviceID Util
_AMD_GPU_UTILIZATION amd-mi-100 0 0 100
_AMD_GPU_UTILIZATION amd-mi-100 1 1 100
cc@amd-mi-100:~/bm/corona-tests/HIP-Examples/gpu-burn$ ~/variorum/build3/examples/variorum-print-verbose-gpu-utilization-example
_AMD_GPU_UTILIZATION Host: amd-mi-100, Socket: 0, DeviceID: 0,Util: 100%
_AMD_GPU_UTILIZATION Host: amd-mi-100, Socket: 1, DeviceID: 1,Util: 100%
```

HIP GPU stream (single GPU)

```
cc@amd-mi-100:~/variorum/build3$ examples/variorum-print-gpu-utilization-example
_AMD_GPU_UTILIZATION Host Socket DeviceID Util
_AMD_GPU_UTILIZATION amd-mi-100 0 0 100
_AMD_GPU_UTILIZATION amd-mi-100 1 1 0
cc@amd-mi-100:~/variorum/build3$ examples/variorum-print-verbose-gpu-utilization-example
_AMD_GPU_UTILIZATION Host: amd-mi-100, Socket: 0, DeviceID: 0,Util: 100%
_AMD_GPU_UTILIZATION Host: amd-mi-100, Socket: 1, DeviceID: 1,Util: 0%
```

### Corona

No workload running:

```
marathe1@corona236 (amd-gpu-util-fix) 0]$ examples/variorum-print-gpu-utilization-example
_AMD_GPU_UTILIZATION Host Socket DeviceID Util
_AMD_GPU_UTILIZATION corona236 0 0 0
_AMD_GPU_UTILIZATION corona236 0 1 0
_AMD_GPU_UTILIZATION corona236 0 2 0
_AMD_GPU_UTILIZATION corona236 0 3 0
_AMD_GPU_UTILIZATION corona236 1 4 0
_AMD_GPU_UTILIZATION corona236 1 5 0
_AMD_GPU_UTILIZATION corona236 1 6 0
_AMD_GPU_UTILIZATION corona236 1 7 0
marathe1@corona236 (amd-gpu-util-fix) 0]$ examples/variorum-print-verbose-gpu-utilization-example
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 0,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 1,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 2,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 3,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 4,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 5,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 6,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 7,Util: 0%
```

HIP GPU Burn:

```
marathe1@corona236 (amd-gpu-util-fix) 0]$ examples/variorum-print-gpu-utilization-example
_AMD_GPU_UTILIZATION Host Socket DeviceID Util
_AMD_GPU_UTILIZATION corona236 0 0 100
_AMD_GPU_UTILIZATION corona236 0 1 100
_AMD_GPU_UTILIZATION corona236 0 2 100
_AMD_GPU_UTILIZATION corona236 0 3 100
_AMD_GPU_UTILIZATION corona236 1 4 100
_AMD_GPU_UTILIZATION corona236 1 5 100
_AMD_GPU_UTILIZATION corona236 1 6 100
_AMD_GPU_UTILIZATION corona236 1 7 100
marathe1@corona236 (amd-gpu-util-fix) 0]$ examples/variorum-print-verbose-gpu-utilization-example
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 0,Util: 100%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 1,Util: 100%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 2,Util: 100%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 3,Util: 100%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 4,Util: 100%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 5,Util: 100%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 6,Util: 100%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 7,Util: 100%

```

HIP GPU Stream:

```
marathe1@corona236 (amd-gpu-util-fix) 0]$ examples/variorum-print-gpu-utilization-example
_AMD_GPU_UTILIZATION Host Socket DeviceID Util
_AMD_GPU_UTILIZATION corona236 0 0 100
_AMD_GPU_UTILIZATION corona236 0 1 0
_AMD_GPU_UTILIZATION corona236 0 2 0
_AMD_GPU_UTILIZATION corona236 0 3 0
_AMD_GPU_UTILIZATION corona236 1 4 0
_AMD_GPU_UTILIZATION corona236 1 5 0
_AMD_GPU_UTILIZATION corona236 1 6 0
_AMD_GPU_UTILIZATION corona236 1 7 0
marathe1@corona236 (amd-gpu-util-fix) 0]$ examples/variorum-print-verbose-gpu-utilization-example
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 0,Util: 100%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 1,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 2,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 0, DeviceID: 3,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 4,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 5,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 6,Util: 0%
_AMD_GPU_UTILIZATION Host: corona236, Socket: 1, DeviceID: 7,Util: 0%
```


#### Update 4: Added tests on Corona
