### PR TITLE
add return statement for missing platforms in variourm_get_energy_json

### DIFF
--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1739,7 +1739,7 @@ int variorum_get_energy_json(char **get_energy_obj_str)
                                        VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
                                        getenv("HOSTNAME"), __FILE__,
                                        __FUNCTION__, __LINE__);
-        return 0;
+                return 0;
             }
             err = g_platform[i].variorum_get_energy_json(node_obj);
             if (err)

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1739,6 +1739,7 @@ int variorum_get_energy_json(char **get_energy_obj_str)
                                        VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
                                        getenv("HOSTNAME"), __FILE__,
                                        __FUNCTION__, __LINE__);
+        return 0;
             }
             err = g_platform[i].variorum_get_energy_json(node_obj);
             if (err)


### PR DESCRIPTION
# Description

There is a missing return statement in the `variourm_get_energy_json` causing a segfault; This pull request will resolve this.

Fixes #537, closes #539

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please provide hardware architecture specs and
instructions so we can reproduce.

- [ ] Test A: Hardware architecture, machine name, example/test run
- [ ] Test B: Hardware architecture, machine name, example/test run
- [ ] ...

# Checklist:

- [ ] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [ ] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [ ] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
