### PR TITLE
Sapphire Rapids initial port.

### DIFF
--- a/README
+++ b/README
@@ -101,6 +101,7 @@ Supported Intel Microarchitectures:
     0x9E (Kaby Lake)
     0x55 (Skylake, Cascade Lake, Cooper Lake)
     0x6A (Ice Lake)
+    0x8F (Sapphire Rapids)
 
 Supported Intel GPUs:
 

--- a/src/variorum/Intel/CMakeLists.txt
+++ b/src/variorum/Intel/CMakeLists.txt
@@ -17,6 +17,7 @@ set(variorum_intel_headers
   ${CMAKE_CURRENT_SOURCE_DIR}/Intel_06_55.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Intel_06_9E.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Intel_06_6A.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Intel_06_8F.h
   ${CMAKE_CURRENT_SOURCE_DIR}/variorum_cpuid.h
   CACHE INTERNAL "")
 
@@ -34,6 +35,7 @@ set(variorum_intel_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/Intel_06_55.c
   ${CMAKE_CURRENT_SOURCE_DIR}/Intel_06_9E.c
   ${CMAKE_CURRENT_SOURCE_DIR}/Intel_06_6A.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/Intel_06_8F.c
   ${CMAKE_CURRENT_SOURCE_DIR}/variorum_cpuid.c
   CACHE INTERNAL "")
 

--- a/src/variorum/Intel/Intel_06_8F.c
+++ b/src/variorum/Intel/Intel_06_8F.c
@@ -1,0 +1,183 @@
+// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <Intel_06_8F.h>
+#include <clocks_features.h>
+#include <config_architecture.h>
+#include <counters_features.h>
+#include <power_features.h>
+#include <thermal_features.h>
+
+static struct sapphire_rapids_6a_offsets msrs =
+{
+    .msr_platform_info            = 0xCE,
+    .ia32_time_stamp_counter      = 0x10,
+    .msr_rapl_power_unit          = 0x606,
+    .msr_pkg_power_limit          = 0x610,
+    .msr_pkg_energy_status        = 0x611,
+    .msr_pkg_power_info           = 0x614,
+    .msr_dram_power_limit         = 0x618,
+    .msr_dram_energy_status       = 0x619,
+    .msr_dram_power_info          = 0x61C,
+};
+
+int fm_06_8f_get_power_limits(int long_ver)
+{
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
+    variorum_get_topology(&nsockets, &ncores, &nthreads, P_INTEL_CPU_IDX);
+
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        if (long_ver == 0)
+        {
+            print_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                      msrs.msr_rapl_power_unit, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_package_power_limit(stdout, msrs.msr_pkg_power_limit,
+                                              msrs.msr_rapl_power_unit, socket);
+        }
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        if (long_ver == 0)
+        {
+            print_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+    }
+
+    if (long_ver == 0)
+    {
+        print_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+    }
+    else if (long_ver == 1)
+    {
+        print_verbose_rapl_power_unit(stdout, msrs.msr_rapl_power_unit);
+    }
+
+    return 0;
+}
+
+int fm_06_8f_get_features(void)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    fprintf(stdout, "msr_platform_info            = 0x%lx\n",
+            msrs.msr_platform_info);
+    fprintf(stdout, "ia32_time_stamp_counter      = 0x%lx\n",
+            msrs.ia32_time_stamp_counter);
+    fprintf(stdout, "msr_rapl_power_unit          = 0x%lx\n",
+            msrs.msr_rapl_power_unit);
+    fprintf(stdout, "msr_pkg_power_limit          = 0x%lx\n",
+            msrs.msr_pkg_power_limit);
+    fprintf(stdout, "msr_pkg_energy_status        = 0x%lx\n",
+            msrs.msr_pkg_energy_status);
+    fprintf(stdout, "msr_pkg_power_info           = 0x%lx\n",
+            msrs.msr_pkg_power_info);
+    fprintf(stdout, "msr_dram_power_limit         = 0x%lx\n",
+            msrs.msr_dram_power_limit);
+    fprintf(stdout, "msr_dram_energy_status       = 0x%lx\n",
+            msrs.msr_dram_energy_status);
+    fprintf(stdout, "msr_dram_power_info          = 0x%lx\n",
+            msrs.msr_dram_power_info);
+    return 0;
+}
+
+int fm_06_8f_get_power(int long_ver)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    if (long_ver == 0)
+    {
+        print_power_data(stdout, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                         msrs.msr_dram_energy_status);
+    }
+    else if (long_ver == 1)
+    {
+        print_verbose_power_data(stdout, msrs.msr_rapl_power_unit,
+                                 msrs.msr_pkg_energy_status, msrs.msr_dram_energy_status);
+    }
+    return 0;
+}
+
+int fm_06_8f_get_node_power_json(char **get_power_obj_str)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    json_t *get_power_obj = json_object();
+
+    json_get_power_data(get_power_obj, msrs.msr_pkg_power_limit,
+                        msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                        msrs.msr_dram_energy_status);
+
+    *get_power_obj_str = json_dumps(get_power_obj, 0);
+    json_decref(get_power_obj);
+
+    return 0;
+}
+
+int fm_06_8f_get_node_power_domain_info_json(char **get_domain_obj_str)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    json_t *get_domain_obj = json_object();
+
+    json_get_power_domain_info(get_domain_obj, msrs.msr_pkg_power_info,
+                               msrs.msr_dram_power_info, msrs.msr_rapl_power_unit,
+                               msrs.msr_pkg_power_limit);
+
+    *get_domain_obj_str = json_dumps(get_domain_obj, 0);
+    json_decref(get_domain_obj);
+
+    return 0;
+}
+
+int fm_06_9e_monitoring(FILE *output)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    get_all_power_data_fixed(output, msrs.msr_pkg_power_limit,
+                             msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
+                             msrs.msr_dram_energy_status, msrs.ia32_fixed_counters,
+                             msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl, msrs.ia32_aperf,
+                             msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
+    return 0;
+}

--- a/src/variorum/Intel/Intel_06_8F.c
+++ b/src/variorum/Intel/Intel_06_8F.c
@@ -174,7 +174,7 @@ int fm_06_8f_get_node_power_domain_info_json(char **get_domain_obj_str)
     return 0;
 }
 
-int fm_06_9e_monitoring(FILE *output)
+int fm_06_8f_monitoring(FILE *output)
 {
     char *val = getenv("VARIORUM_LOG");
     if (val != NULL && atoi(val) == 1)

--- a/src/variorum/Intel/Intel_06_8F.c
+++ b/src/variorum/Intel/Intel_06_8F.c
@@ -24,6 +24,14 @@ static struct sapphire_rapids_6a_offsets msrs =
     .msr_dram_power_limit         = 0x618,
     .msr_dram_energy_status       = 0x619,
     .msr_dram_power_info          = 0x61C,
+    .ia32_fixed_counters[0]       = 0x309,
+    .ia32_fixed_counters[1]       = 0x30A,
+    .ia32_fixed_counters[2]       = 0x30B,
+    .ia32_fixed_ctr_ctrl          = 0x38D,
+    .ia32_perf_global_status      = 0x38E,
+    .ia32_perf_global_ctrl        = 0x38F,
+    .ia32_mperf                   = 0xE7,
+    .ia32_aperf                   = 0xE8,
 };
 
 int fm_06_8f_get_power_limits(int long_ver)

--- a/src/variorum/Intel/Intel_06_8F.h
+++ b/src/variorum/Intel/Intel_06_8F.h
@@ -30,6 +30,19 @@ struct sapphire_rapids_6a_offsets
     off_t msr_dram_energy_status;
     /// @brief Address for DRAM_POWER_INFO.
     off_t msr_dram_power_info;
+    /// @brief Address for IA32_FIXED_CTR_CTRL.
+    off_t ia32_fixed_ctr_ctrl;
+    /// @brief Address for IA32_PERF_GLOBAL_STATUS.
+    off_t ia32_perf_global_status;
+    /// @brief Address for IA32_PERF_GLOBAL_CTRL.
+    off_t ia32_perf_global_ctrl;
+    /// @brief Address for IA32_MPERF.
+    off_t ia32_mperf;
+    /// @brief Address for IA32_APERF.
+    off_t ia32_aperf;
+    /// @brief Array of unique addresses for fixed counters.
+    off_t ia32_fixed_counters[3];
+
 };
 
 int fm_06_8f_get_power_limits(int long_ver);

--- a/src/variorum/Intel/Intel_06_8F.h
+++ b/src/variorum/Intel/Intel_06_8F.h
@@ -1,0 +1,46 @@
+// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef SAPPHIRE_RAPIDS_6A_H_INCLUDE
+#define SAPPHIRE_RAPIDS_6A_H_INCLUDE
+
+#include <sys/types.h>
+#include <jansson.h>
+
+/// @brief List of unique addresses for Sapphire Rapids Family/Model 6AH.
+struct sapphire_rapids_6a_offsets
+{
+    /// @brief Address for MSR_PLATFORM_INFO.
+    off_t msr_platform_info;
+    /// @brief Address for IA32_TIME_STAMP_COUNTER.
+    off_t ia32_time_stamp_counter;
+    /// @brief Address for RAPL_POWER_UNIT.
+    off_t msr_rapl_power_unit;
+    /// @brief Address for PKG_POWER_LIMIT.
+    off_t msr_pkg_power_limit;
+    /// @brief Address for PKG_ENERGY_STATUS.
+    off_t msr_pkg_energy_status;
+    /// @brief Address for PKG_POWER_INFO.
+    off_t msr_pkg_power_info;
+    /// @brief Address for DRAM_POWER_LIMIT.
+    off_t msr_dram_power_limit;
+    /// @brief Address for DRAM_ENERGY_STATUS.
+    off_t msr_dram_energy_status;
+    /// @brief Address for DRAM_POWER_INFO.
+    off_t msr_dram_power_info;
+};
+
+int fm_06_8f_get_power_limits(int long_ver);
+
+int fm_06_8f_get_power(int long_ver);
+
+int fm_06_8f_get_features(void);
+
+int fm_06_8f_get_node_power_json(char **get_power_obj_str);
+
+int fm_06_8f_get_node_power_domain_info_json(char **get_domain_obj_str);
+
+int fm_06_8f_monitoring(FILE *output);
+#endif

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -17,6 +17,7 @@
 #include <Intel_06_9E.h>
 #include <Intel_06_55.h>
 #include <Intel_06_6A.h>
+#include <Intel_06_8F.h>
 
 uint64_t *detect_intel_arch(void)
 {

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -266,6 +266,11 @@ int set_intel_func_ptrs(int idx)
         g_platform[idx].variorum_print_power_limit = fm_06_8f_get_power_limits;
         g_platform[idx].variorum_print_features = fm_06_8f_get_features;
         g_platform[idx].variorum_print_power = fm_06_8f_get_power;
+        g_platform[idx].variorum_get_node_power_json =
+            fm_06_8f_get_node_power_json;
+        g_platform[idx].variorum_get_node_power_domain_info_json =
+            fm_06_8f_get_node_power_domain_info_json;
+        g_platform[idx].variorum_monitoring = fm_06_8f_monitoring;
     }
     else
     {

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -260,7 +260,7 @@ int set_intel_func_ptrs(int idx)
         g_platform[idx].variorum_print_power = fm_06_6a_get_power;
     }
     // Sapphire Rapids 06_8F
-    else if (*g_platform[idx].arch_id == FM_06_6F)
+    else if (*g_platform[idx].arch_id == FM_06_8F)
     {
         g_platform[idx].variorum_print_power_limit = fm_06_8f_get_power_limits;
         g_platform[idx].variorum_print_features = fm_06_8f_get_features;

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -259,6 +259,13 @@ int set_intel_func_ptrs(int idx)
         g_platform[idx].variorum_print_features = fm_06_6a_get_features;
         g_platform[idx].variorum_print_power = fm_06_6a_get_power;
     }
+    // Sapphire Rapids 06_8F
+    else if (*g_platform[idx].arch_id == FM_06_6F)
+    {
+        g_platform[idx].variorum_print_power_limit = fm_06_8f_get_power_limits;
+        g_platform[idx].variorum_print_features = fm_06_8f_get_features;
+        g_platform[idx].variorum_print_power = fm_06_8f_get_power;
+    }
     else
     {
         return VARIORUM_ERROR_UNSUPPORTED_PLATFORM;

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -59,6 +59,7 @@ enum intel_arch_e
     FM_06_9E = 158, // Kaby Lake
     FM_06_57 = 87,  // Knights Landing
     FM_06_6A = 106, // IceLake
+    FM_06_8F = 143, // Sapphire Rapids
 };
 
 /// @brief List of IBM family and models.

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -40,6 +40,7 @@ int variorum_poll_power(FILE *output);
 /// - Intel Kaby Lake
 /// - Intel Cascade Lake
 /// - Intel Cooper Lake
+/// - Intel Sapphire Rapids
 ///
 /// @param [in] output Location for output (stdout, stderr, filename).
 ///
@@ -173,6 +174,7 @@ int variorum_cap_each_gpu_power_limit(int gpu_power_limit);
 /// - Intel Ice Lake
 /// - Intel Cascade Lake
 /// - Intel Cooper Lake
+/// - Intel Sapphire Rapids
 /// - NVIDIA Volta
 ///
 /// @return 0 if successful or if feature has not been implemented or is
@@ -194,6 +196,7 @@ int variorum_print_verbose_power_limit(void);
 /// - Intel Ice Lake
 /// - Intel Cascade Lake
 /// - Intel Cooper Lake
+/// - Intel Sapphire Rapids
 /// - NVIDIA Volta
 ///
 /// @return 0 if successful or if feature has not been implemented or is
@@ -287,6 +290,7 @@ int variorum_print_counters(void);
 /// - Intel Ice Lake
 /// - Intel Cascade Lake
 /// - Intel Cooper Lake
+/// - Intel Sapphire Rapids
 /// - NVIDIA Volta
 ///
 /// @return 0 if successful or if feature has not been implemented or is
@@ -309,6 +313,7 @@ int variorum_print_verbose_power(void);
 /// - Intel Ice Lake
 /// - Intel Cascade Lake
 /// - Intel Cooper Lake
+/// - Intel Sapphire Rapids
 /// - Intel Arctic Sound
 /// - NVIDIA Volta
 ///
@@ -379,6 +384,7 @@ void variorum_print_topology(void);
 /// - Intel Ice Lake
 /// - Intel Cascade Lake
 /// - Intel Cooper Lake
+/// - Intel Sapphire Rapids
 ///
 /// @return 0 if successful or if feature has not been implemented or is
 /// not supported, otherwise -1
@@ -516,6 +522,7 @@ int variorum_disable_turbo(void);
 /// - Intel Kaby Lake
 /// - Intel Cascade Lake
 /// - Intel Cooper Lake
+/// - Intel Sapphire Rapids
 ///
 /// @param [out] output String (passed by reference) that contains the node-level
 /// power information.
@@ -540,6 +547,7 @@ int variorum_get_node_power_json(char **get_power_obj_str);
 /// - Intel Kaby Lake
 /// - Intel Cascade Lake
 /// - Intel Cooper Lake
+/// - Intel Sapphire Rapids
 ///
 /// @param [out] output String (passed by reference) that contains the node-level
 /// domain information.


### PR DESCRIPTION
# Description

Initial port for Sapphire Rapids architecture.

Fixes #356 .

Future work - Check if we need to pick up any MSR offsets from Table 2-39, eg PLATFORM_POWER_LIMIT.

## Type of change

- [x] New feature/architecture support (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

- [x] Build test: Poodle
- [ ] Example tests: ANL.

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [ ] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
