### PR TITLE
Initialize low-level GPU API once instead of at each Variorum API call

### DIFF
--- a/src/variorum/AMD_GPU/amd_gpu_power_features.c
+++ b/src/variorum/AMD_GPU/amd_gpu_power_features.c
@@ -29,16 +29,6 @@ void get_power_data(int chipid, int total_sockets, int verbose, FILE *output)
 
     gethostname(hostname, 1024);
 
-    ret = rsmi_init(0);
-    if (ret != RSMI_STATUS_SUCCESS)
-    {
-        variorum_error_handler("Could not initialize RSMI",
-                               VARIORUM_ERROR_PLATFORM_ENV,
-                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
-                               __LINE__);
-        exit(-1);
-    }
-
     ret = rsmi_num_monitor_devices(&num_devices);
     if (ret != RSMI_STATUS_SUCCESS)
     {
@@ -142,16 +132,6 @@ void get_power_limit_data(int chipid, int total_sockets, int verbose,
     struct timeval now;
 
     gethostname(hostname, 1024);
-
-    ret = rsmi_init(0);
-    if (ret != RSMI_STATUS_SUCCESS)
-    {
-        variorum_error_handler("Could not initialize RSMI",
-                               VARIORUM_ERROR_PLATFORM_ENV,
-                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
-                               __LINE__);
-        exit(-1);
-    }
 
     ret = rsmi_num_monitor_devices(&num_devices);
     if (ret != RSMI_STATUS_SUCCESS)
@@ -276,16 +256,6 @@ void get_thermals_data(int chipid, int total_sockets, int verbose, FILE *output)
     int i;
 
     gethostname(hostname, 1024);
-
-    ret = rsmi_init(0);
-    if (ret != RSMI_STATUS_SUCCESS)
-    {
-        variorum_error_handler("Could not initialize RSMI",
-                               VARIORUM_ERROR_PLATFORM_ENV,
-                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
-                               __LINE__);
-        exit(-1);
-    }
 
     ret = rsmi_num_monitor_devices(&num_devices);
     if (ret != RSMI_STATUS_SUCCESS)
@@ -470,16 +440,6 @@ void get_clocks_data(int chipid, int total_sockets, int verbose, FILE *output)
     struct timeval now;
 
     gethostname(hostname, 1024);
-
-    ret = rsmi_init(0);
-    if (ret != RSMI_STATUS_SUCCESS)
-    {
-        variorum_error_handler("Could not initialize RSMI",
-                               VARIORUM_ERROR_PLATFORM_ENV,
-                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
-                               __LINE__);
-        exit(-1);
-    }
 
     ret = rsmi_num_monitor_devices(&num_devices);
     if (ret != RSMI_STATUS_SUCCESS)
@@ -678,16 +638,6 @@ void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
 
     gethostname(hostname, 1024);
 
-    ret = rsmi_init(0);
-    if (ret != RSMI_STATUS_SUCCESS)
-    {
-        variorum_error_handler("Could not initialize RSMI",
-                               VARIORUM_ERROR_PLATFORM_ENV,
-                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
-                               __LINE__);
-        exit(-1);
-    }
-
     ret = rsmi_num_monitor_devices(&num_devices);
     if (ret != RSMI_STATUS_SUCCESS)
     {
@@ -885,16 +835,6 @@ void cap_each_gpu_power_limit(int chipid, int total_sockets,
     unsigned int powerlimit_uwatts = powerlimit * 1000000;
 
     gethostname(hostname, 1024);
-
-    ret = rsmi_init(0);
-    if (ret != RSMI_STATUS_SUCCESS)
-    {
-        variorum_error_handler("Could not initialize RSMI",
-                               VARIORUM_ERROR_PLATFORM_ENV,
-                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
-                               __LINE__);
-        exit(-1);
-    }
 
     ret = rsmi_num_monitor_devices(&num_devices);
     if (ret != RSMI_STATUS_SUCCESS)

--- a/src/variorum/AMD_GPU/config_amd_gpu.c
+++ b/src/variorum/AMD_GPU/config_amd_gpu.c
@@ -48,7 +48,6 @@ int set_amd_gpu_func_ptrs(int idx)
         err = VARIORUM_ERROR_UNSUPPORTED_PLATFORM;
     }
 
-
     if (init_complete == 0)
     {
         ret = rsmi_init(0);

--- a/src/variorum/AMD_GPU/config_amd_gpu.c
+++ b/src/variorum/AMD_GPU/config_amd_gpu.c
@@ -22,6 +22,7 @@ uint64_t *detect_amd_gpu_arch(void)
 
 int set_amd_gpu_func_ptrs(int idx)
 {
+    static int init_complete = 0;
     int err = 0;
 
     if (*g_platform[idx].arch_id == AMD_INSTINCT)
@@ -46,5 +47,19 @@ int set_amd_gpu_func_ptrs(int idx)
         err = VARIORUM_ERROR_UNSUPPORTED_PLATFORM;
     }
 
+
+    if (init_complete == 0)
+    {
+        ret = rsmi_init(0);
+        if (ret != RSMI_STATUS_SUCCESS)
+        {
+            variorum_error_handler("Could not initialize RSMI",
+                                   VARIORUM_ERROR_PLATFORM_ENV,
+                                   getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                                   __LINE__);
+            exit(-1);
+        }
+        init_complete = 1;
+    }
     return err;
 }

--- a/src/variorum/AMD_GPU/config_amd_gpu.c
+++ b/src/variorum/AMD_GPU/config_amd_gpu.c
@@ -24,6 +24,7 @@ int set_amd_gpu_func_ptrs(int idx)
 {
     static int init_complete = 0;
     int err = 0;
+    rsmi_status_t ret;
 
     if (*g_platform[idx].arch_id == AMD_INSTINCT)
     {

--- a/src/variorum/Nvidia_GPU/config_nvidia.c
+++ b/src/variorum/Nvidia_GPU/config_nvidia.c
@@ -20,6 +20,7 @@ uint64_t *detect_gpu_arch(void)
 
 int set_nvidia_func_ptrs(int idx)
 {
+    static int init_complete = 0;
     int err = 0;
 
     if (*g_platform[idx].arch_id == VOLTA)
@@ -43,6 +44,10 @@ int set_nvidia_func_ptrs(int idx)
         err = VARIORUM_ERROR_UNSUPPORTED_PLATFORM;
     }
 
-    initNVML();
+    if (init_complete == 0)
+    {
+        initNVML();
+        init_complete = 1;
+    }
     return err;
 }

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -30,7 +30,23 @@ void initNVML(void)
     /* Initialize GPU reading */
     m_unit_devices_file_desc = NULL;
     nvmlReturn_t result = nvmlInit();
-    nvmlDeviceGetCount(&m_total_unit_devices);
+    if (result != NVML_SUCCESS)
+    {
+        variorum_error_handler("Could not initialize NVML",
+                               VARIORUM_ERROR_PLATFORM_ENV,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                               __LINE__);
+        exit(-1);
+    }
+    result = nvmlDeviceGetCount(&m_total_unit_devices);
+    if (result != NVML_SUCCESS)
+    {
+        variorum_error_handler("Could not query GPU devices on the system",
+                               VARIORUM_ERROR_PLATFORM_ENV,
+                               getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                               __LINE__);
+        exit(-1);
+    }
     m_unit_devices_file_desc = (nvmlDevice_t *) malloc(sizeof(
                                    nvmlDevice_t) * m_total_unit_devices);
     if (m_unit_devices_file_desc == NULL)


### PR DESCRIPTION
# Description

This PR adds state-preserving logic to the GPU functionality in Variorum. The goal is to call the respective initialization functions provided by the low-level device-specific APIs. 

Fixes #427 

Closes https://github.com/LLNL/variorum/pull/459 once all tests pass.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Since this fix touches the AMD and Nvidia GPUs, it is tested on the following systems:
- [x] Lassen/Alehouse: Nvidia V100 GPUs
- [x] nvhpc1: Nvidia A100 GPUs
- [x] Corona/Tioga: AMD GPUs

