### PR TITLE
Fix inconsistent spacing issue with powmon

### DIFF
--- a/src/powmon/common.c
+++ b/src/powmon/common.c
@@ -68,7 +68,7 @@ void parse_json_obj(char *s, int num_sockets)
 
     if (write_header == true)
     {
-        fprintf(logfile, "%s, %s, ", "Timestamp (ms)", "Node Power (W)");
+        fprintf(logfile, "%s,%s,", "Timestamp (ms)", "Node Power (W)");
         for (i = 0; i < num_sockets; i++)
         {
             char str[40];


### PR DESCRIPTION
# Description

Inconsistent spacing in CSV is causing python script to fail. 

Fixes #424 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Tested on lassen.

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
