### PR TITLE
WIP: Add new API for caliper.

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -41,6 +41,7 @@ set(BASIC_EXAMPLES
     variorum-print-verbose-power-example
     variorum-print-verbose-thermals-example
     variorum-print-energy-example
+    variorum-get-domain-power-value-example 
 )
 
 message(STATUS "Adding variorum examples")

--- a/src/examples/variorum-get-domain-power-value-example.c
+++ b/src/examples/variorum-get-domain-power-value-example.c
@@ -28,7 +28,6 @@ enum power_domain {NODE = 0, PROCESSOR, MEMORY, GPU};
 int main(int argc, char **argv)
 {
     double power_value = 0.0;
-    enum power_domain domain = NODE;
 
 #ifdef SECOND_RUN
     int i;

--- a/src/examples/variorum-get-domain-power-value-example.c
+++ b/src/examples/variorum-get-domain-power-value-example.c
@@ -1,0 +1,110 @@
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
+// Variorum Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include <getopt.h>
+#include <stdio.h>
+
+#include <variorum.h>
+
+#ifdef SECOND_RUN
+static inline double do_work(int input)
+{
+    int i;
+    double result = (double)input;
+
+    for (i = 0; i < 100000; i++)
+    {
+        result += i + result;
+    }
+
+    return result;
+}
+#endif
+
+enum power_domain {NODE = 0, PROCESSOR, MEMORY, GPU};
+
+int main(int argc, char **argv)
+{
+    double power_value;
+    enum power_domain domain = NODE;
+
+#ifdef SECOND_RUN
+    int i;
+    int size = 1E3;
+    volatile double x = 0.0;
+#endif
+
+    const char *usage = "Usage: %s [-h] [-v]\n";
+    int opt;
+    while ((opt = getopt(argc, argv, "hv")) != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+                printf(usage, argv[0]);
+                return 0;
+            case 'v':
+                printf("%s\n", variorum_get_current_version());
+                return 0;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                return -1;
+        }
+    }
+
+    // Get power data from Node domain, deviceID is irrelevant and ignored here.
+    power_value = variorum_get_domain_power_value(NODE, 0);
+    printf("Power for the Node domain is %lf watts\n", power_value);
+
+    // Get power data from Socket domain and specify device (socket) ID as 1.
+    power_value = variorum_get_domain_power_value(PROCESSOR, 1);
+    printf("Processor Power for Socket 1 is %lf watts\n", power_value);
+
+    // Get power data from Memory domain and specify device (memory DIMM) ID as 0.
+    power_value = variorum_get_domain_power_value(MEMORY, 0);
+    printf("Power for Memory from Socket 0 is  %lf watts\n", power_value);
+
+/*
+    // Get power data from GPU domain and specify device (GPU) ID as 2.
+    power_value = variorum_get_domain_power_value(GPU, 2);
+    printf("Power for the GPU ID 2 is %lf watts\n", power_value);
+
+    if (power_value == -1.0)
+    {
+        printf("Variorum get_domain_power_value failed!\n");
+    }
+
+#ifdef SECOND_RUN
+    for (i = 0; i < size; i++)
+    {
+        x += do_work(i);
+    }
+    printf("Final result: %f\n", x);
+
+    // Get power data from Node domain, deviceID is irrelevant and ignored here.
+    power_value = variorum_get_domain_power_value(NODE, 0);
+    printf("Power for the Node domain is %lf watts\n", power_value);
+
+    // Get power data from Socket domain and specify device (socket) ID as 1.
+    power_value = variorum_get_domain_power_value(SOCKET, 1);
+    printf("Power for Socket 1 is %lf watts\n", power_value);
+
+    // Get power data from Memory domain and specify device (memory DIMM) ID as 0.
+    power_value = variorum_get_domain_power_value(MEMORY, 0);
+    printf("Power for the Memory DIMM 0 is  %lf watts\n", power_value);
+
+    // Get power data from GPU domain and specify device (GPU) ID as 2.
+    power_value = variorum_get_domain_power_value(GPU, 2);
+    printf("Power for the GPU ID 2 is %lf watts\n", power_value);
+
+    if (power_value == -1.0)
+    {
+        printf("Variorum get_domain_power_value failed!\n");
+    }
+#endif
+*/
+
+    return 0;
+}

--- a/src/examples/variorum-get-domain-power-value-example.c
+++ b/src/examples/variorum-get-domain-power-value-example.c
@@ -27,7 +27,7 @@ enum power_domain {NODE = 0, PROCESSOR, MEMORY, GPU};
 
 int main(int argc, char **argv)
 {
-    double power_value;
+    double power_value = 0.0;
     enum power_domain domain = NODE;
 
 #ifdef SECOND_RUN
@@ -57,24 +57,37 @@ int main(int argc, char **argv)
     // Get power data from Node domain, deviceID is irrelevant and ignored here.
     power_value = variorum_get_domain_power_value(NODE, 0);
     printf("Power for the Node domain is %lf watts\n", power_value);
-
-    // Get power data from Socket domain and specify device (socket) ID as 1.
-    power_value = variorum_get_domain_power_value(PROCESSOR, 1);
-    printf("Processor Power for Socket 1 is %lf watts\n", power_value);
-
-    // Get power data from Memory domain and specify device (memory DIMM) ID as 0.
-    power_value = variorum_get_domain_power_value(MEMORY, 0);
-    printf("Power for Memory from Socket 0 is  %lf watts\n", power_value);
-
-/*
-    // Get power data from GPU domain and specify device (GPU) ID as 2.
-    power_value = variorum_get_domain_power_value(GPU, 2);
-    printf("Power for the GPU ID 2 is %lf watts\n", power_value);
-
     if (power_value == -1.0)
     {
         printf("Variorum get_domain_power_value failed!\n");
     }
+
+    // Get power data from Socket domain and specify device (socket) ID as 1.
+    power_value = variorum_get_domain_power_value(PROCESSOR, 1);
+    printf("Processor Power for Socket 1 is %lf watts\n", power_value);
+    if (power_value == -1.0)
+    {
+        printf("Variorum get_domain_power_value failed!\n");
+    }
+
+    // Get power data from Memory domain and specify device (memory DIMM) ID as 0.
+    power_value = variorum_get_domain_power_value(MEMORY, 0);
+    printf("Power for Memory from Socket 0 is  %lf watts\n", power_value);
+    if (power_value == -1.0)
+    {
+        printf("Variorum get_domain_power_value failed!\n");
+    }
+
+    /*
+        // Get power data from GPU domain and specify device (GPU) ID as 2.
+        power_value = variorum_get_domain_power_value(GPU, 2);
+        printf("Power for the GPU ID 2 is %lf watts\n", power_value);
+
+        if (power_value == -1.0)
+        {
+            printf("Variorum get_domain_power_value failed!\n");
+        }
+    */
 
 #ifdef SECOND_RUN
     for (i = 0; i < size; i++)
@@ -86,25 +99,40 @@ int main(int argc, char **argv)
     // Get power data from Node domain, deviceID is irrelevant and ignored here.
     power_value = variorum_get_domain_power_value(NODE, 0);
     printf("Power for the Node domain is %lf watts\n", power_value);
-
-    // Get power data from Socket domain and specify device (socket) ID as 1.
-    power_value = variorum_get_domain_power_value(SOCKET, 1);
-    printf("Power for Socket 1 is %lf watts\n", power_value);
-
-    // Get power data from Memory domain and specify device (memory DIMM) ID as 0.
-    power_value = variorum_get_domain_power_value(MEMORY, 0);
-    printf("Power for the Memory DIMM 0 is  %lf watts\n", power_value);
-
-    // Get power data from GPU domain and specify device (GPU) ID as 2.
-    power_value = variorum_get_domain_power_value(GPU, 2);
-    printf("Power for the GPU ID 2 is %lf watts\n", power_value);
-
     if (power_value == -1.0)
     {
         printf("Variorum get_domain_power_value failed!\n");
     }
+
+    // Get power data from Socket domain and specify device (socket) ID as 1.
+    power_value = variorum_get_domain_power_value(PROCESSOR, 1);
+    printf("Power for Socket 1 is %lf watts\n", power_value);
+    if (power_value == -1.0)
+    {
+        printf("Variorum get_domain_power_value failed!\n");
+    }
+
+    // Get power data from Memory domain and specify device (memory DIMM) ID as 0.
+    power_value = variorum_get_domain_power_value(MEMORY, 0);
+    printf("Power for the Memory from Socket 0 is  %lf watts\n", power_value);
+    if (power_value == -1.0)
+    {
+        printf("Variorum get_domain_power_value failed!\n");
+    }
+
+
+    /*
+        // Get power data from GPU domain and specify device (GPU) ID as 2.
+        power_value = variorum_get_domain_power_value(GPU, 2);
+        printf("Power for the GPU ID 2 is %lf watts\n", power_value);
+
+        if (power_value == -1.0)
+        {
+            printf("Variorum get_domain_power_value failed!\n");
+        }
+    */
 #endif
-*/
+
 
     return 0;
 }

--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -487,7 +487,6 @@ double ibm_cpu_p9_get_domain_power_value(int domain, int deviceID)
         printf("Running %s\n", __FUNCTION__);
     }
 
-    void *buf;
     int fd;
     double power_value = 0.0;
     int rc;
@@ -517,12 +516,8 @@ double ibm_cpu_p9_get_domain_power_value(int domain, int deviceID)
     // we use it to calculate the offsets here.
     lseek(fd, deviceID * OCC_SENSOR_DATA_BLOCK_SIZE, SEEK_SET);
 
-    buf = malloc(OCC_SENSOR_DATA_BLOCK_SIZE);
-    if (!buf)
-    {
-        printf("Failed to allocate\n");
-        return -1.0;
-    }
+    // Allocate static memory here for signal-safe implementation.
+    char buf[OCC_SENSOR_DATA_BLOCK_SIZE];
 
     for (rc = bytes = 0; bytes < OCC_SENSOR_DATA_BLOCK_SIZE; bytes += rc)
     {
@@ -537,13 +532,11 @@ double ibm_cpu_p9_get_domain_power_value(int domain, int deviceID)
     if (bytes != OCC_SENSOR_DATA_BLOCK_SIZE)
     {
         printf("Failed to read data\n");
-        free(buf);
         return -1.0;
     }
 
     power_value = get_power_sensor_value(domain, deviceID, buf);
 
-    free(buf);
     close(fd);
 
     return power_value;

--- a/src/variorum/IBM/Power9.h
+++ b/src/variorum/IBM/Power9.h
@@ -24,4 +24,5 @@ int ibm_cpu_p9_get_node_power_json(char **get_power_obj_str);
 
 int ibm_cpu_p9_get_node_power_domain_info_json(char **get_domain_obj_str);
 
+double ibm_cpu_p9_get_domain_power_value(int domain, int deviceID);
 #endif

--- a/src/variorum/IBM/config_ibm.c
+++ b/src/variorum/IBM/config_ibm.c
@@ -36,6 +36,8 @@ int set_ibm_func_ptrs(int idx)
         g_platform[idx].variorum_get_node_power_json = ibm_cpu_p9_get_node_power_json;
         g_platform[idx].variorum_get_node_power_domain_info_json =
             ibm_cpu_p9_get_node_power_domain_info_json;
+        g_platform[idx].variorum_get_domain_power_value =
+            ibm_cpu_p9_get_domain_power_value;
     }
     else
     {

--- a/src/variorum/IBM/ibm_power_features.h
+++ b/src/variorum/IBM/ibm_power_features.h
@@ -154,4 +154,6 @@ void json_get_power_sensors(int chipid,
                             json_t *get_power_obj,
                             const void *buf);
 
+double get_power_sensor_value(int domain, int chipid, const void *buf);
+
 #endif

--- a/src/variorum/config_architecture.c
+++ b/src/variorum/config_architecture.c
@@ -212,11 +212,6 @@ void variorum_get_topology(unsigned *nsockets, unsigned *ncores,
 
     if (!init_variorum_get_topology)
     {
-        // Commenting per Stephanie's code
-        // Patki guesses this should be left uncommented
-
-        // init_variorum_get_topology = 1;
-
         rc = variorum_init_topology();
 
         if (rc != 0)
@@ -360,6 +355,7 @@ void variorum_init_func_ptrs()
         g_platform[i].variorum_get_node_power_json = NULL;
         g_platform[i].variorum_get_node_power_domain_info_json = NULL;
         g_platform[i].variorum_print_energy = NULL;
+        g_platform[i].variorum_get_domain_power_value = NULL;
     }
 }
 

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -255,6 +255,12 @@ struct platform
     /// @return Error code.
     int (*variorum_print_energy)(void);
 
+    /// @brief Return a double value for a given power domain and device ID.
+    ///
+    /// @return output double value with power information for the specified
+    /// domain and device ID.  Returns -1.0 for error.
+    double (*variorum_get_domain_power_value)(int domain, int deviceID);
+
     /// @brief Identifier for architecture.
     uint64_t *arch_id;
     /// @brief Hostname.

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1142,3 +1142,39 @@ char *variorum_get_current_version()
 {
     return QuoteMacro(VARIORUM_VERSION);
 }
+
+// Variorum Advanced APIs
+// For this API, the accepted domains are node:0, socket:1, memory:2, gpu:3.
+// We may need to check here for which internal function to call based on the
+// domain specifically for multi-arch build.
+double variorum_get_domain_power_value(int domain, int deviceID)
+{
+    int err = 0;
+    int i;
+    err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    for (i = 0; i < P_NUM_PLATFORMS; i++)
+    {
+        if (g_platform[i].variorum_get_domain_power_value == NULL)
+        {
+            variorum_error_handler("Feature not yet implemented or is not supported",
+                                   VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                                   __FUNCTION__, __LINE__);
+            return 0;
+        }
+        err = g_platform[i].variorum_get_domain_power_value(domain, deviceID);
+        if (err)
+        {
+            return -1;
+        }
+    }
+    err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
+    if (err)
+    {
+        return -1;
+    }
+    return err;
+}

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1150,6 +1150,7 @@ char *variorum_get_current_version()
 double variorum_get_domain_power_value(int domain, int deviceID)
 {
     int err = 0;
+    double power_value = 0.0;
     int i;
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
     if (err)
@@ -1165,16 +1166,12 @@ double variorum_get_domain_power_value(int domain, int deviceID)
                                    __FUNCTION__, __LINE__);
             return 0;
         }
-        err = g_platform[i].variorum_get_domain_power_value(domain, deviceID);
-        if (err)
-        {
-            return -1;
-        }
+        power_value = g_platform[i].variorum_get_domain_power_value(domain, deviceID);
     }
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
     if (err)
     {
         return -1;
     }
-    return err;
+    return power_value;
 }

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -575,6 +575,20 @@ int variorum_get_node_power_domain_info_json(char **get_domain_obj_str);
 #define QuoteMacro(macro) QuoteIdent(macro)
 char *variorum_get_current_version(void);
 
+/**************************/
+/* Variorum Advanced APIs */
+/**************************/
+/// @brief Return a double value for a given power domain and device ID. 
+///
+/// @supparch
+/// - IBM Power9
+/// - Intel Broadwell
+///
+/// @param [out] output double value with power information for the specified
+//  domain and device ID.  Returns -1 if domain, device or value is unavailable.
+//  Accepted domains are node:0, socket:1, memory:2, gpu:3. 
+double variorum_get_domain_power_value(int domain, int deviceID);
+
 /***********/
 /* Testing */
 /***********/

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -578,15 +578,15 @@ char *variorum_get_current_version(void);
 /**************************/
 /* Variorum Advanced APIs */
 /**************************/
-/// @brief Return a double value for a given power domain and device ID. 
+/// @brief Return a double value for a given power domain and device ID.
 ///
 /// @supparch
 /// - IBM Power9
 /// - Intel Broadwell
 ///
 /// @param [out] output double value with power information for the specified
-//  domain and device ID.  Returns -1 if domain, device or value is unavailable.
-//  Accepted domains are node:0, socket:1, memory:2, gpu:3. 
+/// domain and device ID.  Returns -1.0 if domain, device or value is unavailable.
+///  Accepted domains are node:0, socket:1, memory:2, gpu:3.
 double variorum_get_domain_power_value(int domain, int deviceID);
 
 /***********/


### PR DESCRIPTION
# Description
Adds a new advanced API to return a double power value based on domain and device ID. 

Builds correctly only on Lassen. No GPU power reported.

Fixes #436. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Tested on Lassen only. 

```
./examples/variorum-get-domain-power-value-example 
Power for the Node domain is 428.000000 watts
Processor Power for Socket 1 is 78.000000 watts
Power for Memory from Socket 0 is  21.000000 watts
```
# Checklist:

- [ ] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [ ] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [ ] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
