### PR TITLE
Fix off-by-1 error in GPU utilization parsing in var_monitor

### DIFF
--- a/src/var_monitor/common.c
+++ b/src/var_monitor/common.c
@@ -322,7 +322,7 @@ void parse_json_util_obj(char *util_str, int num_sockets)
             for (j = 0; j < ndevices; j++)
             {
                 char device_id[24];
-                snprintf(device_id, 24, "GPU%d_util%%", (i * num_sockets) + j + 1);
+                snprintf(device_id, 24, "GPU%d_util%%", (i * num_sockets) + j);
                 gpu_util = json_integer_value(json_object_get(socket_obj, device_id));
                 // Don't write out a comma after the last column name
                 if ((i + 1) == num_sockets && (j + 1) == ndevices)


### PR DESCRIPTION
# Description

Fixes #544 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please provide hardware architecture specs and
instructions so we can reproduce.

- [X] Lassen GPU build

# Checklist:

- [X] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [X] I have added comments in my code
- [X] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [X] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
