### PR TITLE
Change uint<>_t assignments from -1 to 0

### DIFF
--- a/src/variorum/AMD_GPU/amd_gpu_power_features.c
+++ b/src/variorum/AMD_GPU/amd_gpu_power_features.c
@@ -199,8 +199,8 @@ void get_power_limit_data(int chipid, int total_sockets, int verbose,
     for (int i = chipid * gpus_per_socket;
          i < (chipid + 1) * gpus_per_socket; i++)
     {
-        uint64_t pwr_val = -1, pwr_min = -1, pwr_max = -1;
-        double pwr_val_flt = -1.0;
+        uint64_t pwr_val = 0, pwr_min = 0, pwr_max = 0;
+        double pwr_val_flt = 0.0;
 
         ret = rsmi_dev_power_cap_get(i, 0, &pwr_val);
         if (ret != RSMI_STATUS_SUCCESS)
@@ -963,7 +963,7 @@ void get_json_power_data(json_t *get_power_obj, int total_sockets)
     int chipid;
     uint32_t num_devices;
     int gpus_per_socket;
-    uint64_t pwr_val = -1;
+    uint64_t pwr_val = 0;
     double pwr_val_flt = 0.0;
     double total_gpu_power = 0.0;
     int d;


### PR DESCRIPTION
# Description

Change uint64_t assignments from -1 to 0. 
Change one matching double assignment from -1 to 0. 
Needs verification that all of these assignments have been captured. 
Needs testing on corona.

Fixes #485 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

- [x] Corona

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
