### PR TITLE
Fix compatibility with ROCm < 6.0.0

### DIFF
--- a/src/variorum/AMD_GPU/amd_gpu_power_features.c
+++ b/src/variorum/AMD_GPU/amd_gpu_power_features.c
@@ -17,7 +17,7 @@
 #include <cprintf.h>
 #endif
 
-#include <rocm_version.h>
+#include <rocm-core/rocm_version.h>
 
 void get_power_data(int chipid, int total_sockets, int verbose, FILE *output)
 {


### PR DESCRIPTION
# Description

Frontier currently only has rocm/6.0.0 which is unusable because of https://github.com/ROCm/ROCm/issues/2752. https://github.com/LLNL/variorum/commit/192a58d4a47dc87354acdb0dc629a9e316822429 switched to the interface for ROCm 6.0.0 and higher while commenting the necessary code for earlier versions. This pull request restores the compatibility by checking for `ROCM_VERSION_MAJOR`.

Fixes #513.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Running the tests on `Frontier` with `rocm-5.7.1`.

Test before merge:
- [x] Corona 6.0.2
- [x] Tioga 6.0.2
- [x] Tioga 5.7.1 
Note: Using Rocm 5.7.1 on Tioga results in a warning with `/usr/tce/packages/gcc/gcc-10.3.1/bin/ld: warning: librocm_smi64.so.6, needed by /lib/../lib64/libhwloc.so, may conflict with librocm_smi64.so.5. The power data generated from variorum-print-power-example is correct. This warning doesn't have to do with the PR's fix but rather the fact that GCC is built with a newer ROCm in our toolchain. We expect to use the newer version, and this was a test for backward compatibility, so declaring this test as successful. 


# Checklist:

- [ ] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [ ] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes