### PR TITLE
Fix extern linkage issues in 'nvidia_gpu_power_features.h' in newer versions of gcc

### DIFF
--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -16,6 +16,7 @@ unsigned m_total_unit_devices;
 nvmlDevice_t *m_unit_devices_file_desc;
 unsigned m_gpus_per_socket;
 char m_hostname[1024];
+
 void initNVML(void)
 {
     unsigned int d;

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -12,6 +12,10 @@
 #include <variorum_error.h>
 #include <variorum_timers.h>
 
+unsigned m_total_unit_devices;
+nvmlDevice_t *m_unit_devices_file_desc;
+unsigned m_gpus_per_socket;
+char m_hostname[1024];
 void initNVML(void)
 {
     unsigned int d;

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.h
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.h
@@ -11,10 +11,10 @@
 
 #include <nvml.h>
 
-unsigned m_total_unit_devices;
-nvmlDevice_t *m_unit_devices_file_desc;
-unsigned m_gpus_per_socket;
-char m_hostname[1024];
+extern unsigned m_total_unit_devices;
+extern nvmlDevice_t *m_unit_devices_file_desc;
+extern unsigned m_gpus_per_socket;
+extern char m_hostname[1024];
 
 void initNVML(void);
 


### PR DESCRIPTION
### Description:

This pull request addresses the linker errors that were emerging due to multiple definitions of the variables: m_total_unit_devices, m_unit_devices_file_desc, m_gpus_per_socket, and m_hostname.

### Changes:
### Added extern Declarations:
In nvidia_gpu_power_features.h, I added the extern keyword to the declarations of the mentioned variables. This ensures that they're treated as declarations and not definitions.
### Centralized Definitions:
I've ensured that these variables are defined only in one source file (nvidia_gpu_power_features.c, for instance). This eradicates the multiple definitions issue and adheres to good coding practices.
Fixes #463 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please provide hardware architecture specs and
instructions so we can reproduce.

- [ ] Test A: TitanXP, Intel Broadwell CPU


# Checklist:

- [ ] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [ ] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
