### PR TITLE
update astyle formatting

### DIFF
--- a/scripts/check-cpp-c-format.sh
+++ b/scripts/check-cpp-c-format.sh
@@ -33,6 +33,7 @@ astyle --errors-to-stdout \
        --break-after-logical \
        --indent-switches \
        --formatted \
+       --add-brackets \
        ${FILES}
 
 #

--- a/src/powmon/common.c
+++ b/src/powmon/common.c
@@ -89,7 +89,9 @@ void parse_json_obj(char *s, int num_sockets)
             }
 
             if ((i + 1) == num_sockets)
+            {
                 write_header = false;
+            }
         }
 
     }
@@ -168,7 +170,9 @@ void take_measurement(bool measure_all)
 
     // Verbose output with all sensors/registers
     if (measure_all == true)
+    {
         variorum_monitoring(logfile);
+    }
 
 #if 0
     total_joules += rapl_data[0] + rapl_data[1];

--- a/src/variorum/AMD/config_amd.c
+++ b/src/variorum/AMD/config_amd.c
@@ -55,7 +55,9 @@ int set_amd_func_ptrs(int idx)
         }
     }
     else
+    {
         return VARIORUM_ERROR_UNSUPPORTED_PLATFORM;
+    }
 
     /* smi monitor initialization */
     ret = esmi_init();


### PR DESCRIPTION
# Description

Updates astyle config with flag to add brackets to unbracketed one line conditional statements. 
```
if ((i + 1) == num_sockets)
    write_header = false;
```
Becomes
```
if ((i + 1) == num_sockets)
{
    write_header = false;
}
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update
- [x] Internal cleanup

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes
