### PR TITLE
format .h files, parameters on new lines

### DIFF
--- a/src/variorum/AMD/amd_power_features.h
+++ b/src/variorum/AMD/amd_power_features.h
@@ -32,8 +32,10 @@ struct rapl_data
     double *core_joules;
 };
 
-int print_energy_data(FILE *writedest,
-                      off_t msr_rapl_unit,
-                      off_t msr_core_energy_status);
+int print_energy_data(
+    FILE *writedest,
+    off_t msr_rapl_unit,
+    off_t msr_core_energy_status
+);
 
 #endif

--- a/src/variorum/AMD/config_amd.h
+++ b/src/variorum/AMD/config_amd.h
@@ -9,8 +9,12 @@
 #include <inttypes.h>
 #include <e_smi/e_smi.h>
 
-uint64_t *detect_amd_arch(void);
+uint64_t *detect_amd_arch(
+    void
+);
 
-int set_amd_func_ptrs(int idx);
+int set_amd_func_ptrs(
+    int idx
+);
 
 #endif

--- a/src/variorum/AMD/epyc.h
+++ b/src/variorum/AMD/epyc.h
@@ -8,28 +8,50 @@
 
 #include <jansson.h>
 
-int amd_cpu_epyc_get_power(int long_ver);
+int amd_cpu_epyc_get_power(
+    int long_ver
+);
 
-int amd_cpu_epyc_get_power_limits(int long_ver);
+int amd_cpu_epyc_get_power_limits(
+    int long_ver
+);
 
-int amd_cpu_epyc_set_socket_power_limit(int pcap_new);
+int amd_cpu_epyc_set_socket_power_limit(
+    int pcap_new
+);
 
-int amd_cpu_epyc_set_and_verify_best_effort_node_power_limit(int pcap_new);
+int amd_cpu_epyc_set_and_verify_best_effort_node_power_limit(
+    int pcap_new
+);
 
-int amd_cpu_epyc_print_energy();
+int amd_cpu_epyc_print_energy(
+    void
+);
 
-int amd_cpu_epyc_print_boostlimit();
+int amd_cpu_epyc_print_boostlimit(
+    void
+);
 
-int amd_cpu_epyc_set_each_core_boostlimit(int boostlimit);
+int amd_cpu_epyc_set_each_core_boostlimit(
+    int boostlimit
+);
 
-//int amd_cpu_epyc_set_and_verify_core_boostlimit(int core,
-//                                                unsigned int boostlimit);
+//int amd_cpu_epyc_set_and_verify_core_boostlimit(
+//    int core,
+//    unsigned int boostlimit
+//);
 
-int amd_cpu_epyc_set_socket_boostlimit(int socket,
-                                       int boostlimit);
+int amd_cpu_epyc_set_socket_boostlimit(
+    int socket,
+    int boostlimit
+);
 
-int amd_cpu_epyc_get_node_power_json(char **get_power_obj_str);
+int amd_cpu_epyc_get_node_power_json(
+    char **get_power_obj_str
+);
 
-int amd_cpu_epyc_get_node_power_domain_info_json(char **get_domain_obj_str);
+int amd_cpu_epyc_get_node_power_domain_info_json(
+    char **get_domain_obj_str
+);
 
 #endif

--- a/src/variorum/AMD_GPU/amd_gpu_power_features.h
+++ b/src/variorum/AMD_GPU/amd_gpu_power_features.h
@@ -12,29 +12,51 @@
 
 #include <rocm_smi/rocm_smi.h>
 
-void get_power_data(int chipid,
-                    int total_sockets,
-                    int verbose,
-                    FILE *output);
+void get_power_data(
+    int chipid,
+    int total_sockets,
+    int verbose,
+    FILE *output
+);
 
-void get_power_limit_data(int chipid,
-                          int total_sockets,
-                          int verbose,
-                          FILE *output);
+void get_power_limit_data(
+    int chipid,
+    int total_sockets,
+    int verbose,
+    FILE *output
+);
 
-void get_thermals_data(int chipid,
-                       int total_sockets,
-                       int verbose,
-                       FILE *output);
+void get_thermals_data(
+    int chipid,
+    int total_sockets,
+    int verbose,
+    FILE *output
+);
 
-void get_clocks_data(int chipid, int total_sockets, int verbose, FILE *output);
+void get_clocks_data(
+    int chipid,
+    int total_sockets,
+    int verbose,
+    FILE *output
+);
 
-void get_gpu_utilization_data(int chipid, int total_sockets, int verbose,
-                              FILE *output);
+void get_gpu_utilization_data(
+    int chipid,
+    int total_sockets,
+    int verbose,
+    FILE *output
+);
 
-void cap_each_gpu_power_limit(int chipid, int total_sockets,
-                              unsigned int powerlimit);
+void cap_each_gpu_power_limit(
+    int chipid,
+    int total_sockets,
+    unsigned int powerlimit
+);
 
-void get_thermals_json(int chipid, int total_sockets, json_t *output);
+void get_thermals_json(
+    int chipid,
+    int total_sockets,
+    json_t *output
+);
 
 #endif

--- a/src/variorum/AMD_GPU/config_amd_gpu.h
+++ b/src/variorum/AMD_GPU/config_amd_gpu.h
@@ -8,8 +8,12 @@
 
 #include <inttypes.h>
 
-uint64_t *detect_amd_gpu_arch(void);
+uint64_t *detect_amd_gpu_arch(
+    void
+);
 
-int set_amd_gpu_func_ptrs(int idx);
+int set_amd_gpu_func_ptrs(
+    int idx
+);
 
 #endif

--- a/src/variorum/AMD_GPU/instinctGPU.h
+++ b/src/variorum/AMD_GPU/instinctGPU.h
@@ -9,18 +9,32 @@
 #include <jansson.h>
 #include <sys/time.h>
 
-int amd_gpu_instinct_get_power(int verbose);
+int amd_gpu_instinct_get_power(
+    int verbose
+);
 
-int amd_gpu_instinct_get_power_limit(int verbose);
+int amd_gpu_instinct_get_power_limit(
+    int verbose
+);
 
-int amd_gpu_instinct_get_thermals(int verbose);
+int amd_gpu_instinct_get_thermals(
+    int verbose
+);
 
-int amd_gpu_instinct_get_clocks(int verbose);
+int amd_gpu_instinct_get_clocks(
+    int verbose
+);
 
-int amd_gpu_instinct_get_gpu_utilization(int verbose);
+int amd_gpu_instinct_get_gpu_utilization(
+    int verbose
+);
 
-int amd_gpu_instinct_cap_each_gpu_power_limit(unsigned int powerlimit);
+int amd_gpu_instinct_cap_each_gpu_power_limit(
+    unsigned int powerlimit
+);
 
-int amd_gpu_instinct_get_thermals_json(json_t *get_thermal_obj);
+int amd_gpu_instinct_get_thermals_json(
+    json_t *get_thermal_obj
+);
 
 #endif

--- a/src/variorum/ARM/ARM_Juno_r2.h
+++ b/src/variorum/ARM/ARM_Juno_r2.h
@@ -8,19 +8,33 @@
 
 #include <jansson.h>
 
-int arm_juno_r2_get_power(int long_ver);
+int arm_juno_r2_get_power(
+    int long_ver
+);
 
-int arm_juno_r2_get_thermals(int long_ver);
+int arm_juno_r2_get_thermals(
+    int long_ver
+);
 
-int arm_juno_r2_get_clocks(int long_ver);
+int arm_juno_r2_get_clocks(
+    int long_ver
+);
 
-int arm_juno_r2_get_frequencies(void);
+int arm_juno_r2_get_frequencies(
+    void
+);
 
-int arm_juno_r2_cap_socket_frequency(int cpuid,
-                                     int freq);
+int arm_juno_r2_cap_socket_frequency(
+    int cpuid,
+    int freq
+);
 
-int arm_juno_r2_get_power_json(char **get_power_obj_str);
+int arm_juno_r2_get_power_json(
+    char **get_power_obj_str
+);
 
-int arm_juno_r2_get_power_domain_info_json(char **get_domain_obj_str);
+int arm_juno_r2_get_power_domain_info_json(
+    char **get_domain_obj_str
+);
 
 #endif

--- a/src/variorum/ARM/ARM_Neoverse_N1.h
+++ b/src/variorum/ARM/ARM_Neoverse_N1.h
@@ -8,17 +8,29 @@
 
 #include <jansson.h>
 
-int arm_neoverse_n1_get_power(int long_ver);
+int arm_neoverse_n1_get_power(
+    int long_ver
+);
 
-int arm_neoverse_n1_get_thermals(int long_ver);
+int arm_neoverse_n1_get_thermals(
+    int long_ver
+);
 
-int arm_neoverse_n1_get_clocks(int long_ver);
+int arm_neoverse_n1_get_clocks(
+    int long_ver
+);
 
-int arm_neoverse_n1_cap_socket_frequency(int cpuid,
-        int freq);
+int arm_neoverse_n1_cap_socket_frequency(
+    int cpuid,
+    int freq
+);
 
-int arm_neoverse_n1_get_power_json(char **get_power_obj_str);
+int arm_neoverse_n1_get_power_json(
+    char **get_power_obj_str
+);
 
-int arm_neoverse_n1_get_power_domain_info_json(char **get_domain_obj_str);
+int arm_neoverse_n1_get_power_domain_info_json(
+    char **get_domain_obj_str
+);
 
 #endif

--- a/src/variorum/ARM/arm_util.h
+++ b/src/variorum/ARM/arm_util.h
@@ -14,17 +14,27 @@
 extern unsigned m_num_package;
 extern char m_hostname[1024];
 
-int read_file_ui64(const int,
-                   uint64_t *);
+int read_file_ui64(
+    const int,
+    uint64_t *
+);
 
-int write_file_ui64(const int,
-                    uint64_t);
+int write_file_ui64(
+    const int,
+    uint64_t
+);
 
-int read_array_ui64(const int,
-                    uint64_t **);
+int read_array_ui64(
+    const int,
+    uint64_t **
+);
 
-void init_arm(void);
+void init_arm(
+    void
+);
 
-void shutdown_arm(void);
+void shutdown_arm(
+    void
+);
 
 #endif

--- a/src/variorum/ARM/config_arm.h
+++ b/src/variorum/ARM/config_arm.h
@@ -8,8 +8,12 @@
 
 #include <inttypes.h>
 
-uint64_t *detect_arm_arch(void);
+uint64_t *detect_arm_arch(
+    void
+);
 
-int set_arm_func_ptrs(int idx);
+int set_arm_func_ptrs(
+    int idx
+);
 
 #endif

--- a/src/variorum/ARM/juno_r2_power_features.h
+++ b/src/variorum/ARM/juno_r2_power_features.h
@@ -12,24 +12,38 @@
 
 #include <arm_util.h>
 
-int arm_cpu_juno_r2_get_power_data(int verbose,
-                                   FILE *output);
+int arm_cpu_juno_r2_get_power_data(
+    int verbose,
+    FILE *output
+);
 
-int arm_cpu_juno_r2_get_thermal_data(int verbose,
-                                     FILE *output);
+int arm_cpu_juno_r2_get_thermal_data(
+    int verbose,
+    FILE *output
+);
 
-int arm_cpu_juno_r2_get_frequencies(int chipid,
-                                    FILE *output);
+int arm_cpu_juno_r2_get_frequencies(
+    int chipid,
+    FILE *output
+);
 
-int arm_cpu_juno_r2_get_clocks_data(int chipid,
-                                    int verbose,
-                                    FILE *output);
+int arm_cpu_juno_r2_get_clocks_data(
+    int chipid,
+    int verbose,
+    FILE *output
+);
 
-int arm_cpu_juno_r2_cap_socket_frequency(int socketid,
-        int new_freq);
+int arm_cpu_juno_r2_cap_socket_frequency(
+    int socketid,
+    int new_freq
+);
 
-int arm_cpu_juno_r2_json_get_power_data(json_t *get_power_obj);
+int arm_cpu_juno_r2_json_get_power_data(
+    json_t *get_power_obj
+);
 
-int arm_cpu_juno_r2_json_get_power_domain_info(json_t *get_domain_obj);
+int arm_cpu_juno_r2_json_get_power_domain_info(
+    json_t *get_domain_obj
+);
 
 #endif

--- a/src/variorum/ARM/neoverse_N1_power_features.h
+++ b/src/variorum/ARM/neoverse_N1_power_features.h
@@ -14,21 +14,33 @@
 
 #define NUM_CORES 80
 
-int arm_cpu_neoverse_n1_get_power_data(int verbose,
-                                       FILE *output);
+int arm_cpu_neoverse_n1_get_power_data(
+    int verbose,
+    FILE *output
+);
 
-int arm_cpu_neoverse_n1_get_thermal_data(int verbose,
-        FILE *output);
+int arm_cpu_neoverse_n1_get_thermal_data(
+    int verbose,
+    FILE *output
+);
 
-int arm_cpu_neoverse_n1_get_clocks_data(int chipid,
-                                        int verbose,
-                                        FILE *output);
+int arm_cpu_neoverse_n1_get_clocks_data(
+    int chipid,
+    int verbose,
+    FILE *output
+);
 
-int arm_cpu_neoverse_n1_cap_socket_frequency(int socketid,
-        int new_freq);
+int arm_cpu_neoverse_n1_cap_socket_frequency(
+    int socketid,
+    int new_freq
+);
 
-int arm_cpu_neoverse_n1_json_get_power_data(json_t *get_power_obj);
+int arm_cpu_neoverse_n1_json_get_power_data(
+    json_t *get_power_obj
+);
 
-int arm_cpu_neoverse_n1_json_get_power_domain_info(json_t *get_domain_obj);
+int arm_cpu_neoverse_n1_json_get_power_domain_info(
+    json_t *get_domain_obj
+);
 
 #endif

--- a/src/variorum/IBM/Power9.h
+++ b/src/variorum/IBM/Power9.h
@@ -8,22 +8,40 @@
 
 #include <jansson.h>
 
-int ibm_cpu_p9_get_power(int long_ver);
+int ibm_cpu_p9_get_power(
+    int long_ver
+);
 
-int ibm_cpu_p9_get_power_limits(int long_ver);
+int ibm_cpu_p9_get_power_limits(
+    int long_ver
+);
 
-int ibm_cpu_p9_cap_socket_power_limit(int long_ver);
+int ibm_cpu_p9_cap_socket_power_limit(
+    int long_ver
+);
 
-int ibm_cpu_p9_cap_and_verify_node_power_limit(int pcap_new);
+int ibm_cpu_p9_cap_and_verify_node_power_limit(
+    int pcap_new
+);
 
-int ibm_cpu_p9_cap_gpu_power_ratio(int gpu_power_ratio);
+int ibm_cpu_p9_cap_gpu_power_ratio(
+    int gpu_power_ratio
+);
 
-int ibm_cpu_p9_monitoring(FILE *output);
+int ibm_cpu_p9_monitoring(
+    FILE *output
+);
 
-int ibm_cpu_p9_get_node_power_json(char **get_power_obj_str);
+int ibm_cpu_p9_get_node_power_json(
+    char **get_power_obj_str
+);
 
-int ibm_cpu_p9_get_node_power_domain_info_json(char **get_domain_obj_str);
+int ibm_cpu_p9_get_node_power_domain_info_json(
+    char **get_domain_obj_str
+);
 
-int ibm_cpu_p9_get_node_thermal_json(json_t *get_thermal_obj);
+int ibm_cpu_p9_get_node_thermal_json(
+    json_t *get_thermal_obj
+);
 
 #endif

--- a/src/variorum/IBM/config_ibm.h
+++ b/src/variorum/IBM/config_ibm.h
@@ -8,8 +8,12 @@
 
 #include <inttypes.h>
 
-uint64_t *detect_ibm_arch(void);
+uint64_t *detect_ibm_arch(
+    void
+);
 
-int set_ibm_func_ptrs(int idx);
+int set_ibm_func_ptrs(
+    int idx
+);
 
 #endif

--- a/src/variorum/IBM/ibm_power_features.h
+++ b/src/variorum/IBM/ibm_power_features.h
@@ -129,32 +129,46 @@ struct occ_sensor_counter
     uint8_t  pad[5];
 } __attribute__((__packed__));
 
-void print_power_sensors(int chipid,
-                         int long_ver,
-                         FILE *output,
-                         const void *buf);
+void print_power_sensors(
+    int chipid,
+    int long_ver,
+    FILE *output,
+    const void *buf
+);
 
-void print_all_sensors_header(int chipid,
-                              FILE *output,
-                              const void *buf);
+void print_all_sensors_header(
+    int chipid,
+    FILE *output,
+    const void *buf
+);
 
-void print_all_sensors(int chipid,
-                       FILE *output,
-                       const void *buf);
+void print_all_sensors(
+    int chipid,
+    FILE *output,
+    const void *buf
+);
 
-unsigned long read_counter(const struct occ_sensor_data_header *hb,
-                           uint32_t offset);
+unsigned long read_counter(
+    const struct occ_sensor_data_header *hb,
+    uint32_t offset
+);
 
-unsigned long read_sensor(const struct occ_sensor_data_header *hb,
-                          uint32_t offset,
-                          int attr);
+unsigned long read_sensor(
+    const struct occ_sensor_data_header *hb,
+    uint32_t offset,
+    int attr
+);
 
-void json_get_power_sensors(int chipid,
-                            json_t *get_power_obj,
-                            const void *buf);
+void json_get_power_sensors(
+    int chipid,
+    json_t *get_power_obj,
+    const void *buf
+);
 
-void json_get_thermal_sensors(int chipid,
-                              json_t *get_thermal_obj,
-                              const void *buf);
+void json_get_thermal_sensors(
+    int chipid,
+    json_t *get_thermal_obj,
+    const void *buf
+);
 
 #endif

--- a/src/variorum/Intel/Intel_06_2A.h
+++ b/src/variorum/Intel/Intel_06_2A.h
@@ -78,39 +78,72 @@ struct sandybridge_2a_offsets
     off_t msrs_pcu_pmon_evtsel[4];
 };
 
-int intel_cpu_fm_06_2a_get_power_limits(int long_ver);
+int intel_cpu_fm_06_2a_get_power_limits(
+    int long_ver
+);
 
-int intel_cpu_fm_06_2a_cap_power_limits(int package_power_limit);
+int intel_cpu_fm_06_2a_cap_power_limits(
+    int package_power_limit
+);
 
-int intel_cpu_fm_06_2a_get_features(void);
+int intel_cpu_fm_06_2a_get_features(
+    void
+);
 
-int intel_cpu_fm_06_2a_get_thermals(int long_ver);
+int intel_cpu_fm_06_2a_get_thermals(
+    int long_ver
+);
 
-int intel_cpu_fm_06_2a_get_counters(int long_ver);
+int intel_cpu_fm_06_2a_get_counters(
+    int long_ver
+);
 
-int intel_cpu_fm_06_2a_get_clocks(int long_ver);
+int intel_cpu_fm_06_2a_get_clocks(
+    int long_ver
+);
 
-int intel_cpu_fm_06_2a_get_power(int long_ver);
+int intel_cpu_fm_06_2a_get_power(
+    int long_ver
+);
 
-int intel_cpu_fm_06_2a_enable_turbo(void);
+int intel_cpu_fm_06_2a_enable_turbo(
+    void
+);
 
-int intel_cpu_fm_06_2a_disable_turbo(void);
+int intel_cpu_fm_06_2a_disable_turbo(
+    void
+);
 
-int intel_cpu_fm_06_2a_get_turbo_status(void);
+int intel_cpu_fm_06_2a_get_turbo_status(
+    void
+);
 
-int intel_cpu_fm_06_2a_poll_power(FILE *output);
+int intel_cpu_fm_06_2a_poll_power(
+    FILE *output
+);
 
-int intel_cpu_fm_06_2a_monitoring(FILE *output);
+int intel_cpu_fm_06_2a_monitoring(
+    FILE *output
+);
 
-int intel_cpu_fm_06_2a_get_node_power_json(char **get_power_obj_str);
+int intel_cpu_fm_06_2a_get_node_power_json(
+    char **get_power_obj_str
+);
 
-int intel_cpu_fm_06_2a_get_node_power_domain_info_json(char
-        **get_domain_obj_str);
+int intel_cpu_fm_06_2a_get_node_power_domain_info_json(
+    char **get_domain_obj_str
+);
 
-int intel_cpu_fm_06_2a_cap_best_effort_node_power_limit(int node_power_limit);
+int intel_cpu_fm_06_2a_cap_best_effort_node_power_limit(
+    int node_power_limit
+);
 
-int intel_cpu_fm_06_2a_get_frequencies(void);
+int intel_cpu_fm_06_2a_get_frequencies(
+    void
+);
 
-int intel_cpu_fm_06_2a_get_thermals_json(json_t *get_thermal_obj);
+int intel_cpu_fm_06_2a_get_thermals_json(
+    json_t *get_thermal_obj
+);
 
 #endif

--- a/src/variorum/Intel/Intel_06_2D.h
+++ b/src/variorum/Intel/Intel_06_2D.h
@@ -81,39 +81,72 @@ struct sandybridge_2d_offsets
     off_t msrs_pcu_pmon_evtsel[4];
 };
 
-int intel_cpu_fm_06_2d_get_power_limits(int long_ver);
+int intel_cpu_fm_06_2d_get_power_limits(
+    int long_ver
+);
 
-int intel_cpu_fm_06_2d_cap_power_limits(int package_power_limit);
+int intel_cpu_fm_06_2d_cap_power_limits(
+    int package_power_limit
+);
 
-int intel_cpu_fm_06_2d_get_features(void);
+int intel_cpu_fm_06_2d_get_features(
+    void
+);
 
-int intel_cpu_fm_06_2d_get_thermals(int long_ver);
+int intel_cpu_fm_06_2d_get_thermals(
+    int long_ver
+);
 
-int intel_cpu_fm_06_2d_get_counters(int long_ver);
+int intel_cpu_fm_06_2d_get_counters(
+    int long_ver
+);
 
-int intel_cpu_fm_06_2d_get_clocks(int long_ver);
+int intel_cpu_fm_06_2d_get_clocks(
+    int long_ver
+);
 
-int intel_cpu_fm_06_2d_get_power(int long_ver);
+int intel_cpu_fm_06_2d_get_power(
+    int long_ver
+);
 
-int intel_cpu_fm_06_2d_enable_turbo(void);
+int intel_cpu_fm_06_2d_enable_turbo(
+    void
+);
 
-int intel_cpu_fm_06_2d_disable_turbo(void);
+int intel_cpu_fm_06_2d_disable_turbo(
+    void
+);
 
-int intel_cpu_fm_06_2d_get_turbo_status(void);
+int intel_cpu_fm_06_2d_get_turbo_status(
+    void
+);
 
-int intel_cpu_fm_06_2d_poll_power(FILE *output);
+int intel_cpu_fm_06_2d_poll_power(
+    FILE *output
+);
 
-int intel_cpu_fm_06_2d_monitoring(FILE *output);
+int intel_cpu_fm_06_2d_monitoring(
+    FILE *output
+);
 
-int intel_cpu_fm_06_2d_get_node_power_json(char **get_power_obj_str);
+int intel_cpu_fm_06_2d_get_node_power_json(
+    char **get_power_obj_str
+);
 
-int intel_cpu_fm_06_2d_get_node_power_domain_info_json(char
-        **get_domain_obj_str);
+int intel_cpu_fm_06_2d_get_node_power_domain_info_json(
+    char **get_domain_obj_str
+);
 
-int intel_cpu_fm_06_2d_cap_best_effort_node_power_limit(int node_power_limit);
+int intel_cpu_fm_06_2d_cap_best_effort_node_power_limit(
+    int node_power_limit
+);
 
-int intel_cpu_fm_06_2d_get_frequencies(void);
+int intel_cpu_fm_06_2d_get_frequencies(
+    void
+);
 
-int intel_cpu_fm_06_2d_get_thermals_json(json_t *get_thermal_obj);
+int intel_cpu_fm_06_2d_get_thermals_json(
+    json_t *get_thermal_obj
+);
 
 #endif

--- a/src/variorum/Intel/Intel_06_3E.h
+++ b/src/variorum/Intel/Intel_06_3E.h
@@ -81,39 +81,72 @@ struct ivybridge_3e_offsets
     off_t msr_config_tdp_nominal;
 };
 
-int intel_cpu_fm_06_3e_get_power_limits(int long_ver);
+int intel_cpu_fm_06_3e_get_power_limits(
+    int long_ver
+);
 
-int intel_cpu_fm_06_3e_cap_power_limits(int package_power_limit);
+int intel_cpu_fm_06_3e_cap_power_limits(
+    int package_power_limit
+);
 
-int intel_cpu_fm_06_3e_get_features(void);
+int intel_cpu_fm_06_3e_get_features(
+    void
+);
 
-int intel_cpu_fm_06_3e_get_thermals(int long_ver);
+int intel_cpu_fm_06_3e_get_thermals(
+    int long_ver
+);
 
-int intel_cpu_fm_06_3e_get_counters(int long_ver);
+int intel_cpu_fm_06_3e_get_counters(
+    int long_ver
+);
 
-int intel_cpu_fm_06_3e_get_clocks(int long_ver);
+int intel_cpu_fm_06_3e_get_clocks(
+    int long_ver
+);
 
-int intel_cpu_fm_06_3e_get_power(int long_ver);
+int intel_cpu_fm_06_3e_get_power(
+    int long_ver
+);
 
-int intel_cpu_fm_06_3e_enable_turbo(void);
+int intel_cpu_fm_06_3e_enable_turbo(
+    void
+);
 
-int intel_cpu_fm_06_3e_disable_turbo(void);
+int intel_cpu_fm_06_3e_disable_turbo(
+    void
+);
 
-int intel_cpu_fm_06_3e_get_turbo_status(void);
+int intel_cpu_fm_06_3e_get_turbo_status(
+    void
+);
 
-int intel_cpu_fm_06_3e_poll_power(FILE *output);
+int intel_cpu_fm_06_3e_poll_power(
+    FILE *output
+);
 
-int intel_cpu_fm_06_3e_monitoring(FILE *output);
+int intel_cpu_fm_06_3e_monitoring(
+    FILE *output
+);
 
-int intel_cpu_fm_06_3e_get_node_power_json(char **get_power_obj_str);
+int intel_cpu_fm_06_3e_get_node_power_json(
+    char **get_power_obj_str
+);
 
-int intel_cpu_fm_06_3e_get_node_power_domain_info_json(char
-        **get_domain_obj_str);
+int intel_cpu_fm_06_3e_get_node_power_domain_info_json(
+    char **get_domain_obj_str
+);
 
-int intel_cpu_fm_06_3e_cap_best_effort_node_power_limit(int node_power_limit);
+int intel_cpu_fm_06_3e_cap_best_effort_node_power_limit(
+    int node_power_limit
+);
 
-int intel_cpu_fm_06_3e_get_frequencies(void);
+int intel_cpu_fm_06_3e_get_frequencies(
+    void
+);
 
-int intel_cpu_fm_06_3e_get_thermals_json(json_t *get_thermal_obj);
+int intel_cpu_fm_06_3e_get_thermals_json(
+    json_t *get_thermal_obj
+);
 
 #endif

--- a/src/variorum/Intel/Intel_06_3F.h
+++ b/src/variorum/Intel/Intel_06_3F.h
@@ -83,39 +83,72 @@ struct haswell_3f_offsets
     off_t msr_config_tdp_nominal;
 };
 
-int intel_cpu_fm_06_3f_get_power_limits(int long_ver);
+int intel_cpu_fm_06_3f_get_power_limits(
+    int long_ver
+);
 
-int intel_cpu_fm_06_3f_cap_power_limits(int package_power_limit);
+int intel_cpu_fm_06_3f_cap_power_limits(
+    int package_power_limit
+);
 
-int intel_cpu_fm_06_3f_get_features(void);
+int intel_cpu_fm_06_3f_get_features(
+    void
+);
 
-int intel_cpu_fm_06_3f_get_thermals(int long_ver);
+int intel_cpu_fm_06_3f_get_thermals(
+    int long_ver
+);
 
-int intel_cpu_fm_06_3f_get_counters(int long_ver);
+int intel_cpu_fm_06_3f_get_counters(
+    int long_ver
+);
 
-int intel_cpu_fm_06_3f_get_clocks(int long_ver);
+int intel_cpu_fm_06_3f_get_clocks(
+    int long_ver
+);
 
-int intel_cpu_fm_06_3f_get_power(int long_ver);
+int intel_cpu_fm_06_3f_get_power(
+    int long_ver
+);
 
-int intel_cpu_fm_06_3f_enable_turbo(void);
+int intel_cpu_fm_06_3f_enable_turbo(
+    void
+);
 
-int intel_cpu_fm_06_3f_disable_turbo(void);
+int intel_cpu_fm_06_3f_disable_turbo(
+    void
+);
 
-int intel_cpu_fm_06_3f_get_turbo_status(void);
+int intel_cpu_fm_06_3f_get_turbo_status(
+    void
+);
 
-int intel_cpu_fm_06_3f_poll_power(FILE *output);
+int intel_cpu_fm_06_3f_poll_power(
+    FILE *output
+);
 
-int intel_cpu_fm_06_3f_monitoring(FILE *output);
+int intel_cpu_fm_06_3f_monitoring(
+    FILE *output
+);
 
-int intel_cpu_fm_06_3f_get_node_power_json(char **get_power_obj_str);
+int intel_cpu_fm_06_3f_get_node_power_json(
+    char **get_power_obj_str
+);
 
-int intel_cpu_fm_06_3f_get_node_power_domain_info_json(char
-        **get_domain_obj_str);
+int intel_cpu_fm_06_3f_get_node_power_domain_info_json(
+    char **get_domain_obj_str
+);
 
-int intel_cpu_fm_06_3f_cap_best_effort_node_power_limit(int node_power_limit);
+int intel_cpu_fm_06_3f_cap_best_effort_node_power_limit(
+    int node_power_limit
+);
 
-int intel_cpu_fm_06_3f_get_frequencies(void);
+int intel_cpu_fm_06_3f_get_frequencies(
+    void
+);
 
-int intel_cpu_fm_06_3f_get_thermals_json(json_t *get_thermal_obj);
+int intel_cpu_fm_06_3f_get_thermals_json(
+    json_t *get_thermal_obj
+);
 
 #endif

--- a/src/variorum/Intel/Intel_06_4F.h
+++ b/src/variorum/Intel/Intel_06_4F.h
@@ -83,39 +83,72 @@ struct broadwell_4f_offsets
     off_t msr_config_tdp_nominal;
 };
 
-int intel_cpu_fm_06_4f_get_power_limits(int long_ver);
+int intel_cpu_fm_06_4f_get_power_limits(
+    int long_ver
+);
 
-int intel_cpu_fm_06_4f_cap_power_limits(int package_power_limit);
+int intel_cpu_fm_06_4f_cap_power_limits(
+    int package_power_limit
+);
 
-int intel_cpu_fm_06_4f_get_features(void);
+int intel_cpu_fm_06_4f_get_features(
+    void
+);
 
-int intel_cpu_fm_06_4f_get_thermals(int long_ver);
+int intel_cpu_fm_06_4f_get_thermals(
+    int long_ver
+);
 
-int intel_cpu_fm_06_4f_get_counters(int long_ver);
+int intel_cpu_fm_06_4f_get_counters(
+    int long_ver
+);
 
-int intel_cpu_fm_06_4f_get_clocks(int long_ver);
+int intel_cpu_fm_06_4f_get_clocks(
+    int long_ver
+);
 
-int intel_cpu_fm_06_4f_get_power(int long_ver);
+int intel_cpu_fm_06_4f_get_power(
+    int long_ver
+);
 
-int intel_cpu_fm_06_4f_enable_turbo(void);
+int intel_cpu_fm_06_4f_enable_turbo(
+    void
+);
 
-int intel_cpu_fm_06_4f_disable_turbo(void);
+int intel_cpu_fm_06_4f_disable_turbo(
+    void
+);
 
-int intel_cpu_fm_06_4f_get_turbo_status(void);
+int intel_cpu_fm_06_4f_get_turbo_status(
+    void
+);
 
-int intel_cpu_fm_06_4f_poll_power(FILE *output);
+int intel_cpu_fm_06_4f_poll_power(
+    FILE *output
+);
 
-int intel_cpu_fm_06_4f_monitoring(FILE *output);
+int intel_cpu_fm_06_4f_monitoring(
+    FILE *output
+);
 
-int intel_cpu_fm_06_4f_get_node_power_json(char **get_power_obj_str);
+int intel_cpu_fm_06_4f_get_node_power_json(
+    char **get_power_obj_str
+);
 
-int intel_cpu_fm_06_4f_get_node_power_domain_info_json(char
-        **get_domain_obj_str);
+int intel_cpu_fm_06_4f_get_node_power_domain_info_json(
+    char **get_domain_obj_str
+);
 
-int intel_cpu_fm_06_4f_cap_best_effort_node_power_limit(int node_power_limit);
+int intel_cpu_fm_06_4f_cap_best_effort_node_power_limit(
+    int node_power_limit
+);
 
-int intel_cpu_fm_06_4f_get_frequencies(void);
+int intel_cpu_fm_06_4f_get_frequencies(
+    void
+);
 
-int intel_cpu_fm_06_4f_get_thermals_json(json_t *get_thermal_obj);
+int intel_cpu_fm_06_4f_get_thermals_json(
+    json_t *get_thermal_obj
+);
 
 #endif

--- a/src/variorum/Intel/clocks_features.h
+++ b/src/variorum/Intel/clocks_features.h
@@ -66,22 +66,28 @@ struct perf_data
 /// @param [in] msr_aperf Unique MSR address for IA32_APERF.
 /// @param [in] msr_mperf Unique MSR address for IA32_MPERF.
 /// @param [in] msr_tsc Unique MSR address for IA32_TIME_STAMP_COUNTER.
-void clocks_storage(struct clocks_data **cd,
-                    off_t msr_aperf,
-                    off_t msr_mperf,
-                    off_t msr_tsc);
+void clocks_storage(
+    struct clocks_data **cd,
+    off_t msr_aperf,
+    off_t msr_mperf,
+    off_t msr_tsc
+);
 
 /// @brief Allocate array for storing raw register data from IA32_PERF_STATUS
 /// and IA32_PERF_CTL.
 ///
 /// @param [in] pd Pointer to perf-related data.
 /// @param [in] msr_perf_status Unique MSR address for IA32_PERF_STATUS.
-void perf_storage(struct perf_data **pd,
-                  off_t msr_perf_status);
+void perf_storage(
+    struct perf_data **pd,
+    off_t msr_perf_status
+);
 
-void perf_storage_temp(struct perf_data **pd,
-                       off_t msr_perf_ctl,
-                       enum ctl_domains_e control_domains);
+void perf_storage_temp(
+    struct perf_data **pd,
+    off_t msr_perf_ctl,
+    enum ctl_domains_e control_domains
+);
 
 ///// @brief Print the label for the abbreviated clocks data print out.
 /////
@@ -97,13 +103,15 @@ void perf_storage_temp(struct perf_data **pd,
 /// @param [in] msr_perf_status Unique MSR address for IA32_PERF_STATUS.
 /// @param [in] msr_platform_info Unique MSR address for MSR_PLATFORM_INFO.
 /// @param [in] control_domain Specific granularity of control.
-int print_clocks_data(FILE *writedest,
-                      off_t msr_aperf,
-                      off_t msr_mperf,
-                      off_t msr_tsc,
-                      off_t msr_perf_status,
-                      off_t msr_platform_info,
-                      enum ctl_domains_e control_domain);
+int print_clocks_data(
+    FILE *writedest,
+    off_t msr_aperf,
+    off_t msr_mperf,
+    off_t msr_tsc,
+    off_t msr_perf_status,
+    off_t msr_platform_info,
+    enum ctl_domains_e control_domain
+);
 
 /// @brief Print clocks data in long format.
 ///
@@ -114,27 +122,33 @@ int print_clocks_data(FILE *writedest,
 /// @param [in] msr_perf_status Unique MSR address for IA32_PERF_STATUS.
 /// @param [in] msr_platform_info Unique MSR address for MSR_PLATFORM_INFO.
 /// @param [in] control_domain Specific granularity of control.
-int print_verbose_clocks_data(FILE *writedest,
-                              off_t msr_aperf,
-                              off_t msr_mperf,
-                              off_t msr_tsc,
-                              off_t msr_perf_status,
-                              off_t msr_platform_info,
-                              enum ctl_domains_e control_domain);
+int print_verbose_clocks_data(
+    FILE *writedest,
+    off_t msr_aperf,
+    off_t msr_mperf,
+    off_t msr_tsc,
+    off_t msr_perf_status,
+    off_t msr_platform_info,
+    enum ctl_domains_e control_domain
+);
 
-void get_available_frequencies(FILE *writedest,
-                               off_t *msr_platform_info,
-                               off_t *msr_turbo_ratio_limit,
-                               off_t *msr_turbo_ratio_limit_cores,
-                               off_t *msr_config_tdp_l1,
-                               off_t *msr_config_tdp_l2);
+void get_available_frequencies(
+    FILE *writedest,
+    off_t *msr_platform_info,
+    off_t *msr_turbo_ratio_limit,
+    off_t *msr_turbo_ratio_limit_cores,
+    off_t *msr_config_tdp_l1,
+    off_t *msr_config_tdp_l2
+);
 
-void get_available_frequencies_skx(FILE *writedest,
-                                   off_t *msr_platform_info,
-                                   off_t *msr_turbo_ratio_limit,
-                                   off_t *msr_turbo_ratio_limit_cores,
-                                   off_t *msr_config_tdp_l1,
-                                   off_t *msr_config_tdp_l2);
+void get_available_frequencies_skx(
+    FILE *writedest,
+    off_t *msr_platform_info,
+    off_t *msr_turbo_ratio_limit,
+    off_t *msr_turbo_ratio_limit_cores,
+    off_t *msr_config_tdp_l1,
+    off_t *msr_config_tdp_l2
+);
 
 ///// @brief Print current p-state.
 /////
@@ -148,10 +162,12 @@ void get_available_frequencies_skx(FILE *writedest,
 ///// @param [in] pstate Desired p-state.
 //void set_p_state(unsigned socket,
 //                 uint64_t pstate);
-void cap_p_state(int cpu_freq_mhz,
-                 enum ctl_domains_e domain,
-                 off_t msr_perf_status);
-//
+void cap_p_state(
+    int cpu_freq_mhz,
+    enum ctl_domains_e domain,
+    off_t msr_perf_status
+);
+
 ///****************************************/
 ///* Software Controlled Clock Modulation */
 ///****************************************/

--- a/src/variorum/Intel/config_intel.h
+++ b/src/variorum/Intel/config_intel.h
@@ -8,10 +8,16 @@
 
 #include <inttypes.h>
 
-uint64_t *detect_intel_arch(void);
+uint64_t *detect_intel_arch(
+    void
+);
 
-int set_intel_func_ptrs(int idx);
+int set_intel_func_ptrs(
+    int idx
+);
 
-int gpu_power_ratio_unimplemented(int long_ver);
+int gpu_power_ratio_unimplemented(
+    int long_ver
+);
 
 #endif

--- a/src/variorum/Intel/counters_features.h
+++ b/src/variorum/Intel/counters_features.h
@@ -61,15 +61,19 @@ struct fixed_counter_config
 ///        reference clock cycles.
 /// @param [in] msrs_fixed_ctrs Array storing unique MSR addresses for fixed
 ///        counters.
-void fixed_counter_storage(struct fixed_counter **ctr0,
-                           struct fixed_counter **ctr1,
-                           struct fixed_counter **ctr2,
-                           off_t *msrs_fixed_ctrs);
+void fixed_counter_storage(
+    struct fixed_counter **ctr0,
+    struct fixed_counter **ctr1,
+    struct fixed_counter **ctr2,
+    off_t *msrs_fixed_ctrs
+);
 
 /// @brief Initialize storage for fixed-function performance counter data.
 ///
 /// @param [out] ctr Data for fixed-function performance counters.
-void init_fixed_counter(struct fixed_counter *ctr);
+void init_fixed_counter(
+    struct fixed_counter *ctr
+);
 
 /// @brief Set value of IA32_FIXED_CTR_CTL and IA32_PERF_GLOBAL_CTL and reset
 /// all fixed-function performance counters on all logical processors.
@@ -82,11 +86,13 @@ void init_fixed_counter(struct fixed_counter *ctr);
 ///        reference clock cycles.
 /// @param [in] msr1 Unique MSR address.
 /// @param [in] msr2 Unique MSR address.
-void set_fixed_counter_ctrl(struct fixed_counter *ctr0,
-                            struct fixed_counter *ctr1,
-                            struct fixed_counter *ctr2,
-                            off_t msr1,
-                            off_t msr2);
+void set_fixed_counter_ctrl(
+    struct fixed_counter *ctr0,
+    struct fixed_counter *ctr1,
+    struct fixed_counter *ctr2,
+    off_t msr1,
+    off_t msr2
+);
 
 /// @brief Initialize storage for performance global control and fixed-function
 /// performance control data, and store it on the heap.
@@ -99,10 +105,12 @@ void set_fixed_counter_ctrl(struct fixed_counter *ctr0,
 ///        fixed-function performance counter.
 /// @param [in] msr_perf_global_ctrl Unique MSR address for MSR_PERF_GLOBAL_CTRL.
 /// @param [in] msr_fixed_counter_ctrl Unique MSR address for MSR_FIXED_COUNTER_CTRL.
-void fixed_counter_ctrl_storage(uint64_t ***perf_ctrl,
-                                uint64_t ***fixed_ctrl,
-                                off_t msr_perf_global_ctrl,
-                                off_t msr_fixed_counter_ctrl);
+void fixed_counter_ctrl_storage(
+    uint64_t ***perf_ctrl,
+    uint64_t ***fixed_ctrl,
+    off_t msr_perf_global_ctrl,
+    off_t msr_fixed_counter_ctrl
+);
 
 /// @brief Enable fixed-function counters by setting enable bit in
 /// IA32_FIXED_CTR_CTL.
@@ -111,9 +119,11 @@ void fixed_counter_ctrl_storage(uint64_t ***perf_ctrl,
 ///        counters.
 /// @param [in] msr1 Unique MSR address.
 /// @param [in] msr2 Unique MSR address.
-void enable_fixed_counters(off_t *msrs_fixed_ctrs,
-                           off_t msr1,
-                           off_t msr2);
+void enable_fixed_counters(
+    off_t *msrs_fixed_ctrs,
+    off_t msr1,
+    off_t msr2
+);
 
 /// @brief Disable fixed-function counters by clearing enable bit in
 /// IA32_FIXED_CTR_CTL.
@@ -122,37 +132,51 @@ void enable_fixed_counters(off_t *msrs_fixed_ctrs,
 ///        counters.
 /// @param [in] msr1 Unique MSR address.
 /// @param [in] msr2 Unique MSR address.
-void disable_fixed_counters(off_t *msrs_fixed_ctrs,
-                            off_t msr1,
-                            off_t msr2);
+void disable_fixed_counters(
+    off_t *msrs_fixed_ctrs,
+    off_t msr1,
+    off_t msr2
+);
 
-void print_fixed_counter_data(FILE *writedest,
-                              off_t *msrs_fixed_ctrs);
+void print_fixed_counter_data(
+    FILE *writedest,
+    off_t *msrs_fixed_ctrs
+);
 
-void print_verbose_fixed_counter_data(FILE *writedest,
-                                      off_t *msrs_fixed_ctrs);
+void print_verbose_fixed_counter_data(
+    FILE *writedest,
+    off_t *msrs_fixed_ctrs
+);
 
-void print_perfmon_counter_data(FILE *writedest,
-                                off_t *msrs_perfevtsel_ctrs,
-                                off_t *msrs_perfmon_ctrs);
+void print_perfmon_counter_data(
+    FILE *writedest,
+    off_t *msrs_perfevtsel_ctrs,
+    off_t *msrs_perfmon_ctrs
+);
 
-void print_verbose_perfmon_counter_data(FILE *writedest,
-                                        off_t *msrs_perfevtsel_ctrs,
-                                        off_t *msrs_perfmon_ctrs);
+void print_verbose_perfmon_counter_data(
+    FILE *writedest,
+    off_t *msrs_perfevtsel_ctrs,
+    off_t *msrs_perfmon_ctrs
+);
 
-void print_all_counter_data(FILE *writedest,
-                            off_t *msrs_fixed_ctrs,
-                            off_t *msrs_perfevtsel_ctrs,
-                            off_t *msrs_perfmon_ctrs,
-                            off_t *msrs_pcu_pmon_evtsel,
-                            off_t *msrs_pcu_pmon_ctrs);
+void print_all_counter_data(
+    FILE *writedest,
+    off_t *msrs_fixed_ctrs,
+    off_t *msrs_perfevtsel_ctrs,
+    off_t *msrs_perfmon_ctrs,
+    off_t *msrs_pcu_pmon_evtsel,
+    off_t *msrs_pcu_pmon_ctrs
+);
 
-void print_verbose_all_counter_data(FILE *writedest,
-                                    off_t *msrs_fixed_ctrs,
-                                    off_t *msrs_perfevtsel_ctrs,
-                                    off_t *msrs_perfmon_ctrs,
-                                    off_t *msrs_pcu_pmon_evtsel,
-                                    off_t *msrs_pcu_pmon_ctrs);
+void print_verbose_all_counter_data(
+    FILE *writedest,
+    off_t *msrs_fixed_ctrs,
+    off_t *msrs_perfevtsel_ctrs,
+    off_t *msrs_perfmon_ctrs,
+    off_t *msrs_pcu_pmon_evtsel,
+    off_t *msrs_pcu_pmon_ctrs
+);
 
 /*************************************/
 /* Programmable Performance Counters */
@@ -170,14 +194,18 @@ void print_verbose_all_counter_data(FILE *writedest,
 /// @param [in] pmcnum Unique performance event select counter identifier.
 /// @param [in] msrs_perfevtsel_ctrs Array of unique addresses for
 ///        PERFEVTSEL_CTRS.
-void set_all_pmc_ctrl(uint64_t cmask,
-                      uint64_t flags,
-                      uint64_t umask,
-                      uint64_t eventsel,
-                      int pmcnum,
-                      off_t *msrs_perfevtsel_ctrs);
+void set_all_pmc_ctrl(
+    uint64_t cmask,
+    uint64_t flags,
+    uint64_t umask,
+    uint64_t eventsel,
+    int pmcnum,
+    off_t *msrs_perfevtsel_ctrs
+);
 
-int cpuid_num_pmc(void);
+int cpuid_num_pmc(
+    void
+);
 
 /// @brief Structure containing data of performance event select counters.
 struct perfevtsel
@@ -226,8 +254,10 @@ struct pmc
 /// @param [out] e Data for performance event select counters.
 /// @param [in] msrs_perfevtsel_ctrs Array of unique addresses for
 ///        PERFEVTSEL_CTRS.
-void perfevtsel_storage(struct perfevtsel **e,
-                        off_t *msrs_perfevtsel_ctrs);
+void perfevtsel_storage(
+    struct perfevtsel **e,
+    off_t *msrs_perfevtsel_ctrs
+);
 
 /// @brief Allocate storage for performance counters and reset values.
 ///
@@ -237,8 +267,10 @@ void perfevtsel_storage(struct perfevtsel **e,
 ///        PERFMON_CTRS.
 /// @return 0 if successful, else -1 if no general-purpose performance counters
 /// are available.
-int enable_pmc(off_t *msrs_perfevtsel_ctrs,
-               off_t *msrs_perfmon_ctrs);
+int enable_pmc(
+    off_t *msrs_perfevtsel_ctrs,
+    off_t *msrs_perfmon_ctrs
+);
 
 /// @brief Set a performance event select counter on a single logical processor.
 ///
@@ -252,27 +284,33 @@ int enable_pmc(off_t *msrs_perfevtsel_ctrs,
 /// @param [in] thread Unique logical processor identifier.
 /// @param [in] msrs_perfevtsel_ctrs Array of unique addresses for
 ///        PERFEVTSEL_CTRS.
-void set_pmc_ctrl_flags(uint64_t cmask,
-                        uint64_t flags,
-                        uint64_t umask,
-                        uint64_t eventsel,
-                        int pmcnum,
-                        unsigned thread,
-                        off_t *msrs_perfevtsel_ctrs);
+void set_pmc_ctrl_flags(
+    uint64_t cmask,
+    uint64_t flags,
+    uint64_t umask,
+    uint64_t eventsel,
+    int pmcnum,
+    unsigned thread,
+    off_t *msrs_perfevtsel_ctrs
+);
 
 /// @brief Store the general-purpose performance counter data on the heap.
 ///
 /// @param [out] p Data for general-purpose performance counters.
 /// @param [in] msrs_perfmon_ctrs Array of unique addresses for
 ///        PERFMON_CTRS.
-void pmc_storage(struct pmc **p,
-                 off_t *msrs_perfmon_ctrs);
+void pmc_storage(
+    struct pmc **p,
+    off_t *msrs_perfmon_ctrs
+);
 
 /// @brief Reset all performance counters for each logical processor.
 ///
 /// @param [in] msrs_perfmon_ctrs Array of unique addresses for
 ///        PERFMON_CTRS.
-void clear_all_pmc(off_t *msrs_perfmon_ctrs);
+void clear_all_pmc(
+    off_t *msrs_perfmon_ctrs
+);
 
 /// @brief Structure containing data of uncore performance event select
 /// counters.
@@ -312,8 +350,10 @@ struct unc_counters
 ///        counters.
 /// @param [in] msrs_pcu_pmon_evtsel Array of unique addresses for
 ///        PCU_PMON_EVTSEL.
-void unc_perfevtsel_storage(struct unc_perfevtsel **uevt,
-                            off_t *msrs_pcu_pmon_evtsel);
+void unc_perfevtsel_storage(
+    struct unc_perfevtsel **uevt,
+    off_t *msrs_pcu_pmon_evtsel
+);
 
 /// @brief Store the uncore general-purpose performance counter data on the
 /// heap.
@@ -322,8 +362,10 @@ void unc_perfevtsel_storage(struct unc_perfevtsel **uevt,
 ///        counters.
 /// @param [in] msrs_pcu_pmon_ctrs Array of unique addresses for
 ///        PCU_PMON_CTRS.
-void unc_counters_storage(struct unc_counters **uc,
-                          off_t *msrs_pcu_pmon_ctrs);
+void unc_counters_storage(
+    struct unc_counters **uc,
+    off_t *msrs_pcu_pmon_ctrs
+);
 
 /// @brief Allocate storage for uncore performance counters and reset values.
 ///
@@ -331,14 +373,18 @@ void unc_counters_storage(struct unc_counters **uc,
 ///        PCU_PMON_EVTSEL.
 /// @param [in] msrs_pcu_pmon_ctrs Array of unique addresses for
 ///        PCU_PMON_CTRS.
-void enable_pcu(off_t *msrs_pcu_pmon_evtsel,
-                off_t *msrs_pcu_pmon_ctrs);
+void enable_pcu(
+    off_t *msrs_pcu_pmon_evtsel,
+    off_t *msrs_pcu_pmon_ctrs
+);
 
 /// @brief Reset all uncore performance counters for each socket.
 ///
 /// @param [in] msrs_pcu_pmon_ctrs Array of unique addresses for
 ///        PCU_PMON_CTRS.
-void clear_all_pcu(off_t *msrs_pcu_pmon_ctrs);
+void clear_all_pcu(
+    off_t *msrs_pcu_pmon_ctrs
+);
 
 /// @brief Print out uncore performance counter data.
 ///
@@ -347,25 +393,31 @@ void clear_all_pcu(off_t *msrs_pcu_pmon_ctrs);
 ///        PCU_PMON_EVTSEL.
 /// @param [in] msrs_pcu_pmon_ctrs Array of unique addresses for
 ///        PCU_PMON_CTRS.
-void print_unc_counter_data(FILE *writedest,
-                            off_t *msrs_pcu_pmon_evtsel,
-                            off_t *msrs_pcu_pmon_ctrs);
+void print_unc_counter_data(
+    FILE *writedest,
+    off_t *msrs_pcu_pmon_evtsel,
+    off_t *msrs_pcu_pmon_ctrs
+);
 
-void print_verbose_unc_counter_data(FILE *writedest,
-                                    off_t *msrs_pcu_pmon_evtsel,
-                                    off_t *msrs_pcu_pmon_ctrs);
+void print_verbose_unc_counter_data(
+    FILE *writedest,
+    off_t *msrs_pcu_pmon_evtsel,
+    off_t *msrs_pcu_pmon_ctrs
+);
 
-void get_all_power_data_fixed(FILE *writedest,
-                              off_t msr_pkg_power_limit,
-                              off_t msr_dram_power_limit,
-                              off_t msr_rapl_unit,
-                              off_t msr_package_energy_status,
-                              off_t msr_dram_energy_status,
-                              off_t *msrs_fixed_ctrs,
-                              off_t msr_perf_global_ctrl,
-                              off_t msr_fixed_counter_ctrl,
-                              off_t msr_aperf,
-                              off_t msr_mperf,
-                              off_t msr_tsc);
+void get_all_power_data_fixed(
+    FILE *writedest,
+    off_t msr_pkg_power_limit,
+    off_t msr_dram_power_limit,
+    off_t msr_rapl_unit,
+    off_t msr_package_energy_status,
+    off_t msr_dram_energy_status,
+    off_t *msrs_fixed_ctrs,
+    off_t msr_perf_global_ctrl,
+    off_t msr_fixed_counter_ctrl,
+    off_t msr_aperf,
+    off_t msr_mperf,
+    off_t msr_tsc
+);
 
 #endif

--- a/src/variorum/Intel_GPU/GPU.h
+++ b/src/variorum/Intel_GPU/GPU.h
@@ -6,14 +6,24 @@
 #ifndef INTEL_GPU_H_INCLUDE
 #define INTEL_GPU_H_INCLUDE
 
-extern int intel_gpu_get_power(int long_ver);
+extern int intel_gpu_get_power(
+    int long_ver
+);
 
-extern int intel_gpu_get_thermals(int long_ver);
+extern int intel_gpu_get_thermals(
+    int long_ver
+);
 
-extern int intel_gpu_get_clocks(int long_ver);
+extern int intel_gpu_get_clocks(
+    int long_ver
+);
 
-extern int intel_gpu_cap_each_gpu_power_limit(unsigned int powerlimit);
+extern int intel_gpu_cap_each_gpu_power_limit(
+    unsigned int powerlimit
+);
 
-extern int intel_gpu_get_power_limit(int long_ver);
+extern int intel_gpu_get_power_limit(
+    int long_ver
+);
 
 #endif

--- a/src/variorum/Intel_GPU/config_intel_gpu.h
+++ b/src/variorum/Intel_GPU/config_intel_gpu.h
@@ -11,8 +11,12 @@
 #include <GPU.h>
 #include <intel_gpu_power_features.h>
 
-extern uint64_t *detect_intel_gpu_arch(void);
+extern uint64_t *detect_intel_gpu_arch(
+    void
+);
 
-extern int set_intel_gpu_func_ptrs(int idx);
+extern int set_intel_gpu_func_ptrs(
+    int idx
+);
 
 #endif

--- a/src/variorum/Intel_GPU/intel_gpu_power_features.h
+++ b/src/variorum/Intel_GPU/intel_gpu_power_features.h
@@ -11,27 +11,41 @@
 
 #include <libapmidg.h>
 
-void initAPMIDG(void);
+void initAPMIDG(
+    void
+);
 
-void shutdownAPMIDG(void);
+void shutdownAPMIDG(
+    void
+);
 
-void get_power_data(int chipid,
-                    int verbose,
-                    FILE *output);
+void get_power_data(
+    int chipid,
+    int verbose,
+    FILE *output
+);
 
-void get_thermal_data(int chipid,
-                      int verbose,
-                      FILE *output);
+void get_thermal_data(
+    int chipid,
+    int verbose,
+    FILE *output
+);
 
-void get_clocks_data(int chipid,
-                     int verbose,
-                     FILE *output);
+void get_clocks_data(
+    int chipid,
+    int verbose,
+    FILE *output
+);
 
-void cap_each_gpu_power_limit(int chipid,
-                              unsigned int powerlimit);
+void cap_each_gpu_power_limit(
+    int chipid,
+    unsigned int powerlimit
+);
 
-void get_power_limit_data(int chipid,
-                          int verbose,
-                          FILE *output);
+void get_power_limit_data(
+    int chipid,
+    int verbose,
+    FILE *output
+);
 
 #endif

--- a/src/variorum/config_architecture.h
+++ b/src/variorum/config_architecture.h
@@ -290,23 +290,35 @@ extern struct platform g_platform[2];
 // across Intel and AMD platforms.
 extern int P_MSR_CORE_IDX;
 
-int variorum_enter(const char *filename,
-                   const char *func_name,
-                   int line_num);
+int variorum_enter(
+    const char *filename,
+    const char *func_name,
+    int line_num
+);
 
-int variorum_exit(const char *filename,
-                  const char *func_name,
-                  int line_num);
+int variorum_exit(
+    const char *filename,
+    const char *func_name,
+    int line_num
+);
 
-void variorum_get_topology(unsigned *nsockets,
-                           unsigned *ncores,
-                           unsigned *nthreads,
-                           int idx);
+void variorum_get_topology(
+    unsigned *nsockets,
+    unsigned *ncores,
+    unsigned *nthreads,
+    int idx
+);
 
-int variorum_set_func_ptrs(void);
+int variorum_set_func_ptrs(
+    void
+);
 
-int variorum_detect_arch(void);
+int variorum_detect_arch(
+    void
+);
 
-void variorum_init_func_ptrs(void);
+void variorum_init_func_ptrs(
+    void
+);
 
 #endif

--- a/src/variorum/variorum_error.h
+++ b/src/variorum/variorum_error.h
@@ -29,17 +29,23 @@ enum variorum_error_e
     VARIORUM_ERROR_FUNCTION                = -15
 };
 
-void variorum_error_handler(const char *desc,
-                            int err,
-                            const char *host,
-                            const char *file,
-                            const char *func,
-                            int line);
+void variorum_error_handler(
+    const char *desc,
+    int err,
+    const char *host,
+    const char *file,
+    const char *func,
+    int line
+);
 
-char *get_variorum_error_message(enum variorum_error_e err);
+char *get_variorum_error_message(
+    enum variorum_error_e err
+);
 
-void variorum_error_message(enum variorum_error_e err,
-                            char *msg,
-                            size_t size);
+void variorum_error_message(
+    enum variorum_error_e err,
+    char *msg,
+    size_t size
+);
 
 #endif

--- a/src/variorum/variorum_timers.h
+++ b/src/variorum/variorum_timers.h
@@ -19,16 +19,24 @@ struct mstimer
 };
 
 /// @brief Get a number of millis from a monotonic clock.
-unsigned long now_ms(void);
+unsigned long now_ms(
+    void
+);
 
 /// @brief Sleep until timer time has elapsed.
-int timer_sleep(struct mstimer *t);
+int timer_sleep(
+    struct mstimer *t
+);
 
 /// @brief Initialize a msTimer.
-void init_msTimer(struct mstimer *t,
-                  int ms_interval);
+void init_msTimer(
+    struct mstimer *t,
+    int ms_interval
+);
 
 /// @brief Use a select to sleep a given number of millis.
-void sleep_ms(long ms);
+void sleep_ms(
+    long ms
+);
 
 #endif


### PR DESCRIPTION
# Description

Code formatting cleanup, breaks function definition parameters onto separate lines

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update
- [x] Internal cleanup

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes
