### PR TITLE
CI: add output of model name from /proc/cpuinfo

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -230,6 +230,7 @@ jobs:
         run: |
           uname -a
           uname -r
+          cat /proc/cpuinfo | grep "model name"
           cd msr-safe
           sudo insmod msr-safe.ko
           sudo chmod o=u /dev/cpu/*/msr_safe


### PR DESCRIPTION
# Description

Running into job failures when loading msr-safe because CPU is unsupported. This provides more details as to which CPUs we are getting with GitHub Actions.

One idea is to expect a failure for the verify job if we are on a CPU that is unsupported instead of failing, but this will require some changes to the order in which we check system information.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Build/CI update

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes