### PR TITLE
Powmon rehaul

### DIFF
--- a/src/powmon/common.c
+++ b/src/powmon/common.c
@@ -8,12 +8,13 @@
 #include <variorum.h>
 #include <variorum_timers.h>
 #include <jansson.h>
+#include <stdbool.h>
 
 #define FASTEST_SAMPLE_INTERVAL_MS 50
 
 struct thread_args
 {
-    bool measure_all = 0;
+    bool measure_all = false;
     unsigned long sample_interval = FASTEST_SAMPLE_INTERVAL_MS;
 };
 
@@ -34,17 +35,17 @@ void take_measurement(bool measure_all)
     pthread_mutex_lock(&mlock);
 
     // Default is to just dump out instantaneous power samples
-    if (measure_all == 0) {
+    if (measure_all == false) {
     // Extract power information from Variorum JSON API
 
     // Write out to logfile
-    fprintf(logfile, "%ld %lf %lf %lf %lf %lf %lf %lu %lu %lu %lu\n", now_ms(),
-            rapl_data[0], rapl_data[1], rapl_data[6], rapl_data[7], rapl_data[8],
-            rapl_data[9], instr0, instr1, core0, core1);
+    //fprintf(logfile, "%ld %lf %lf %lf %lf %lf %lf %lu %lu %lu %lu\n", now_ms(),
+      //      rapl_data[0], rapl_data[1], rapl_data[6], rapl_data[7], rapl_data[8],
+        //    rapl_data[9], instr0, instr1, core0, core1);
     }
 
     // Verbose output with all sensors/registers
-    if (measure_all == 1)
+    if (measure_all == true)
         variorum_monitoring(logfile);
 
 #if 0

--- a/src/powmon/common.c
+++ b/src/powmon/common.c
@@ -71,9 +71,13 @@ void parse_json_obj(char *s, int num_sockets)
         fprintf(logfile, "%s %s ", "Timestamp (ms)", "Node Power (W)");
         for (i = 0; i < num_sockets; i++)
         {
-            fprintf(logfile, "%s", "Socket %i CPU Power (W)", i);
-            fprintf(logfile, "%s", "Socket %i GPU Power (W)", i);
-            fprintf(logfile, "%s", "Socket %i Mem Power (W)", i);
+            char str[40];
+            sprintf(str, "Socket %i CPU Power (W)", i);
+            fprintf(logfile, "%s", str);
+            sprintf(str, "Socket %i GPU Power (W)", i);
+            fprintf(logfile, "%s", str);
+            sprintf(str, "Socket %i Mem Power (W)", i);
+            fprintf(logfile, "%s", str);
 
             if ((i + 1) == num_sockets)
                 write_header = false;
@@ -188,7 +192,7 @@ void *power_measurement(void *arg)
     // 50 ms should be short enough to always get good information (this is
     // default).
     printf("Using sampling interval of: %ld ms\n", th_args.sample_interval);
-    printf("Using verbosity of: %ld ms\n", th_args.measure_all);
+    printf("Using verbosity of: %d ms\n", th_args.measure_all);
     init_msTimer(&timer, th_args.sample_interval);
     start = now_ms();
 

--- a/src/powmon/common.c
+++ b/src/powmon/common.c
@@ -68,19 +68,19 @@ void parse_json_obj(char *s, int num_sockets)
 
     if (write_header == true)
     {
-        fprintf(logfile,"%s %s ", "Timestamp (ms)", "Node Power (W)");
+        fprintf(logfile, "%s %s ", "Timestamp (ms)", "Node Power (W)");
         for (i = 0; i < num_sockets; i++)
         {
-            fprintf(logfile,"%s", "Socket %i CPU Power (W)", i);
-            fprintf(logfile,"%s", "Socket %i GPU Power (W)", i);
-            fprintf(logfile,"%s", "Socket %i Mem Power (W)", i);
+            fprintf(logfile, "%s", "Socket %i CPU Power (W)", i);
+            fprintf(logfile, "%s", "Socket %i GPU Power (W)", i);
+            fprintf(logfile, "%s", "Socket %i Mem Power (W)", i);
 
-            if ((i+1) == num_sockets)
+            if ((i + 1) == num_sockets)
                 write_header = false;
         }
 
     }
-     fprintf(logfile,"%ld %lf ", now_ms(), power_node);
+    fprintf(logfile, "%ld %lf ", now_ms(), power_node);
 
     for (i = 0; i < num_sockets; i++)
     {
@@ -91,10 +91,10 @@ void parse_json_obj(char *s, int num_sockets)
                                     json_metric_names[(num_sockets * 2) + i]));
 
 
-        fprintf(logfile,"%lf %lf %lf ", power_cpu, power_gpu, power_mem);
+        fprintf(logfile, "%lf %lf %lf ", power_cpu, power_gpu, power_mem);
 
-         // We wrote values for all sockets, let's move to the next line.
-        if ((i+1) == num_sockets)
+        // We wrote values for all sockets, let's move to the next line.
+        if ((i + 1) == num_sockets)
             fprintf(logfile, "\n");
     }
 

--- a/src/powmon/common.c
+++ b/src/powmon/common.c
@@ -35,12 +35,13 @@ void take_measurement(bool measure_all)
     pthread_mutex_lock(&mlock);
 
     // Default is to just dump out instantaneous power samples
-    if (measure_all == false) {
-    // Extract power information from Variorum JSON API
+    if (measure_all == false)
+    {
+        // Extract power information from Variorum JSON API
 
-    // Write out to logfile
-    //fprintf(logfile, "%ld %lf %lf %lf %lf %lf %lf %lu %lu %lu %lu\n", now_ms(),
-      //      rapl_data[0], rapl_data[1], rapl_data[6], rapl_data[7], rapl_data[8],
+        // Write out to logfile
+        //fprintf(logfile, "%ld %lf %lf %lf %lf %lf %lf %lu %lu %lu %lu\n", now_ms(),
+        //      rapl_data[0], rapl_data[1], rapl_data[6], rapl_data[7], rapl_data[8],
         //    rapl_data[9], instr0, instr1, core0, core1);
     }
 

--- a/src/powmon/power_wrapper_dynamic.c
+++ b/src/powmon/power_wrapper_dynamic.c
@@ -68,8 +68,8 @@ void *power_set_measurement(void *arg)
     {
         // This is intel-specific.
         // Preseve the original behavior with variorum_monitoring for now, by
-        // providing `1` as input value for the take_measurement function.
-        take_measurement(1);
+        // providing `true` as input value for the take_measurement function.
+        take_measurement(true);
         if (poll_num % 5 == 0)
         {
             if (watts >= watt_cap)
@@ -268,8 +268,8 @@ int main(int argc, char **argv)
 
         // This is intel-specific.
         // Preseve the original behavior with variorum_monitoring for now, by
-        // providing `1` as input value for the take_measurement function.
-        take_measurement(1);
+        // providing `true` as input value for the take_measurement function.
+        take_measurement(true);
         end = now_ms();
 
         /* Output summary data. */

--- a/src/powmon/power_wrapper_dynamic.c
+++ b/src/powmon/power_wrapper_dynamic.c
@@ -66,7 +66,10 @@ void *power_set_measurement(void *arg)
     timer_sleep(&timer);
     while (running)
     {
-        take_measurement();
+        // This is intel-specific.
+        // Preseve the original behavior with variorum_monitoring for now, by
+        // providing `1` as input value for the take_measurement function.
+        take_measurement(1);
         if (poll_num % 5 == 0)
         {
             if (watts >= watt_cap)
@@ -262,7 +265,11 @@ int main(int argc, char **argv)
 
         /* Stop power measurement thread. */
         running = 0;
-        take_measurement();
+
+        // This is intel-specific.
+        // Preseve the original behavior with variorum_monitoring for now, by
+        // providing `1` as input value for the take_measurement function.
+        take_measurement(1);
         end = now_ms();
 
         /* Output summary data. */

--- a/src/powmon/power_wrapper_static.c
+++ b/src/powmon/power_wrapper_static.c
@@ -184,6 +184,8 @@ int main(int argc, char **argv)
 
         /* Set the cap. */
         //set_rapl_power(watt_cap, watt_cap);
+        // ToDo: Intel-specific, needs to move to the best
+        // effort capping technique.
         printf("Setting each package power limit to %dW\n", watt_cap);
         variorum_cap_each_socket_power_limit(watt_cap);
 
@@ -219,7 +221,11 @@ int main(int argc, char **argv)
 
         /* Stop power measurement thread. */
         running = 0;
-        take_measurement();
+
+        // This is intel-specific.
+        // Preseve the original behavior with variorum_monitoring for now, by
+        // providing `1` as input value for the take_measurement function.
+        take_measurement(1);
         end = now_ms();
 
         /* Output summary data. */

--- a/src/powmon/power_wrapper_static.c
+++ b/src/powmon/power_wrapper_static.c
@@ -224,8 +224,8 @@ int main(int argc, char **argv)
 
         // This is intel-specific.
         // Preseve the original behavior with variorum_monitoring for now, by
-        // providing `1` as input value for the take_measurement function.
-        take_measurement(1);
+        // providing `true` as input value for the take_measurement function.
+        take_measurement(true);
         end = now_ms();
 
         /* Output summary data. */

--- a/src/powmon/powmon.c
+++ b/src/powmon/powmon.c
@@ -78,6 +78,9 @@ int main(int argc, char **argv)
                         "\n"
                         "    -i ms_interval"
                         "        Sampling interval in milliseconds (default = 50ms).\n"
+                        "\n"
+                        "    -v\n"
+                        "        Verbose output that includes all sensors or registers.\n"
                         "\n";
     if (argc == 1 || (argc > 1 && (
                           strncmp(argv[1], "--help", strlen("--help")) == 0 ||
@@ -94,8 +97,9 @@ int main(int argc, char **argv)
     char *logpath = NULL;
     // Default sampling interval in milliseconds
     unsigned long sample_interval = FASTEST_SAMPLE_INTERVAL_MS;
+    bool measure_all = 0;
 
-    while ((opt = getopt(argc, argv, "ca:p:i:")) != -1)
+    while ((opt = getopt(argc, argv, "ca:p:i:v")) != -1)
     {
         switch (opt)
         {
@@ -118,6 +122,9 @@ int main(int argc, char **argv)
                            FASTEST_SAMPLE_INTERVAL_MS);
                     sample_interval = FASTEST_SAMPLE_INTERVAL_MS;
                 }
+                break;
+            case 'v':
+                measure_all = 1;
                 break;
             case '?':
                 if (optopt == 'a')
@@ -261,7 +268,7 @@ int main(int argc, char **argv)
 
         /* Stop power measurement thread. */
         running = 0;
-        take_measurement();
+        take_measurement(measure_all);
         end = now_ms();
 
         if (logpath)

--- a/src/powmon/powmon.c
+++ b/src/powmon/powmon.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
                 }
                 break;
             case 'v':
-                th_args.measure_all = 1;
+                th_args.measure_all = true;
                 break;
             case '?':
                 if (optopt == 'a')

--- a/src/powmon/powmon.c
+++ b/src/powmon/powmon.c
@@ -31,8 +31,6 @@ static double max_watts = 0.0;
 static double min_watts = 1024.0;
 #endif
 
-#define FASTEST_SAMPLE_INTERVAL_MS 50
-
 /*************************/
 /* HW Counter Structures */
 /*************************/
@@ -95,9 +93,8 @@ int main(int argc, char **argv)
     char **arg = NULL;
     int set_app = 0;
     char *logpath = NULL;
-    // Default sampling interval in milliseconds
-    unsigned long sample_interval = FASTEST_SAMPLE_INTERVAL_MS;
-    bool measure_all = 0;
+    // Default struct with sampling interval of 50ms and verbosity of 0.
+    struct thread_args th_args;
 
     while ((opt = getopt(argc, argv, "ca:p:i:v")) != -1)
     {
@@ -115,16 +112,16 @@ int main(int argc, char **argv)
                 logpath = strdup(optarg);
                 break;
             case 'i':
-                sample_interval = atol(optarg);
-                if (sample_interval < FASTEST_SAMPLE_INTERVAL_MS)
+                th_args.sample_interval = atol(optarg);
+                if (th_args.sample_interval < FASTEST_SAMPLE_INTERVAL_MS)
                 {
                     printf("Warning: Specified sample interval (-i) is faster than default. Setting to default sampling interval of %d milliseconds.\n",
                            FASTEST_SAMPLE_INTERVAL_MS);
-                    sample_interval = FASTEST_SAMPLE_INTERVAL_MS;
+                    th_args.sample_interval = FASTEST_SAMPLE_INTERVAL_MS;
                 }
                 break;
             case 'v':
-                measure_all = 1;
+                th_args.measure_all = 1;
                 break;
             case '?':
                 if (optopt == 'a')
@@ -242,7 +239,7 @@ int main(int argc, char **argv)
         pthread_attr_init(&mattr);
         pthread_attr_setdetachstate(&mattr, PTHREAD_CREATE_DETACHED);
         pthread_mutex_init(&mlock, NULL);
-        pthread_create(&mthread, &mattr, power_measurement, (void *) &sample_interval);
+        pthread_create(&mthread, &mattr, power_measurement, (void *) &th_args);
 
         /* Fork. */
         pid_t app_pid = fork();

--- a/src/powmon/powmon.c
+++ b/src/powmon/powmon.c
@@ -21,6 +21,8 @@
 
 #include "highlander.h"
 
+#define FASTEST_SAMPLE_INTERVAL_MS 50
+
 #if 0
 /********/
 /* RAPL */
@@ -95,6 +97,8 @@ int main(int argc, char **argv)
     char *logpath = NULL;
     // Default struct with sampling interval of 50ms and verbosity of 0.
     struct thread_args th_args;
+    th_args.sample_interval = FASTEST_SAMPLE_INTERVAL_MS;
+    th_args.measure_all = false;
 
     while ((opt = getopt(argc, argv, "ca:p:i:v")) != -1)
     {
@@ -265,7 +269,7 @@ int main(int argc, char **argv)
 
         /* Stop power measurement thread. */
         running = 0;
-        take_measurement(measure_all);
+        take_measurement(th_args.measure_all);
         end = now_ms();
 
         if (logpath)


### PR DESCRIPTION
# Description

Adds a `-v` to powmon: the default powmon (without `-v`) will now call the JSON API and output power values to a CSV. This has been requested by many of our users -- the ability to sample simple power information with a running application.  The `-v` option will preserve existing behavior that outputs all sensors or register values, which is the verbose output. 

Fixes #396.

## Type of change

- [x] New feature/architecture support (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests with `sleep 5`, single node/process:
- [x] Lassen, CPU only
- [x] Lassen, CPU+GPU 
- [x] Tioga, CPU only
- [x] Tioga, CPU+GPU 
- [ ] Octomore, CPU only
- [ ] Rhetoric, CPU only
- [ ] Juno r2 

Tests with Hello World MPI, 4 nodes:
- [ ] Lassen, CPU only
- [ ] Tioga, CPU only

Note:
- [ ] When testing with `-v` on GPU platforms, we will see an unimplemented error, because `variorum_monitoring` has not yet been implemented on GPUs. This is existing behavior that needs to be addresses, and is not related to this PR. 

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes
