### PR TITLE
Report GPU power limit using the correct NVML API

### DIFF
--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -123,12 +123,21 @@ void nvidia_gpu_get_power_limits_data(int chipid, int verbose, FILE *output)
     double value = 0.0;
     int d;
     static int init_output = 0;
+    nvmlReturn_t result;
 
     /* Iterate over all GPU device handles populated at init and print GPU power limit */
     for (d = chipid * (int)m_gpus_per_socket;
          d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
-        nvmlDeviceGetPowerManagementLimit(m_unit_devices_file_desc[d], &power_limit);
+        result = nvmlDeviceGetEnforcedPowerLimit(m_unit_devices_file_desc[d],
+                 &power_limit);
+        if (result != NVML_SUCCESS)
+        {
+            variorum_error_handler("Could not query GPU power limit\n",
+                                   VARIORUM_ERROR_PLATFORM_ENV,
+                                   getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                                   __LINE__);
+        }
         value = (double) power_limit * 0.001f;
 
         if (verbose)


### PR DESCRIPTION
# Description

This PR replaces the `nvmlDeviceGetPowerManagementLimit()` call by the `nvmlDeviceGetEnforcedPowerLimit()`. The former API does not report the updated GPU power limit if it has been modified via. an out-of-band interface. For example, if the GPU power limit is implicitly updated by the node power limiting interface on Lassen, the updated GPU power limit is not reflected in the output of the former API. The latter API (i.e., `nvmlDeviceGetEnforcedPowerLimit()`) captures the changes in the GPU power limit applied through both the in-band interface (e.g., `nvidia-smi` or NVML) as well as the out-of-band interface (e.g., IBM node power limit interface). 

Fixes #445 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This fix has been tested on Lassen. Following test cases have been performed:

- [x] Test 0: Report default GPU power limit. Result: Pass
- [x] Test 1: Report GPU power limit after changing it with `nvidia-smi` (i.e., in-band). Result: Pass
- [x] Test 2: Report GPU power limit after resetting it to default (300 W) with `nvidia-smi` (in-band). Result: Pass
- [x] Test 3: Report GPU power limit after implicitly changing it with the IBM node power limit interface (out-of-band). Result: Pass
- [x] Test 4: Report GPU power limit after implicitly resetting it with IBM node power limit interface (out-of-band). Result: Pass

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes
- [x] Added failure checks previously missing for the API call

Thank you for taking the time to contribute to Variorum!
