### PR TITLE
Fix for JSON example memory leak.

### DIFF
--- a/src/examples/variorum-get-node-power-domain-info-json-example.c
+++ b/src/examples/variorum-get-node-power-domain-info-json-example.c
@@ -32,9 +32,6 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Allocate string based on vendor-neutral JSON structure*/
-    s = (char *) malloc(800 * sizeof(char));
-
     ret = variorum_get_node_power_domain_info_json(&s);
 
     if (ret != 0)

--- a/src/examples/variorum-get-node-power-json-example.c
+++ b/src/examples/variorum-get-node-power-json-example.c
@@ -63,12 +63,6 @@ int main(int argc, char **argv)
         exit(-1);
     }
 
-    /* Allocate string based on number of sockets on the platform */
-    /* String allocation below assumes the following:
-     * Upper bound of 180 characters for hostname, timestamp and node power.
-     * Upper bound of 150 characters for per-socket information */
-    s = (char *) malloc((num_sockets * 150 + 180) * sizeof(char));
-
     ret = variorum_get_node_power_json(&s);
     if (ret != 0)
     {

--- a/src/examples/variorum-integration-using-json-example.c
+++ b/src/examples/variorum-integration-using-json-example.c
@@ -115,12 +115,6 @@ int main(void)
         exit(-1);
     }
 
