### PR TITLE
update allowlist name in github action unit test

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -288,7 +288,7 @@ jobs:
           ls -l /dev/cpu/*/msr_safe
           MSR_SAFE_VERSION=`cat /sys/module/msr_safe/version`
           echo -e "MSR_SAFE_VERSION:" ${MSR_SAFE_VERSION}
-          AL=$(printf 'al_%.2x_%x\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
+          AL=$(printf 'al_%.2x_%X\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
           echo -e "AL:" ${AL}
           cut -c 3- allowlists/${AL} > allowlists/${AL}_mod
           cat allowlists/${AL}_mod > /dev/cpu/msr_allowlist

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -290,6 +290,7 @@ jobs:
           echo -e "MSR_SAFE_VERSION:" ${MSR_SAFE_VERSION}
           AL=$(printf 'al_%.2x_%X\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
           echo -e "AL:" ${AL}
+          sed -i -e 1,9d allowlists/${AL}
           cut -c 3- allowlists/${AL} > allowlists/${AL}_mod
           cat allowlists/${AL}_mod
           cat allowlists/${AL}_mod > /dev/cpu/msr_allowlist

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -292,7 +292,6 @@ jobs:
           echo -e "AL:" ${AL}
           sed -i -e 1,9d allowlists/${AL}
           cut -c 3- allowlists/${AL} > allowlists/${AL}_mod
-          head -n 10 allowlists/${AL}_mod > allowlists/${AL}_mod
           cat allowlists/${AL}_mod
           cat allowlists/${AL}_mod > /dev/cpu/msr_allowlist
           head -n 5 /dev/cpu/msr_allowlist

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -292,6 +292,7 @@ jobs:
           echo -e "AL:" ${AL}
           sed -i -e 1,9d allowlists/${AL}
           cut -c 3- allowlists/${AL} > allowlists/${AL}_mod
+          head -n 10 allowlists/${AL}_mod > allowlists/${AL}_mod
           cat allowlists/${AL}_mod
           cat allowlists/${AL}_mod > /dev/cpu/msr_allowlist
           head -n 5 /dev/cpu/msr_allowlist

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -225,20 +225,20 @@ jobs:
           cmake --version
           gcc --version
 
-#      - name: Compile check
-#        env:
-#          BUILD_SHARED_LIBS: ON
-#          BUILD_DOCS: OFF
-#          BUILD_TESTS: OFF
-#          CMAKE_BUILD_TYPE: Release
-#          ENABLE_FORTRAN: ON
-#          ENABLE_MPI: OFF
-#          ENABLE_OPENMP: OFF
-#          VARIORUM_DEBUG: OFF
-#          USE_MSR_SAFE_BEFORE_1_5_0: OFF
-#        run: |
-#          # create out-of-source build and install dir
-#          mkdir build && mkdir install
+      - name: Compile check
+        env:
+          BUILD_SHARED_LIBS: ON
+          BUILD_DOCS: OFF
+          BUILD_TESTS: OFF
+          CMAKE_BUILD_TYPE: Release
+          ENABLE_FORTRAN: ON
+          ENABLE_MPI: OFF
+          ENABLE_OPENMP: OFF
+          VARIORUM_DEBUG: OFF
+          USE_MSR_SAFE_BEFORE_1_5_0: OFF
+        run: |
+          # create out-of-source build and install dir
+          mkdir build && mkdir install
 #          cd build
 #          # setup cmake options
 #          export CMAKE_OPTS="-DBUILD_SHARED_LIBS=${{env.BUILD_SHARED_LIBS}}"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -290,7 +290,8 @@ jobs:
           echo -e "MSR_SAFE_VERSION:" ${MSR_SAFE_VERSION}
           AL=$(printf 'al_%.2x_%x\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
           echo -e "AL:" ${AL}
-          cat allowlists/${AL} > /dev/cpu/msr_allowlist
+          cut -c 3- allowlists/${AL} > allowlists/${AL}_mod
+          cat allowlists/${AL}_mod > /dev/cpu/msr_allowlist
           head -n 5 /dev/cpu/msr_allowlist
 
       - name: Test install with cmake example

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -239,24 +239,24 @@ jobs:
         run: |
           # create out-of-source build and install dir
           mkdir build && mkdir install
-#          cd build
-#          # setup cmake options
-#          export CMAKE_OPTS="-DBUILD_SHARED_LIBS=${{env.BUILD_SHARED_LIBS}}"
-#          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_DOCS=${{env.BUILD_DOCS}}"
-#          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_TESTS=${{env.BUILD_TESTS}}"
-#          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_BUILD_TYPE=${{env.CMAKE_BUILD_TYPE}}"
-#          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_FORTRAN=${{env.ENABLE_FORTRAN}}"
-#          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_MPI=${{env.ENABLE_MPI}}"
-#          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_OPENMP=${{env.ENABLE_OPENMP}}"
-#          export CMAKE_OPTS="${CMAKE_OPTS} -DVARIORUM_DEBUG=${{env.VARIORUM_DEBUG}}"
-#          export CMAKE_OPTS="${CMAKE_OPTS} -DUSE_MSR_SAFE_BEFORE_1_5_0=${{env.USE_MSR_SAFE_BEFORE_1_5_0}}"
-#          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_INSTALL_PREFIX=../install"
-#          echo ${CMAKE_OPTS}
-#          cmake ${CMAKE_OPTS} ../src
-#          # build
-#          VERBOSE=1 make -j
-#          # install
-#          make -j install
+          cd build
+          # setup cmake options
+          export CMAKE_OPTS="-DBUILD_SHARED_LIBS=${{env.BUILD_SHARED_LIBS}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_DOCS=${{env.BUILD_DOCS}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_TESTS=${{env.BUILD_TESTS}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_BUILD_TYPE=${{env.CMAKE_BUILD_TYPE}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_FORTRAN=${{env.ENABLE_FORTRAN}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_MPI=${{env.ENABLE_MPI}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_OPENMP=${{env.ENABLE_OPENMP}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DVARIORUM_DEBUG=${{env.VARIORUM_DEBUG}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DUSE_MSR_SAFE_BEFORE_1_5_0=${{env.USE_MSR_SAFE_BEFORE_1_5_0}}"
+          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_INSTALL_PREFIX=../install"
+          echo ${CMAKE_OPTS}
+          cmake ${CMAKE_OPTS} ../src
+          # build
+          VERBOSE=1 make -j
+          # install
+          make -j install
 
       - name: Clone msr-safe
         uses: actions/checkout@v2
@@ -277,17 +277,17 @@ jobs:
 
       - name: Load msr-safe
         run: |
-#          uname -a
-#          uname -r
-#          cd msr-safe
-#          sudo insmod msr-safe.ko
-#          sudo chmod o=u /dev/cpu/*/msr_safe
-#          sudo chmod o=u /dev/cpu/msr_*
-#          sleep 2
-#          ls -l /dev/cpu
-#          ls -l /dev/cpu/*/msr_safe
-#          MSR_SAFE_VERSION=`cat /sys/module/msr_safe/version`
-#          echo -e "MSR_SAFE_VERSION:" ${MSR_SAFE_VERSION}
+          uname -a
+          uname -r
+          cd msr-safe
+          sudo insmod msr-safe.ko
+          sudo chmod o=u /dev/cpu/*/msr_safe
+          sudo chmod o=u /dev/cpu/msr_*
+          sleep 2
+          ls -l /dev/cpu
+          ls -l /dev/cpu/*/msr_safe
+          MSR_SAFE_VERSION=`cat /sys/module/msr_safe/version`
+          echo -e "MSR_SAFE_VERSION:" ${MSR_SAFE_VERSION}
           AL=$(printf 'al_%.2x_%X\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
           echo -e "AL:" ${AL}
           cut -c 3- allowlists/${AL} > allowlists/${AL}_mod

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -288,7 +288,7 @@ jobs:
           ls -l /dev/cpu/*/msr_safe
           MSR_SAFE_VERSION=`cat /sys/module/msr_safe/version`
           echo -e "MSR_SAFE_VERSION:" ${MSR_SAFE_VERSION}
-          AL=$(printf 'al_%.2x%x\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
+          AL=$(printf 'al_%.2x_%x\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
           echo -e "AL:" ${AL}
           cat allowlists/${AL} > /dev/cpu/msr_allowlist
           head -n 5 /dev/cpu/msr_allowlist

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -225,38 +225,38 @@ jobs:
           cmake --version
           gcc --version
 
-      - name: Compile check
-        env:
-          BUILD_SHARED_LIBS: ON
-          BUILD_DOCS: OFF
-          BUILD_TESTS: OFF
-          CMAKE_BUILD_TYPE: Release
-          ENABLE_FORTRAN: ON
-          ENABLE_MPI: OFF
-          ENABLE_OPENMP: OFF
-          VARIORUM_DEBUG: OFF
-          USE_MSR_SAFE_BEFORE_1_5_0: OFF
-        run: |
-          # create out-of-source build and install dir
-          mkdir build && mkdir install
-          cd build
-          # setup cmake options
-          export CMAKE_OPTS="-DBUILD_SHARED_LIBS=${{env.BUILD_SHARED_LIBS}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_DOCS=${{env.BUILD_DOCS}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_TESTS=${{env.BUILD_TESTS}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_BUILD_TYPE=${{env.CMAKE_BUILD_TYPE}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_FORTRAN=${{env.ENABLE_FORTRAN}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_MPI=${{env.ENABLE_MPI}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_OPENMP=${{env.ENABLE_OPENMP}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DVARIORUM_DEBUG=${{env.VARIORUM_DEBUG}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DUSE_MSR_SAFE_BEFORE_1_5_0=${{env.USE_MSR_SAFE_BEFORE_1_5_0}}"
-          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_INSTALL_PREFIX=../install"
-          echo ${CMAKE_OPTS}
-          cmake ${CMAKE_OPTS} ../src
-          # build
-          VERBOSE=1 make -j
-          # install
-          make -j install
+#      - name: Compile check
+#        env:
+#          BUILD_SHARED_LIBS: ON
+#          BUILD_DOCS: OFF
+#          BUILD_TESTS: OFF
+#          CMAKE_BUILD_TYPE: Release
+#          ENABLE_FORTRAN: ON
+#          ENABLE_MPI: OFF
+#          ENABLE_OPENMP: OFF
+#          VARIORUM_DEBUG: OFF
+#          USE_MSR_SAFE_BEFORE_1_5_0: OFF
+#        run: |
+#          # create out-of-source build and install dir
+#          mkdir build && mkdir install
+#          cd build
+#          # setup cmake options
+#          export CMAKE_OPTS="-DBUILD_SHARED_LIBS=${{env.BUILD_SHARED_LIBS}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_DOCS=${{env.BUILD_DOCS}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DBUILD_TESTS=${{env.BUILD_TESTS}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_BUILD_TYPE=${{env.CMAKE_BUILD_TYPE}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_FORTRAN=${{env.ENABLE_FORTRAN}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_MPI=${{env.ENABLE_MPI}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_OPENMP=${{env.ENABLE_OPENMP}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DVARIORUM_DEBUG=${{env.VARIORUM_DEBUG}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DUSE_MSR_SAFE_BEFORE_1_5_0=${{env.USE_MSR_SAFE_BEFORE_1_5_0}}"
+#          export CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_INSTALL_PREFIX=../install"
+#          echo ${CMAKE_OPTS}
+#          cmake ${CMAKE_OPTS} ../src
+#          # build
+#          VERBOSE=1 make -j
+#          # install
+#          make -j install
 
       - name: Clone msr-safe
         uses: actions/checkout@v2
@@ -277,20 +277,21 @@ jobs:
 
       - name: Load msr-safe
         run: |
-          uname -a
-          uname -r
-          cd msr-safe
-          sudo insmod msr-safe.ko
-          sudo chmod o=u /dev/cpu/*/msr_safe
-          sudo chmod o=u /dev/cpu/msr_*
-          sleep 2
-          ls -l /dev/cpu
-          ls -l /dev/cpu/*/msr_safe
-          MSR_SAFE_VERSION=`cat /sys/module/msr_safe/version`
-          echo -e "MSR_SAFE_VERSION:" ${MSR_SAFE_VERSION}
+#          uname -a
+#          uname -r
+#          cd msr-safe
+#          sudo insmod msr-safe.ko
+#          sudo chmod o=u /dev/cpu/*/msr_safe
+#          sudo chmod o=u /dev/cpu/msr_*
+#          sleep 2
+#          ls -l /dev/cpu
+#          ls -l /dev/cpu/*/msr_safe
+#          MSR_SAFE_VERSION=`cat /sys/module/msr_safe/version`
+#          echo -e "MSR_SAFE_VERSION:" ${MSR_SAFE_VERSION}
           AL=$(printf 'al_%.2x_%X\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
           echo -e "AL:" ${AL}
           cut -c 3- allowlists/${AL} > allowlists/${AL}_mod
+          cat allowlists/${AL}_mod
           cat allowlists/${AL}_mod > /dev/cpu/msr_allowlist
           head -n 5 /dev/cpu/msr_allowlist
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -290,9 +290,7 @@ jobs:
           echo -e "MSR_SAFE_VERSION:" ${MSR_SAFE_VERSION}
           AL=$(printf 'al_%.2x_%X\n' $(lscpu | grep "CPU family:" | awk -F: '{print $2}') $(lscpu | grep "Model:" | awk -F: '{print $2}'))
           echo -e "AL:" ${AL}
-          sed -i -e 1,9d allowlists/${AL}
-          cut -c 3- allowlists/${AL} > allowlists/${AL}_mod
-          cat allowlists/${AL}_mod
+          cut -c 2- allowlists/${AL} > allowlists/${AL}_mod
           cat allowlists/${AL}_mod > /dev/cpu/msr_allowlist
           head -n 5 /dev/cpu/msr_allowlist
 


### PR DESCRIPTION
# Description

Recent change in msr-safe changed name of allowlists from al_06XX to al_06_XX. Update unit test to find the correct allowlist.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Build/CI update

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes
