### PR TITLE
Fix tioga build issue

### DIFF
--- a/src/variorum/AMD/epyc.c
+++ b/src/variorum/AMD/epyc.c
@@ -508,7 +508,7 @@ int amd_cpu_epyc_get_json_boostlimit(json_t *get_clock_obj_json)
         printf("Running %s\n\n", __FUNCTION__);
     }
 
-    int socket, core,  ret;
+    int socket, core,  ret = 0;
     uint32_t boostlimit;
 
     int num_sockets = g_platform[P_AMD_CPU_IDX].num_sockets;
@@ -518,8 +518,8 @@ int amd_cpu_epyc_get_json_boostlimit(json_t *get_clock_obj_json)
 
     for (socket = 0; socket < num_sockets; ++socket)
     {
-        char socket_name[16];
-        snprintf(socket_name, 16, "socket_%d", socket);
+        char socket_name[32];
+        snprintf(socket_name, 32, "socket_%d", socket);
         json_t *socket_obj = json_object_get(get_clock_obj_json, socket_name);
         if (socket_obj == NULL)
         {
@@ -536,13 +536,13 @@ int amd_cpu_epyc_get_json_boostlimit(json_t *get_clock_obj_json)
         for (core = 0; core < cores_per_socket; ++core)
         {
             ret = esmi_core_boostlimit_get(current_core, &boostlimit);
-            char core_avg_string[24];
-            snprintf(core_avg_string, 24, "core_%d_avg_freq_mhz", current_core);
+            char core_avg_string[32];
+            snprintf(core_avg_string, 32, "core_%d_avg_freq_mhz", current_core);
             json_object_set_new(core_obj, core_avg_string, json_real(boostlimit));
             current_core++;
         }
     }
-    return 0;
+    return ret;
 }
 
 int amd_cpu_epyc_set_each_core_boostlimit(int boostlimit)
@@ -684,7 +684,7 @@ int amd_cpu_epyc_get_power_json(json_t *get_power_obj)
     uint32_t current_power;
     double node_power = 0.0;
     int i, ret = 0;
-    int sockID_len = 12;
+    int sockID_len = 32;
     char sockID[sockID_len];
 
 #ifdef VARIORUM_WITH_AMD_CPU

--- a/src/variorum/AMD/epyc.h
+++ b/src/variorum/AMD/epyc.h
@@ -25,7 +25,7 @@ int amd_cpu_epyc_set_and_verify_best_effort_node_power_limit(
 );
 
 int amd_cpu_epyc_print_energy(
-    void
+    int long_ver
 );
 
 int amd_cpu_epyc_print_boostlimit(

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -722,6 +722,7 @@ int variorum_get_energy_json(char **get_energy_obj_str);
 /// @brief Returns Variorum version as a constant string.
 ///
 /// @supparch
+
 /// - All architectures
 ///
 /// @return Returns a constant string containing the

--- a/src/variorum/variorum.h
+++ b/src/variorum/variorum.h
@@ -722,7 +722,6 @@ int variorum_get_energy_json(char **get_energy_obj_str);
 /// @brief Returns Variorum version as a constant string.
 ///
 /// @supparch
-
 /// - All architectures
 ///
 /// @return Returns a constant string containing the


### PR DESCRIPTION
# Description

Fixes #548. 
There was an issue with the `int long_ver` missing in the `epyc.h` file, causing build errors. Also, some warnings were being generated with `sprintf` due to size of the char array.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Was able to test the build on Tioga, but unable to test Variorum examples as HSMP is still down. 
Note: A known warning exists on Tioga as we're not using the verbosity flag on AMD yet.

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
