### PR TITLE
add links to recordings from ECP Tutorial 2023

### DIFF
--- a/src/docs/sphinx/Publications.rst
+++ b/src/docs/sphinx/Publications.rst
@@ -16,6 +16,11 @@
  Presentations
 ***************
 
+-  Power Management on Exascale Platforms with Variorum, ECP Tutorial Series 2023.
+
+     -  Introduction to Variorum `Recording <https://uoregon.zoom.us/rec/share/K6rSbJeeW3R0wPndnspRJ3a-_ZJ_TywH__2fGJKW3h6TutWTac77RawRmr9ypCWV.EvsYnRIV7jy8pAdK>`_
+     -  Integrating Variorum with System Software and Tools `Recording <https://uoregon.zoom.us/rec/share/d1DQsA350JJrU0hVbQf401YOm5p4cLbKIN29rBv9_4Blp2sCjV-SKqXXEwDQa284.c2bhMxzM9Ia2qoDM>`_
+
 -  Introduction to Variorum, ECP Tutorial Series 2021.
 
       -  :download:`Module 1 Slides


### PR DESCRIPTION
# Description

Adds recording links to ECP Tutorial Series 2023.

Fixes #406 

Docs: https://variorum.readthedocs.io/en/add-2023-tutorial/Publications.html

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Build/CI update