-    /* Allocate string based on number of sockets on the platform */
-    /* String allocation below assumes the following:
-     * Upper bound of 180 characters for hostname, timestamp and node power.
-     * Upper bound of 150 characters for per-socket information */
-    s = (char *) malloc((num_sockets * 150 + 180) * sizeof(char));
-
     ret = variorum_get_node_power_json(&s);
     if (ret != 0)
     {


### PR DESCRIPTION
## Description
Removed the `malloc` calls that caused unused and leaked memory allocation from JSON examples. Fixes #398.

## Testing
Tested the change on Octomore:

```
$ sudo examples/variorum-get-node-power-json-example
{"host": "octomore", "power_gpu_watts_socket_0": -1.0, "timestamp": 1683139685116663, "power_cpu_watts_socket_1": 0.0, "power_cpu_watts_socket_0": 0.0, "power_mem_watts_socket_0": 0.0, "power_mem_watts_socket_1": 0.0, "power_gpu_watts_socket_1": -1.0, "power_node_watts": 0.0}
{"host": "octomore", "power_gpu_watts_socket_0": -1.0, "timestamp": 1683139687989717, "power_cpu_watts_socket_1": 40.380222985557957, "power_cpu_watts_socket_0": 21.953460045572452, "power_mem_watts_socket_0": 5.1117648399253754, "power_mem_watts_socket_1": 7.6333167305001508, "power_gpu_watts_socket_1": -1.0, "power_node_watts": 75.078764601555932}
```

```
$ sudo examples/variorum-get-node-power-domain-info-json-example
{"control_range": "[{min: 68.000000, max: 240.000000}, {min: 2.875000, max: 21.000000}]", "control": "[power_cpu, power_mem]", "host": "octomore", "control_units": "[Watts, Watts]", "unsupported": "[power_node]", "measurement": "[power_cpu, power_mem]", "timestamp": 1683139707686270, "measurement_units": "[Watts, Watts]"}
```

```
$ sudo examples/variorum-integration-using-json-example

*****JSON object received from first run is:
{"host": "octomore", "timestamp": 1683139727324080, "power_cpu_watts_socket_0": 0.0, "power_mem_watts_socket_0": 0.0, "power_gpu_watts_socket_1": -1.0, "power_cpu_watts_socket_1": 0.0, "power_gpu_watts_socket_0": -1.0, "power_mem_watts_socket_1": 0.0, "power_node_watts": 0.0}

Extracted power values at node and socket level are:

Node Power: 0.000000 Watts

Socket 0, CPU Power: 0.000000 Watts
Socket 0, GPU Power: -1.000000 Watts
Socket 0, Memory Power: 0.000000 Watts

Socket 1, CPU Power: 0.000000 Watts
Socket 1, GPU Power: -1.000000 Watts
Socket 1, Memory Power: 0.000000 Watts


*****JSON object received from second run is:
{"host": "octomore", "timestamp": 1683139730198346, "power_cpu_watts_socket_0": 21.936471538770984, "power_mem_watts_socket_0": 4.85393799231593, "power_gpu_watts_socket_1": -1.0, "power_cpu_watts_socket_1": 40.197689139014528, "power_gpu_watts_socket_0": -1.0, "power_mem_watts_socket_1": 7.545616519526833, "power_node_watts": 74.533715189628282}

Extracted power values at node and socket level are:

Node Power: 74.533715 Watts

Socket 0, CPU Power: 21.936472 Watts
Socket 0, GPU Power: -1.000000 Watts
Socket 0, Memory Power: 4.853938 Watts

Socket 1, CPU Power: 40.197689 Watts
Socket 1, GPU Power: -1.000000 Watts
Socket 1, Memory Power: 7.545617 Watts

```

Tested on Tioga:

```
$ examples/variorum-get-node-power-json-example
{"host": "tioga23", "timestamp": 1683763427985826, "power_cpu_watts_socket_0": 106.864, "power_gpu_watts_socket_0": -1.0, "power_mem_watts_socket_0": -1.0, "power_node_watts": 106.864}
{"host": "tioga23", "timestamp": 1683763429943637, "power_cpu_watts_socket_0": 106.179, "power_gpu_watts_socket_0": -1.0, "power_mem_watts_socket_0": -1.0, "power_node_watts": 106.179}
```
```
$ examples/variorum-get-node-power-domain-info-json-example
{"host": "tioga23", "timestamp": 1683764360708403, "measurement": "[power_cpu]", "control": "[power_cpu]", "unsupported": "[power_node, power_mem]", "measurement_units": "[Watts]", "control_units": "[Watts]", "control_range": "[{min: 50, max: 240}]"}
```
```
$ examples/variorum-integration-using-json-example

*****JSON object received from first run is:
{"host": "tioga23", "timestamp": 1683763347187439, "power_cpu_watts_socket_0": 113.117, "power_gpu_watts_socket_0": -1.0, "power_mem_watts_socket_0": -1.0, "power_node_watts": 113.117}

Extracted power values at node and socket level are:

Node Power: 113.117000 Watts

Socket 0, CPU Power: 113.117000 Watts
Socket 0, GPU Power: -1.000000 Watts
Socket 0, Memory Power: -1.000000 Watts


*****JSON object received from second run is:
{"host": "tioga23", "timestamp": 1683763349146476, "power_cpu_watts_socket_0": 111.55800000000001, "power_gpu_watts_socket_0": -1.0, "power_mem_watts_socket_0": -1.0, "power_node_watts": 111.55800000000001}

Extracted power values at node and socket level are:

Node Power: 111.558000 Watts

Socket 0, CPU Power: 111.558000 Watts
Socket 0, GPU Power: -1.000000 Watts
Socket 0, Memory Power: -1.000000 Watts
```

Tested on Lassen:

```
$ examples/variorum-get-node-power-json-example
{"host": "lassen32", "timestamp": 1683763940134647, "power_node_watts": 389.0, "power_cpu_watts_socket_0": 82.0, "power_mem_watts_socket_0": 23.0, "power_gpu_watts_socket_0": 82.0, "power_cpu_watts_socket_1": 69.0, "power_mem_watts_socket_1": 22.0, "power_gpu_watts_socket_1": 64.0}
{"host": "lassen32", "timestamp": 1683763941901141, "power_node_watts": 396.0, "power_cpu_watts_socket_0": 82.0, "power_mem_watts_socket_0": 23.0, "power_gpu_watts_socket_0": 82.0, "power_cpu_watts_socket_1": 77.0, "power_mem_watts_socket_1": 22.0, "power_gpu_watts_socket_1": 63.0}
```

```
$ examples/variorum-get-node-power-domain-info-json-example
{"host": "lassen32", "timestamp": 1683764416711602, "measurement": "[power_node, power_cpu, power_mem, power_gpu]", "control": "[power_node, power_gpu]", "unsupported": "[]", "measurement_units": "[Watts, Watts, Watts, Watts]", "control_units": "[Watts, Percentage]", "control_range": "[{min: 500, max: 3050}, {min: 0, max: 100}]"}
```

```
$ examples/variorum-integration-using-json-example

*****JSON object received from first run is:
{"host": "lassen32", "timestamp": 1683763957321729, "power_node_watts": 398.0, "power_cpu_watts_socket_0": 83.0, "power_mem_watts_socket_0": 24.0, "power_gpu_watts_socket_0": 82.0, "power_cpu_watts_socket_1": 79.0, "power_mem_watts_socket_1": 23.0, "power_gpu_watts_socket_1": 64.0}

Extracted power values at node and socket level are:

Node Power: 398.000000 Watts

Socket 0, CPU Power: 83.000000 Watts
Socket 0, GPU Power: 82.000000 Watts
Socket 0, Memory Power: 24.000000 Watts

Socket 1, CPU Power: 79.000000 Watts
Socket 1, GPU Power: 64.000000 Watts
Socket 1, Memory Power: 23.000000 Watts


*****JSON object received from second run is:
{"host": "lassen32", "timestamp": 1683763959109231, "power_node_watts": 387.0, "power_cpu_watts_socket_0": 79.0, "power_mem_watts_socket_0": 23.0, "power_gpu_watts_socket_0": 81.0, "power_cpu_watts_socket_1": 71.0, "power_mem_watts_socket_1": 22.0, "power_gpu_watts_socket_1": 64.0}

Extracted power values at node and socket level are:

Node Power: 387.000000 Watts

Socket 0, CPU Power: 79.000000 Watts
Socket 0, GPU Power: 81.000000 Watts
Socket 0, Memory Power: 23.000000 Watts

Socket 1, CPU Power: 71.000000 Watts
Socket 1, GPU Power: 64.000000 Watts
Socket 1, Memory Power: 22.000000 Watts

```