### PR TITLE
add link to youtube video

### DIFF
--- a/src/docs/sphinx/Publications.rst
+++ b/src/docs/sphinx/Publications.rst
@@ -16,6 +16,8 @@
  Presentations
 ***************
 
+-  Variorum: Vendor-Agnostic Power Management `Watch here <https://www.youtube.com/watch?v=rgJGgPERBao>`_
+
 -  Introduction to Variorum, ECP Tutorial Series 2021.
 
       -  :download:`Module 1 Slides

--- a/src/docs/sphinx/Publications.rst
+++ b/src/docs/sphinx/Publications.rst
@@ -16,7 +16,8 @@
  Presentations
 ***************
 
--  Variorum: Vendor-Agnostic Power Management `Watch here <https://www.youtube.com/watch?v=rgJGgPERBao>`_
+-  Variorum: Vendor-Agnostic Power Management `Watch here
+   <https://www.youtube.com/watch?v=rgJGgPERBao>`_
 
 -  Introduction to Variorum, ECP Tutorial Series 2021.
 


### PR DESCRIPTION
# Description

Adds link to youtube video and whitepaper.

Fixes #408 

TODO: [ ] add whitepaper
Docs: https://variorum.readthedocs.io/en/add-rd100-links/Publications.html

@tpatki : I added the youtube video to publications, but that doesn't seem to be the place to put it. I'll let you move it as needed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Build/CI update