### PR TITLE
Cleanup Juno r2 code to build with `-DENABLE_WARNINGS=ON` 

### DIFF
--- a/src/variorum/ARM/neoverse_N1_power_features.c
+++ b/src/variorum/ARM/neoverse_N1_power_features.c
@@ -206,7 +206,7 @@ int arm_cpu_neoverse_n1_get_clocks_data(int chipid, int verbose, FILE *output)
 
     for (core_iter = 0; core_iter < NUM_CORES; core_iter++)
     {
-        sprintf(freq_fname, "%s%d/scaling_cur_freq", freq_path, core_iter);
+        sprintf(freq_fname, "%s%lu/scaling_cur_freq", freq_path, core_iter);
         int freq_fd = open(freq_fname, O_RDONLY);
         if (!freq_fd)
         {
@@ -274,16 +274,13 @@ int arm_cpu_neoverse_n1_get_clocks_data(int chipid, int verbose, FILE *output)
 
 int arm_cpu_neoverse_n1_cap_socket_frequency(int socketid, int new_freq)
 {
-    static int init_output = 0;
     uint64_t core_iter;
-    uint64_t aggregate_freq = 0;
-
     char freq_fname[4096];
     char *freq_path = "/sys/devices/system/cpu/cpufreq/policy";
 
     for (core_iter = 0; core_iter < NUM_CORES; core_iter++)
     {
-        sprintf(freq_fname, "%s%d/scaling_setspeed", freq_path, core_iter);
+        sprintf(freq_fname, "%s%lu/scaling_setspeed", freq_path, core_iter);
         int freq_fd = open(freq_fname, O_WRONLY);
         if (!freq_fd)
         {


### PR DESCRIPTION
# Description

Addresses several `-Werror=format and `-Werror=unused-variable` on Juno r2, but doesn't fix #526 yet. 

Fixes #527. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

- [x] Juno r2

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes