### PR TITLE
powmon for power and utilization 

### DIFF
--- a/src/powmon/common.c
+++ b/src/powmon/common.c
@@ -15,11 +15,204 @@ struct thread_args
 {
     bool measure_all;
     unsigned long sample_interval;
+    bool power_with_util; 
 };
 
 int init_data(void)
 {
     return 0;
+}
+
+void parse_power_and_util_json_obj(char *pow_str, char *util_str, int num_sockets)
+{
+    int i, j;
+    char hostname[1024];
+    char socket_num[11];
+    size_t size;
+    int ndevices, ndevices_socket ;
+    gethostname(hostname, 1024);
+
+    /* Create a Jansson based JSON structure */
+    json_t *util_obj = NULL;
+
+    double cpu_util, mem_util, sys_util, user_util;
+    int gpu_util;
+    static bool write_header = true;
+
+    /* Create a Jansson based JSON structure */
+    json_t *power_obj = NULL;
+
+    double power_node, power_cpu, power_gpu, power_mem;
+    static char **json_metric_names = NULL;
+
+    /* List of socket-level JSON object metrics */
+    static const char *metrics[] = {"power_cpu_watts_socket_",
+                                    "power_gpu_watts_socket_",
+                                    "power_mem_watts_socket_"
+                                   };
+     /* Allocate space for metric names */
+    json_metric_names = malloc(3 * num_sockets * sizeof(char *));
+    for (i = 0; i < (3 * num_sockets); i++)
+    {
+        json_metric_names[i] = malloc(40);
+    }
+
+    for (i = 0; i < num_sockets; i++)
+    {
+        /* Create a metric name list for querying json object later on */
+        for (j = 0; j < 3; j++)
+        {
+            char current_metric[40];
+            char current_socket[16];
+            strcpy(current_metric, metrics[j]);
+            sprintf(current_socket, "%d", i);
+            strcat(current_metric, current_socket);
+            strcpy(json_metric_names[(num_sockets * j) + i], current_metric);
+        }
+    }
+
+    /* Load the string as a JSON object using Jansson */
+    power_obj = json_loads(pow_str, JSON_DECODE_ANY, NULL);
+
+    /* Extract and print values from JSON object */
+    power_node = json_real_value(json_object_get(power_obj, "power_node_watts"));
+
+    //static char **json_metric_names = NULL;
+
+    /* List of socket-level JSON object metrics */
+    /*static const char *metrics[] = {"power_cpu_watts_socket_",
+                                    "power_gpu_watts_socket_",
+                                    "power_mem_watts_socket_"
+                                   };*/
+
+    /* Allocate space for metric names */
+    /*json_metric_names = malloc(3 * num_sockets * sizeof(char *));
+    for (i = 0; i < (3 * num_sockets); i++)
+    {
+        json_metric_names[i] = malloc(40);
+    }
+
+    for (i = 0; i < num_sockets; i++)
+    {
+        // Create a metric name list for querying json object later on /
+        for (j = 0; j < 3; j++)
+        {
+            char current_metric[40];
+            char current_socket[16];
+            strcpy(current_metric, metrics[j]);
+            sprintf(current_socket, "%d", i);
+            strcat(current_metric, current_socket);
+            strcpy(json_metric_names[(num_sockets * j) + i], current_metric);
+        }
+    }*/
+
+    /* Load the string as a JSON object using Jansson */
+    util_obj = json_loads(util_str, JSON_DECODE_ANY, NULL);
+  
+
+    
+    /* Extract and print values from JSON object */
+    json_t *host_obj = json_object_get(util_obj, hostname);
+    mem_util = json_real_value(json_object_get(host_obj, "memory_util%"));
+    json_t *cpu_util_obj = json_object_get(host_obj, "CPU");
+    cpu_util = json_real_value(json_object_get(cpu_util_obj, "total_util%"));
+    sys_util = json_real_value(json_object_get(cpu_util_obj, "system_util%"));
+    user_util = json_real_value(json_object_get(cpu_util_obj, "user_util%"));
+    json_t *gpu_obj = json_object_get(host_obj, "GPU");
+
+
+    if (write_header == true)
+    { 
+        fprintf(logfile, "%s,%s,", "Timestamp (ms)", "Node Power (W)");
+        for (i = 0; i < num_sockets; i++)
+        {
+            char str[40];
+            sprintf(str, "Socket %i CPU Power (W)", i);
+            fprintf(logfile, "%s,", str);
+            sprintf(str, "Socket %i GPU Power (W)", i);
+            fprintf(logfile, "%s,", str);
+            sprintf(str, "Socket %i Mem Power (W)", i);
+            fprintf(logfile, " %s,", str);
+
+        }
+
+        fprintf(logfile, "%s,%s,%s,%s,", "Memory Utiilizaion%", "Total CPU Utilization%", "User Utilization%", "System Utilization%");
+        for (i = 0; i < num_sockets; ++i)
+        {
+            sprintf(socket_num,"Socket_%d",i);
+            json_t *socket_obj = json_object_get(gpu_obj, socket_num);
+            size = json_object_size(socket_obj);
+            ndevices  = size; 
+            for ( j=0; j < ndevices; j++)
+            {
+                char device_id[12];
+                snprintf(device_id, 12, "GPU%d%d_util%", i, j);
+                // Don't write out a comma after the last column name
+                if ((i + 1) == num_sockets && (j +1) == ndevices)
+                {
+                    fprintf(logfile, "%s\n", device_id);
+                    write_header = false;
+                }
+                else
+                {
+                    fprintf(logfile, "%s,", device_id);
+                }
+            }
+        }
+    }
+
+        fprintf(logfile, "%ld, %lf, ", now_ms(), power_node);
+
+    for (i = 0; i < num_sockets; i++)
+    {
+        power_cpu = json_real_value(json_object_get(power_obj, json_metric_names[i]));
+        power_gpu = json_real_value(json_object_get(power_obj,
+                                    json_metric_names[num_sockets + i]));
+        power_mem = json_real_value(json_object_get(power_obj,
+                                    json_metric_names[(num_sockets * 2) + i]));
+        fprintf(logfile, "%lf, %lf, %lf,", power_cpu, power_gpu, power_mem);
+    }
+        
+
+    fprintf(logfile, "%lf, %lf, %lf, %lf, ", mem_util, cpu_util, user_util, sys_util);
+    for (i = 0; i < num_sockets; ++i)
+    {
+        sprintf(socket_num,"Socket_%d",i);
+        json_t *socket_obj = json_object_get(gpu_obj, socket_num);
+        size = json_object_size(socket_obj);
+        ndevices  = size;
+        for ( j=0; j < ndevices; j++)
+        {   
+            char device_id[12]; 
+            snprintf(device_id, 12, "GPU%d%d_util%", i, j);
+            gpu_util = json_integer_value(json_object_get(socket_obj, device_id));
+            // Don't write out a comma after the last column name
+            if ((i + 1) == num_sockets && (j + 1) == ndevices)
+            {
+                fprintf(logfile, "%d", gpu_util);
+                fprintf(logfile, "\n");
+            }
+            else
+            {
+                fprintf(logfile, "%d,", gpu_util);
+            }
+        }
+    }
+
+ 
+
+
+
+    /* Deallocate metric array */
+    for (i = 0; i < num_sockets * 3; i++)
+    {
+        free(json_metric_names[i]);
+    }
+    free(json_metric_names);
+
+    /*Deallocate JSON object*/
+    json_decref(util_obj);
+    json_decref(power_obj);
 }
 
 void parse_json_obj(char *s, int num_sockets)
@@ -68,7 +261,6 @@ void parse_json_obj(char *s, int num_sockets)
 
     if (write_header == true)
     {
-        fprintf(logfile, "%s,%s,", "Timestamp (ms)", "Node Power (W)");
         for (i = 0; i < num_sockets; i++)
         {
             char str[40];
@@ -78,7 +270,6 @@ void parse_json_obj(char *s, int num_sockets)
             fprintf(logfile, "%s,", str);
             if ((i + 1) == num_sockets)
             {
-                // Don't write out a comma after the last column name
                 sprintf(str, "Socket %i Mem Power (W)", i);
                 fprintf(logfile, "%s\n", str);
             }
@@ -105,8 +296,6 @@ void parse_json_obj(char *s, int num_sockets)
 
         if ((i + 1) == num_sockets)
         {
-            // Don't write out a comma after the last socket's entry.
-            // Write a new line instead.
             fprintf(logfile, "%lf, %lf, %lf", power_cpu, power_gpu, power_mem);
             fprintf(logfile, "\n");
         }
@@ -127,7 +316,8 @@ void parse_json_obj(char *s, int num_sockets)
     json_decref(power_obj);
 }
 
-void take_measurement(bool measure_all)
+
+void take_measurement(bool measure_all, bool power_with_util)
 {
 #if 0
     uint64_t instr0 = 0;
@@ -142,9 +332,10 @@ void take_measurement(bool measure_all)
     if (measure_all == false)
     {
         // Extract power information from Variorum JSON API
-        int ret;
+        int ret_util, ret_pow;
         int num_sockets = 0;
-        char *s = NULL;
+        char *power_str = NULL;
+        char *util_str = NULL;
 
         num_sockets = variorum_get_num_sockets();
 
@@ -154,16 +345,40 @@ void take_measurement(bool measure_all)
             exit(-1);
         }
 
-        ret = variorum_get_node_power_json(&s);
-        if (ret != 0)
-        {
-            printf("JSON get node power failed. Exiting.\n");
-            free(s);
-            exit(-1);
-        }
+        //ret = variorum_get_node_power_json(&s);
+        if (power_with_util == true)
+        { 
+            ret_util = variorum_get_node_utilization_json(&util_str); 
+            if (ret_util != 0)
+            {
+                printf("JSON get node utilization failed. Exiting.\n");
+                free(util_str);
+                exit(-1);
+            }
 
-        // Write out to logfile
-        parse_json_obj(s, num_sockets);
+
+            ret_pow = variorum_get_node_power_json(&power_str);
+            if (ret_pow != 0)
+            {
+                printf("JSON get node power failed. Exiting.\n");
+                free(power_str);
+                exit(-1);
+            }
+        
+            parse_power_and_util_json_obj(power_str, util_str, num_sockets); 
+        }
+        else
+        {
+            ret_pow = variorum_get_node_power_json(&power_str);
+            if (ret_pow != 0)
+            {
+                printf("JSON get node power failed. Exiting.\n");
+                free(power_str);
+                exit(-1);
+            }
+            // Write out to logfile
+            parse_json_obj(power_str, num_sockets);
+        }    
     }
 
     // Verbose output with all sensors/registers
@@ -202,18 +417,20 @@ void *power_measurement(void *arg)
     struct thread_args th_args;
     th_args.sample_interval = (*(struct thread_args *)arg).sample_interval;
     th_args.measure_all = (*(struct thread_args *)arg).measure_all;
+    th_args.power_with_util = (*(struct thread_args *)arg).power_with_util; 
     // According to the Intel docs, the counter wraps at most once per second.
     // 50 ms should be short enough to always get good information (this is
     // default).
     printf("Using sampling interval of: %ld ms\n", th_args.sample_interval);
     printf("Using verbosity of: %d\n", th_args.measure_all);
+    printf("Using verbosity of: %d\n", th_args.power_with_util);
     init_msTimer(&timer, th_args.sample_interval);
     start = now_ms();
 
     timer_sleep(&timer);
     while (running)
     {
-        take_measurement(th_args.measure_all);
+        take_measurement(th_args.measure_all, th_args.power_with_util);
         timer_sleep(&timer);
     }
     return arg;

--- a/src/powmon/power_wrapper_dynamic.c
+++ b/src/powmon/power_wrapper_dynamic.c
@@ -69,7 +69,7 @@ void *power_set_measurement(void *arg)
         // This is intel-specific.
         // Preseve the original behavior with variorum_monitoring for now, by
         // providing `true` as input value for the take_measurement function.
-        take_measurement(true);
+        take_measurement(true, false);
         if (poll_num % 5 == 0)
         {
             if (watts >= watt_cap)
@@ -269,7 +269,7 @@ int main(int argc, char **argv)
         // This is intel-specific.
         // Preseve the original behavior with variorum_monitoring for now, by
         // providing `true` as input value for the take_measurement function.
-        take_measurement(true);
+        take_measurement(true, false);
         end = now_ms();
 
         /* Output summary data. */

--- a/src/powmon/power_wrapper_static.c
+++ b/src/powmon/power_wrapper_static.c
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
         // This is intel-specific.
         // Preseve the original behavior with variorum_monitoring for now, by
         // providing `true` as input value for the take_measurement function.
-        take_measurement(true);
+        take_measurement(true, false);
         end = now_ms();
 
         /* Output summary data. */

--- a/src/powmon/powmon.c
+++ b/src/powmon/powmon.c
@@ -81,7 +81,11 @@ int main(int argc, char **argv)
                         "\n"
                         "    -v\n"
                         "        Verbose output that includes all sensors or registers.\n"
+                        "\n"
+                        "    -u\n"
+                        "        Sampling and printing domain power usage and node utilization \n"
                         "\n";
+
     if (argc == 1 || (argc > 1 && (
                           strncmp(argv[1], "--help", strlen("--help")) == 0 ||
                           strncmp(argv[1], "-h", strlen("-h")) == 0)))
@@ -99,8 +103,9 @@ int main(int argc, char **argv)
     struct thread_args th_args;
     th_args.sample_interval = FASTEST_SAMPLE_INTERVAL_MS;
     th_args.measure_all = false;
+    th_args.power_with_util = false;
 
-    while ((opt = getopt(argc, argv, "ca:p:i:v")) != -1)
+    while ((opt = getopt(argc, argv, "ca:p:i:v:u")) != -1)
     {
         switch (opt)
         {
@@ -126,6 +131,9 @@ int main(int argc, char **argv)
                 break;
             case 'v':
                 th_args.measure_all = true;
+                break;
+            case 'u':
+                th_args.power_with_util = true;
                 break;
             case '?':
                 if (optopt == 'a')
@@ -269,7 +277,7 @@ int main(int argc, char **argv)
 
         /* Stop power measurement thread. */
         running = 0;
-        take_measurement(th_args.measure_all);
+        take_measurement(th_args.measure_all, true);//th_args.power_with_util);
         end = now_ms();
 
         if (logpath)


### PR DESCRIPTION
# Description

Updated `powmon` to include node utilization, so that users can collect power and utilization data in parallel and output that in the file. 

This PR depends on the PR #431. 


Fixes #462

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please provide hardware architecture specs and
instructions so we can reproduce.

- [ ] Test A: Hardware architecture, machine name, example/test run
- [ ] Test B: Hardware architecture, machine name, example/test run
- [ ] ...

# Checklist:

- [ ] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [ ] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [ ] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
