### PR TITLE
bugfix: Resolve build failure on AMD debug version due to undefined variable

### DIFF
--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -415,8 +415,8 @@ int epyc_set_each_core_boostlimit(int boostlimit)
     }
 
 #ifdef VARIORUM_DEBUG
-    fprintf(stdout, "Values are input:%2u MHz, test=%2u MHz\n",
-            boostlimit, core_boost_lim);
+    fprintf(stdout, "Values are input:%2u MHz\n",
+            boostlimit);
 #endif
 
     return 0;


### PR DESCRIPTION
# Description

The debug build for the Variorum library on AMD architecture currently fails. The root cause of this issue is an undefined variable `core_boost_lim `in the debug block of the `epyc_set_each_core_boostlimit(int boostlimit)` function.

Fixes #<issue>
I  have addressed this problem by removing the undefined variable `core_boost_lim `from the debug print message. This change ensures that the debug build can successfully compile without encountering an undefined variable error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
