### PR TITLE
Neoverse code cleanup for building with `-DENABLE_WARNINGS=ON`.

### DIFF
--- a/src/variorum/ARM/ARM_Neoverse_N1.c
+++ b/src/variorum/ARM/ARM_Neoverse_N1.c
@@ -87,7 +87,7 @@ int arm_neoverse_n1_cap_socket_frequency(int cpuid, int freq)
         fprintf(stdout, "The specified CPU ID does not exist\n");
         return -1;
     }
-    ret = arm_cpu_neoverse_n1_cap_socket_frequency(cpuid, freq);
+    ret = arm_cpu_neoverse_n1_cap_socket_frequency(freq);
 
     return ret;
 }

--- a/src/variorum/ARM/neoverse_N1_power_features.c
+++ b/src/variorum/ARM/neoverse_N1_power_features.c
@@ -272,7 +272,7 @@ int arm_cpu_neoverse_n1_get_clocks_data(int chipid, int verbose, FILE *output)
     return 0;
 }
 
-int arm_cpu_neoverse_n1_cap_socket_frequency(int socketid, int new_freq)
+int arm_cpu_neoverse_n1_cap_socket_frequency(int new_freq)
 {
     uint64_t core_iter;
     char freq_fname[4096];

--- a/src/variorum/ARM/neoverse_N1_power_features.h
+++ b/src/variorum/ARM/neoverse_N1_power_features.h
@@ -31,7 +31,6 @@ int arm_cpu_neoverse_n1_get_clocks_data(
 );
 
 int arm_cpu_neoverse_n1_cap_socket_frequency(
-    int socketid,
     int new_freq
 );
 


### PR DESCRIPTION
# Description

Cleanup for `-Werror-unused-parameter` , need to figure out how far to propogate the change and check where to test with @amarathe84.

Fixes #526.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

- [x] Juno r2
- [x] neoverse system?


# Checklist:

- [ ] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [ ] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [ ] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
