### PR TITLE
lassen: add path to cuda/10.1.243 to host configs

### DIFF
--- a/.gitlab/lassen-gpu-build-and-test.yml
+++ b/.gitlab/lassen-gpu-build-and-test.yml
@@ -71,9 +71,10 @@ build-lassen-gpu:
    - cmake --version
    - cd install-gitlab-lassen-gpu/examples/using-with-cmake/c
    - echo -e "PWD:" ${PWD}
+   - export LD_LIBRARY_PATH=/usr/tce/packages/cuda/cuda-10.1.243/lib64:${LD_LIBRARY_PATH}  # hack for getting older cuda
    - mkdir _test_build
    - cd _test_build
-   - cmake -DCMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath -Wl,/usr/tce/packages/cuda/cuda-10.1.243/lib64" ../
+   - cmake ../
    - make VERBOSE=1
    - ./variorum-print-power-example
    - cd ../../../using-with-make/c

--- a/.gitlab/lassen-gpu-build-and-test.yml
+++ b/.gitlab/lassen-gpu-build-and-test.yml
@@ -73,7 +73,7 @@ build-lassen-gpu:
    - echo -e "PWD:" ${PWD}
    - mkdir _test_build
    - cd _test_build
-   - cmake ../
+   - cmake -DCMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath -Wl,/usr/tce/packages/cuda/cuda-10.1.243/lib64" ../
    - make VERBOSE=1
    - ./variorum-print-power-example
    - cd ../../../using-with-make/c

--- a/host-configs/lassen-4.14.0-ppc64le-gcc@8.3.1-cuda@10.1.243-both.cmake
+++ b/host-configs/lassen-4.14.0-ppc64le-gcc@8.3.1-cuda@10.1.243-both.cmake
@@ -19,10 +19,8 @@ set(VARIORUM_WITH_INTEL_CPU OFF CACHE BOOL "")
 set(VARIORUM_WITH_INTEL_GPU OFF CACHE BOOL "")
 set(VARIORUM_WITH_NVIDIA_GPU ON CACHE BOOL "")
 
-# You need to load CUDA 9.2.* to build this on Lassen
-# because hwloc was built with CUDA 9.2.* and not the default CUDA version
-# (10.1.*)
 set(CMAKE_SHARED_LINKER_FLAGS "-L/usr/tce/packages/cuda/cuda-10.1.243/nvidia/targets/ppc64le-linux/lib/stubs/ -lnvidia-ml" CACHE PATH "")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath -Wl,/usr/tce/packages/cuda/cuda-10.1.243/lib64" CACHE PATH "")
 
 # path to global hwloc install
 set(HWLOC_DIR "/usr/global/tools/hwloc/blueos_3_ppc64le_ib/hwloc-1.11.10-cuda/" CACHE PATH "")

--- a/host-configs/lassen-4.14.0-ppc64le-gcc@8.3.1-cuda@10.1.243.cmake
+++ b/host-configs/lassen-4.14.0-ppc64le-gcc@8.3.1-cuda@10.1.243.cmake
@@ -22,9 +22,8 @@ set(VARIORUM_WITH_INTEL_CPU OFF CACHE BOOL "")
 set(VARIORUM_WITH_INTEL_GPU OFF CACHE BOOL "")
 set(VARIORUM_WITH_NVIDIA_GPU ON CACHE BOOL "")
 
-# You need to load CUDA 9.2.* to build this on Lassen
-# because hwloc was built with CUDA 9.2.* and not the default CUDA version (10.1.*)
 set(CMAKE_SHARED_LINKER_FLAGS "-L/usr/tce/packages/cuda/cuda-10.1.243/nvidia/targets/ppc64le-linux/lib/stubs/ -lnvidia-ml" CACHE PATH "")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath -Wl,/usr/tce/packages/cuda/cuda-10.1.243/lib64" CACHE PATH "")
 
 # path to global hwloc install
 set(HWLOC_DIR "/usr/global/tools/hwloc/blueos_3_ppc64le_ib/hwloc-1.11.10-cuda/" CACHE PATH "")


### PR DESCRIPTION
# Description

Adds path to cuda/10.1.243 libraries to CMAKE_EXE_LINKER_FLAGS for rpath.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Build/CI update

# How Has This Been Tested?

- [x] lassen gpu-only
- [x] lassen cpu+gpu

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes