### PR TITLE
Nvidia port memory leak fix 

### DIFF
--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -17,11 +17,17 @@ void initNVML(void)
     unsigned int d;
     unsigned m_num_package;
     /* Initialize GPU reading */
+    m_unit_devices_file_desc = NULL;
     nvmlReturn_t result = nvmlInit();
     nvmlDeviceGetCount(&m_total_unit_devices);
     m_unit_devices_file_desc = (nvmlDevice_t *) malloc(sizeof(
                                    nvmlDevice_t) * m_total_unit_devices);
-
+    if (m_unit_devices_file_desc == NULL)
+    {
+        variorum_error_handler("Could not allocate memory for device file descriptor",
+                               VARIORUM_ERROR_PLATFORM_ENV, getenv("HOSTNAME"), __FILE__, __FUNCTION__,
+                               __LINE__);
+    }
     /* Populate handles to all devices. This assumes block-mapping
      * between packages and GPUs */
     for (d = 0; d < m_total_unit_devices; ++d)
@@ -47,6 +53,10 @@ void initNVML(void)
 
 void shutdownNVML(void)
 {
+    if (m_unit_devices_file_desc != NULL)
+    {
+        free(m_unit_devices_file_desc);
+    }
     nvmlShutdown();
 }
 


### PR DESCRIPTION
# Description

This is a WIP PR to remove memory leaks in the Nvidia port code of Variorum. This change frees up the GPU device descriptor memory block that's allocated in `initNVML()` in `shutdownNVML()`. 

Fixes #449 

## Type of change

- [x] Bug fix (memory leak exposed via. Valgrind)

# How Has This Been Tested?

This fix is being tested on Lassen and Alehouse systems. 

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
