### PR TITLE
Sapphire Rapids Power Capping support (RIKEN)

### DIFF
--- a/src/variorum/Intel/Intel_06_8F.c
+++ b/src/variorum/Intel/Intel_06_8F.c
@@ -32,7 +32,66 @@ static struct sapphire_rapids_6a_offsets msrs =
     .ia32_perf_global_ctrl        = 0x38F,
     .ia32_mperf                   = 0xE7,
     .ia32_aperf                   = 0xE8,
+    
 };
+
+int intel_cpu_fm_06_8f_cap_power_limits(int package_power_limit)
+{
+    unsigned socket;
+    unsigned nsockets, ncores, nthreads;
+#ifdef VARIORUM_WITH_INTEL_CPU
+    variorum_get_topology(&nsockets, &ncores, &nthreads, P_INTEL_CPU_IDX);
+#endif
+
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        cap_package_power_limit(socket, package_power_limit,
+                                msrs.msr_pkg_power_limit,
+                                msrs.msr_rapl_power_unit);
+    }
+    return 0;
+}
+
+int intel_cpu_fm_06_8f_cap_best_effort_node_power_limit(int node_limit)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    /* We make an assumption here to uniformly distribute the specified
+     * power to both sockets as socket-level power caps. We are not accounting
+     * for memory power or uncore power at the moment. We will develop a model
+     * for this in the future.
+     * When an odd number value is provided, we want this to result in
+     * the floor of the value being taken. So while we will be off by 1W total,
+     * we will guarantee that we stay under the specified cap. */
+
+    unsigned nsockets, ncores, nthreads;
+#ifdef VARIORUM_WITH_INTEL_CPU
+    variorum_get_topology(&nsockets, &ncores, &nthreads, P_INTEL_CPU_IDX);
+#endif
+
+    // Adding this for portability and rounding down.
+    // Ideally line 451 should be okay as it is integer division and we have
+    // two sockets only.
+
+    int remainder = node_limit % nsockets;
+    node_limit = (remainder == 0) ? node_limit : (node_limit - remainder);
+
+    int pkg_limit = node_limit / nsockets;
+
+    intel_cpu_fm_06_8f_cap_power_limits(pkg_limit);
+
+    return 0;
+}
 
 int fm_06_8f_get_power_limits(int long_ver)
 {
@@ -71,6 +130,18 @@ int fm_06_8f_get_power_limits(int long_ver)
         else if (long_ver == 1)
         {
             print_verbose_package_power_info(stdout, msrs.msr_pkg_power_info, socket);
+        }
+    }
+
+    for (socket = 0; socket < nsockets; socket++)
+    {
+        if (long_ver == 0)
+        {
+            print_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
+        }
+        else if (long_ver == 1)
+        {
+            print_verbose_dram_power_info(stdout, msrs.msr_dram_power_info, socket);
         }
     }
 
@@ -180,9 +251,13 @@ int fm_06_8f_monitoring(FILE *output)
     }
 
     get_all_power_data_fixed(output, msrs.msr_pkg_power_limit,
-                             msrs.msr_dram_power_limit, msrs.msr_rapl_power_unit, msrs.msr_pkg_energy_status,
-                             msrs.msr_dram_energy_status, msrs.ia32_fixed_counters,
-                             msrs.ia32_perf_global_ctrl, msrs.ia32_fixed_ctr_ctrl, msrs.ia32_aperf,
+                             msrs.msr_dram_power_limit,
+                             msrs.msr_rapl_power_unit,
+                             msrs.msr_pkg_energy_status,
+                             msrs.msr_dram_energy_status,
+                             msrs.ia32_fixed_counters,
+                             msrs.ia32_perf_global_ctrl,
+                             msrs.ia32_fixed_ctr_ctrl, msrs.ia32_aperf,
                              msrs.ia32_mperf, msrs.ia32_time_stamp_counter);
     return 0;
 }
@@ -221,3 +296,8 @@ int fm_06_8f_get_energy_json(json_t *get_energy_obj)
 
     return 0;
 }
+
+
+
+
+

--- a/src/variorum/Intel/Intel_06_8F.c
+++ b/src/variorum/Intel/Intel_06_8F.c
@@ -32,7 +32,7 @@ static struct sapphire_rapids_6a_offsets msrs =
     .ia32_perf_global_ctrl        = 0x38F,
     .ia32_mperf                   = 0xE7,
     .ia32_aperf                   = 0xE8,
-    
+
 };
 
 int intel_cpu_fm_06_8f_cap_power_limits(int package_power_limit)

--- a/src/variorum/Intel/Intel_06_8F.h
+++ b/src/variorum/Intel/Intel_06_8F.h
@@ -77,4 +77,16 @@ int fm_06_8f_get_energy_json(
     json_t *get_energy_obj
 );
 
+int intel_cpu_fm_06_8f_get_power_limits(
+    int long_ver
+);
+
+int intel_cpu_fm_06_8f_cap_power_limits(
+    int package_power_limit
+);
+
+int intel_cpu_fm_06_8f_cap_best_effort_node_power_limit(
+    int node_power_limit
+);
+
 #endif

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -313,6 +313,10 @@ int set_intel_func_ptrs(int idx)
     else if (*g_platform[idx].arch_id == FM_06_8F)
     {
         g_platform[idx].variorum_print_power_limit = fm_06_8f_get_power_limits;
+        g_platform[idx].variorum_cap_each_socket_power_limit = 
+            intel_cpu_fm_06_8f_cap_power_limits;
+        g_platform[idx].variorum_cap_best_effort_node_power_limit =
+            intel_cpu_fm_06_8f_cap_best_effort_node_power_limit;
         g_platform[idx].variorum_print_features = fm_06_8f_get_features;
         g_platform[idx].variorum_print_power = fm_06_8f_get_power;
         g_platform[idx].variorum_print_energy = fm_06_8f_get_energy;

--- a/src/variorum/Intel/config_intel.c
+++ b/src/variorum/Intel/config_intel.c
@@ -313,7 +313,7 @@ int set_intel_func_ptrs(int idx)
     else if (*g_platform[idx].arch_id == FM_06_8F)
     {
         g_platform[idx].variorum_print_power_limit = fm_06_8f_get_power_limits;
-        g_platform[idx].variorum_cap_each_socket_power_limit = 
+        g_platform[idx].variorum_cap_each_socket_power_limit =
             intel_cpu_fm_06_8f_cap_power_limits;
         g_platform[idx].variorum_cap_best_effort_node_power_limit =
             intel_cpu_fm_06_8f_cap_best_effort_node_power_limit;


### PR DESCRIPTION
# Description

Added support for power capping functions for the Sapphire Rapids 06_8F architecture.

Fixes #546 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please provide hardware architecture specs and
instructions so we can reproduce.

Tested on systems at RIKEN by our collaborators. 

- [x] Test A: Intel(R) Xeon(R) CPU Max 9468, run var_monitor on the Kripke application execution.
- [x] Test B: Intel(R) Xeon(R) CPU Max 9468, run power_wrapper_dynamic with different values on the Kripkie application execution.
- [ ] ...

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
