### PR TITLE
Add GPU Energy APIs and support for NVIDIA and AMD GPUs

### DIFF
--- a/src/variorum/Nvidia_GPU/Volta.c
+++ b/src/variorum/Nvidia_GPU/Volta.c
@@ -218,3 +218,43 @@ int volta_get_power_json(json_t *get_power_obj)
     return 0;
 }
 
+int volta_get_energy(int long_ver)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    unsigned iter = 0;
+    unsigned nsockets = 0;
+#ifdef VARIORUM_WITH_NVIDIA_GPU
+    variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
+#endif
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        nvidia_gpu_get_energy_data(iter, long_ver, stdout);
+    }
+    return 0;
+}
+
+int volta_get_energy_json(json_t *get_energy_obj)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    unsigned iter = 0;
+    unsigned nsockets;
+    variorum_get_topology(&nsockets, NULL, NULL, P_NVIDIA_GPU_IDX);
+
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        nvidia_gpu_get_energy_json(iter, get_energy_obj);
+    }
+
+    return 0;
+}
+

--- a/src/variorum/Nvidia_GPU/Volta.h
+++ b/src/variorum/Nvidia_GPU/Volta.h
@@ -48,4 +48,11 @@ int volta_get_gpu_utilization_json(
     char **get_gpu_util_obj_str
 );
 
+int volta_get_energy(
+    int long_ver
+);
+
+int volta_get_energy_json(
+    json_t *get_energy_obj_str
+);
 #endif

--- a/src/variorum/Nvidia_GPU/config_nvidia.c
+++ b/src/variorum/Nvidia_GPU/config_nvidia.c
@@ -38,6 +38,8 @@ int set_nvidia_func_ptrs(int idx)
         g_platform[idx].variorum_cap_each_gpu_power_limit =
             volta_cap_each_gpu_power_limit;
         g_platform[idx].variorum_get_power_json = volta_get_power_json;
+        g_platform[idx].variorum_print_energy = volta_get_energy;
+        g_platform[idx].variorum_get_energy_json = volta_get_energy_json;
     }
     else
     {

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -601,20 +601,20 @@ void nvidia_gpu_get_energy_json(int chipid, json_t *get_energy_obj)
     char socket_id[12];
     snprintf(socket_id, 12, "socket_%d", chipid);
 
-    json_object_set_new(get_power_obj, "num_gpus_per_socket",
+    json_object_set_new(get_energy_obj, "num_gpus_per_socket",
                         json_integer(m_gpus_per_socket));
 
     //try to find socket object in node object, set new object if not found
-    json_t *socket_obj = json_object_get(get_power_obj, socket_id);
+    json_t *socket_obj = json_object_get(get_energy_obj, socket_id);
     if (socket_obj == NULL)
     {
         socket_obj = json_object();
-        json_object_set_new(get_power_obj, socket_id, socket_obj);
+        json_object_set_new(get_energy_obj, socket_id, socket_obj);
     }
 
     //create new json object for GPU
     json_t *gpu_obj = json_object();
-    json_object_set_new(socket_obj, "power_gpu_watts", gpu_obj);
+    json_object_set_new(socket_obj, "energy_gpu_joules", gpu_obj);
 
     for (d = chipid * (int)m_gpus_per_socket;
          d < (chipid + 1) * (int)m_gpus_per_socket; ++d)

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -619,11 +619,11 @@ void nvidia_gpu_get_energy_json(int chipid, json_t *get_energy_obj)
     for (d = chipid * (int)m_gpus_per_socket;
          d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
-        nvmlDeviceGetPowerUsage(m_unit_devices_file_desc[d], &gpu_power);
-        value = (double)gpu_power * 0.001f;
+      nvmlDeviceGetTotalEnergyConsumption(m_unit_devices_file_desc[d], &gpu_energy);
+        value = (double)gpu_energy * 0.001f;
         snprintf(devID, devIDlen, "GPU_%d", d);
         json_object_set_new(gpu_obj, devID, json_real(value));
-        total_gpu_power += value;
+        total_gpu_energy += value;
     }
 
     // If we have an existing CPU object with power_node_watts, update its value.
@@ -631,13 +631,13 @@ void nvidia_gpu_get_energy_json(int chipid, json_t *get_energy_obj)
     // directly. So we don't need to add in the GPU values separately.
 
 #ifndef VARIORUM_WITH_IBM_CPU
-    if (json_object_get(get_power_obj, "power_node_watts") != NULL)
+    if (json_object_get(get_energy_obj, "energy_node_joules") != NULL)
     {
-        double power_node;
-        power_node = json_real_value(json_object_get(get_power_obj,
-                                     "power_node_watts"));
-        json_object_set(get_power_obj, "power_node_watts",
-                        json_real(power_node + total_gpu_power));
+        double energy_node;
+        energy_node = json_real_value(json_object_get(get_energy_obj,
+                                     "energy_node_joules"));
+        json_object_set(get_energy_obj, "energy_node_joules",
+                        json_real(energy_node + total_gpu_energy));
     }
 #endif
 

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -546,14 +546,32 @@ void nvidia_gpu_get_energy_data(int chipid, int verbose, FILE *output)
     double value = 0.0;
     int d;
     static int init_output = 0;
+    /* First call to the get_energy function should return a zero.
+     * that way, we are only reporting the energy consumed with respect to
+     * the function call. Similar to IBM and Intel, we assume delta from
+     * the first call. We'll support a bool for first/prev in the future.*/
+    static int offset_flag = 0;
+    static double energy_offset_value = 0.0;
 
     //Iterate over all GPU device handles for this socket and print power
     for (d = chipid * (int)m_gpus_per_socket;
          d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
-        nvmlDeviceGetTotalEnergyConsumption(m_unit_devices_file_desc[d], &energy);
-        // Convert from milliJoules to Joules
-        value = (double)energy * 0.001f;
+        /* This is the first call, so we store the offset but don't update the value.
+         * So value will stay at 0.0J.*/
+        if (!offset_flag)
+        {
+            nvmlDeviceGetTotalEnergyConsumption(m_unit_devices_file_desc[d], &energy);
+            // Convert from milliJoules to Joules
+            energy_offset_value = (double)energy * 0.001f;
+            offset_flag = 1;
+        }
+        else
+        {
+            nvmlDeviceGetTotalEnergyConsumption(m_unit_devices_file_desc[d], &energy);
+            // Convert from milliJoules to Joules
+            value = (double)energy * 0.001f ;
+        }
 
         if (verbose)
         {
@@ -561,7 +579,7 @@ void nvidia_gpu_get_energy_data(int chipid, int verbose, FILE *output)
             fprintf(output, "%s: %s, %s: %d, %s: %d, %s: %lf W\n",
                     "_NVIDIA_GPU_ENERGY_USAGE Host", m_hostname,
                     "Socket", chipid,
-                    "DeviceID", d, "Energy", value);
+                    "DeviceID", d, "Energy_J", value);
         }
         else
         {
@@ -570,11 +588,11 @@ void nvidia_gpu_get_energy_data(int chipid, int verbose, FILE *output)
 #ifdef LIBJUSTIFY_FOUND
                 cfprintf(output, "%s %s %s %s %s\n",
                          "_NVIDIA_GPU_ENERGY_USAGE", "Host",
-                         "Socket", "DeviceID", "Energy");
+                         "Socket", "DeviceID", "Energy_J");
 #else
                 fprintf(output, "%s %s %s %s %s\n",
                         "_NVIDIA_GPU_ENERGY_USAGE", "Host",
-                        "Socket", "DeviceID", "Energy");
+                        "Socket", "DeviceID", "Energy_J");
 #endif
                 init_output = 1;
             }

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -619,7 +619,7 @@ void nvidia_gpu_get_energy_json(int chipid, json_t *get_energy_obj)
     for (d = chipid * (int)m_gpus_per_socket;
          d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
     {
-      nvmlDeviceGetTotalEnergyConsumption(m_unit_devices_file_desc[d], &gpu_energy);
+        nvmlDeviceGetTotalEnergyConsumption(m_unit_devices_file_desc[d], &gpu_energy);
         value = (double)gpu_energy * 0.001f;
         snprintf(devID, devIDlen, "GPU_%d", d);
         json_object_set_new(gpu_obj, devID, json_real(value));
@@ -635,7 +635,7 @@ void nvidia_gpu_get_energy_json(int chipid, json_t *get_energy_obj)
     {
         double energy_node;
         energy_node = json_real_value(json_object_get(get_energy_obj,
-                                     "energy_node_joules"));
+                                      "energy_node_joules"));
         json_object_set(get_energy_obj, "energy_node_joules",
                         json_real(energy_node + total_gpu_energy));
     }

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -550,10 +550,10 @@ void nvidia_gpu_get_energy_data(int chipid, int verbose, FILE *output)
      * that way, we are only reporting the energy consumed with respect to
      * the function call. Similar to IBM and Intel, we assume delta from
      * the first call. We'll support a bool for first/prev in the future.
-     * We assume a max of 6 GPUs per socket to faciliate static allocation.
+     * We assume a max of 12 GPUs per node to faciliate static allocation.
      * By default, these are initialized to zero. */
-    static uint8_t offset_flag[6] ;
-    static double energy_offset_value[6];
+    static uint8_t offset_flag[12] ;
+    static double energy_offset_value[12];
 
     //Iterate over all GPU device handles for this socket and print power
     for (d = chipid * (int)m_gpus_per_socket;

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -549,9 +549,11 @@ void nvidia_gpu_get_energy_data(int chipid, int verbose, FILE *output)
     /* First call to the get_energy function should return a zero.
      * that way, we are only reporting the energy consumed with respect to
      * the function call. Similar to IBM and Intel, we assume delta from
-     * the first call. We'll support a bool for first/prev in the future.*/
-    static int offset_flag = 0;
-    static double energy_offset_value = 0.0;
+     * the first call. We'll support a bool for first/prev in the future.
+     * We assume a max of 6 GPUs per socket to faciliate static allocation.
+     * By default, these are initialized to zero. */
+    static uint8_t offset_flag[6] ;
+    static double energy_offset_value[6];
 
     //Iterate over all GPU device handles for this socket and print power
     for (d = chipid * (int)m_gpus_per_socket;
@@ -559,18 +561,19 @@ void nvidia_gpu_get_energy_data(int chipid, int verbose, FILE *output)
     {
         /* This is the first call, so we store the offset but don't update the value.
          * So value will stay at 0.0J.*/
-        if (!offset_flag)
+        if (!offset_flag[d])
         {
             nvmlDeviceGetTotalEnergyConsumption(m_unit_devices_file_desc[d], &energy);
             // Convert from milliJoules to Joules
-            energy_offset_value = (double)energy * 0.001f;
-            offset_flag = 1;
+            energy_offset_value[d] = (double)energy * 0.001f;
+            value = 0.0;
+            offset_flag[d] = 1;
         }
         else
         {
             nvmlDeviceGetTotalEnergyConsumption(m_unit_devices_file_desc[d], &energy);
-            // Convert from milliJoules to Joules
-            value = (double)energy * 0.001f ;
+            // Convert from milliJoules to Joules and subtract the corresponding offset.
+            value = ((double)energy * 0.001f) - energy_offset_value[d];
         }
 
         if (verbose)

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.c
@@ -540,3 +540,105 @@ void nvidia_gpu_get_power_json(int chipid, json_t *get_power_obj)
 
 }
 
+void nvidia_gpu_get_energy_data(int chipid, int verbose, FILE *output)
+{
+    unsigned long long energy;
+    double value = 0.0;
+    int d;
+    static int init_output = 0;
+
+    //Iterate over all GPU device handles for this socket and print power
+    for (d = chipid * (int)m_gpus_per_socket;
+         d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
+    {
+        nvmlDeviceGetTotalEnergyConsumption(m_unit_devices_file_desc[d], &energy);
+        // Convert from milliJoules to Joules
+        value = (double)energy * 0.001f;
+
+        if (verbose)
+        {
+
+            fprintf(output, "%s: %s, %s: %d, %s: %d, %s: %lf W\n",
+                    "_NVIDIA_GPU_ENERGY_USAGE Host", m_hostname,
+                    "Socket", chipid,
+                    "DeviceID", d, "Energy", value);
+        }
+        else
+        {
+            if (!init_output)
+            {
+#ifdef LIBJUSTIFY_FOUND
+                cfprintf(output, "%s %s %s %s %s\n",
+                         "_NVIDIA_GPU_ENERGY_USAGE", "Host",
+                         "Socket", "DeviceID", "Energy");
+#else
+                fprintf(output, "%s %s %s %s %s\n",
+                        "_NVIDIA_GPU_ENERGY_USAGE", "Host",
+                        "Socket", "DeviceID", "Energy");
+#endif
+                init_output = 1;
+            }
+#ifdef LIBJUSTIFY_FOUND
+            cfprintf(output, "%s %s %d %d %lf\n",
+                     "_NVIDIA_GPU_ENERGY_USAGE", m_hostname, chipid, d, value);
+#else
+            fprintf(output, "%s %s %d %d %lf\n",
+                    "_NVIDIA_GPU_ENERGY_USAGE", m_hostname, chipid, d, value);
+
+#endif
+        }
+    }
+}
+
+void nvidia_gpu_get_energy_json(int chipid, json_t *get_energy_obj)
+{
+    unsigned long long gpu_energy;
+    double value = 0.0;
+    double total_gpu_energy = 0.0;
+    int d;
+    static size_t devIDlen = 24; // Long enough to avoid format truncation.
+    char devID[devIDlen];
+    char socket_id[12];
+    snprintf(socket_id, 12, "socket_%d", chipid);
+
+    json_object_set_new(get_power_obj, "num_gpus_per_socket",
+                        json_integer(m_gpus_per_socket));
+
+    //try to find socket object in node object, set new object if not found
+    json_t *socket_obj = json_object_get(get_power_obj, socket_id);
+    if (socket_obj == NULL)
+    {
+        socket_obj = json_object();
+        json_object_set_new(get_power_obj, socket_id, socket_obj);
+    }
+
+    //create new json object for GPU
+    json_t *gpu_obj = json_object();
+    json_object_set_new(socket_obj, "power_gpu_watts", gpu_obj);
+
+    for (d = chipid * (int)m_gpus_per_socket;
+         d < (chipid + 1) * (int)m_gpus_per_socket; ++d)
+    {
+        nvmlDeviceGetPowerUsage(m_unit_devices_file_desc[d], &gpu_power);
+        value = (double)gpu_power * 0.001f;
+        snprintf(devID, devIDlen, "GPU_%d", d);
+        json_object_set_new(gpu_obj, devID, json_real(value));
+        total_gpu_power += value;
+    }
+
+    // If we have an existing CPU object with power_node_watts, update its value.
+    // Except on IBM Power9 systems, as they report node power with PWRSYS
+    // directly. So we don't need to add in the GPU values separately.
+
+#ifndef VARIORUM_WITH_IBM_CPU
+    if (json_object_get(get_power_obj, "power_node_watts") != NULL)
+    {
+        double power_node;
+        power_node = json_real_value(json_object_get(get_power_obj,
+                                     "power_node_watts"));
+        json_object_set(get_power_obj, "power_node_watts",
+                        json_real(power_node + total_gpu_power));
+    }
+#endif
+
+}

--- a/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.h
+++ b/src/variorum/Nvidia_GPU/nvidia_gpu_power_features.h
@@ -82,4 +82,15 @@ void nvidia_gpu_get_power_json(
     json_t *output
 );
 
+void nvidia_gpu_get_energy_data(
+    int chipid,
+    int verbose,
+    FILE *output
+);
+
+void nvidia_gpu_get_energy_json(
+    int chipid,
+    json_t *output
+);
+
 #endif

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1573,8 +1573,8 @@ int variorum_print_energy(void)
 {
     int err = 0;
     int i;
-    int has_cpu = 0;
-    int has_gpu = 0;
+ //   int has_cpu = 0;
+ //   int has_gpu = 0;
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
     if (err)
     {
@@ -1585,7 +1585,7 @@ int variorum_print_energy(void)
     // If we have a CPU-only or CPU+GPU multi-platform build, we should print
     // the node-level energy.
     // First check if we have a CPU platform, then check for a GPU platform
-
+/*
 #if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
     has_cpu = 1;
 #endif
@@ -1596,6 +1596,7 @@ int variorum_print_energy(void)
     // CPU-only or multi-platform build
     if ((has_cpu && has_gpu) || (has_cpu))
     {
+*/
         for (i = 0; i < P_NUM_PLATFORMS; i++)
         {
             if (g_platform[i].variorum_print_energy == NULL)
@@ -1611,7 +1612,7 @@ int variorum_print_energy(void)
                 return -1;
             }
         }
-    }
+ /*   }
     else
     {
         // We have a GPU-only build, currently doesn't support get_energy
@@ -1620,6 +1621,7 @@ int variorum_print_energy(void)
                                __FUNCTION__, __LINE__);
         return 0;
     }
+*/
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
 
     if (err)
@@ -1633,8 +1635,8 @@ int variorum_print_verbose_energy(void)
 {
     int err = 0;
     int i;
-    int has_cpu = 0;
-    int has_gpu = 0;
+//    int has_cpu = 0;
+//    int has_gpu = 0;
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
     if (err)
     {
@@ -1645,7 +1647,7 @@ int variorum_print_verbose_energy(void)
     // If we have a CPU-only or CPU+GPU multi-platform build, we should print
     // the node-level energy.
     // First check if we have a CPU platform, then check for a GPU platform
-
+/*
 #if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
     has_cpu = 1;
 #endif
@@ -1656,6 +1658,7 @@ int variorum_print_verbose_energy(void)
     // CPU-only or multi-platform build
     if ((has_cpu && has_gpu) || (has_cpu))
     {
+*/
         for (i = 0; i < P_NUM_PLATFORMS; i++)
         {
             if (g_platform[i].variorum_print_energy == NULL)
@@ -1671,7 +1674,7 @@ int variorum_print_verbose_energy(void)
                 return -1;
             }
         }
-    }
+  /*  }
     else
     {
         // We have a GPU-only build, currently doesn't support get_energy
@@ -1679,7 +1682,7 @@ int variorum_print_verbose_energy(void)
                                VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
                                __FUNCTION__, __LINE__);
         return 0;
-    }
+    }*/
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
     if (err)
     {
@@ -1692,8 +1695,8 @@ int variorum_get_energy_json(char **get_energy_obj_str)
 {
     int err = 0;
     int i;
-    int has_cpu = 0;
-    int has_gpu = 0;
+//    int has_cpu = 0;
+//    int has_gpu = 0;
     char hostname[1024];
     uint64_t ts;
     struct timeval tv;
@@ -1717,7 +1720,7 @@ int variorum_get_energy_json(char **get_energy_obj_str)
     // If we have a CPU-only or CPU+GPU multi-platform build, we should print
     // the node-level energy.
     // First check if we have a CPU platform, then check for a GPU platform
-
+/*
 #if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
     has_cpu = 1;
 #endif
@@ -1728,6 +1731,7 @@ int variorum_get_energy_json(char **get_energy_obj_str)
     // CPU-only or multi-platform build
     if ((has_cpu && has_gpu) || (has_cpu))
     {
+*/
         for (i = 0; i < P_NUM_PLATFORMS; i++)
         {
             if (g_platform[i].variorum_get_energy_json == NULL)
@@ -1745,7 +1749,7 @@ int variorum_get_energy_json(char **get_energy_obj_str)
             }
             *get_energy_obj_str = json_dumps(get_energy_obj, JSON_INDENT(4));
         }
-    }
+  /*  }
     else
     {
         // We have a GPU-only build, currently doesn't support get_energy
@@ -1755,6 +1759,7 @@ int variorum_get_energy_json(char **get_energy_obj_str)
         *get_energy_obj_str = json_dumps(get_energy_obj, JSON_INDENT(4));
         return 0;
     }
+*/
 
     json_decref(get_energy_obj);
 

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1573,8 +1573,8 @@ int variorum_print_energy(void)
 {
     int err = 0;
     int i;
- //   int has_cpu = 0;
- //   int has_gpu = 0;
+    //   int has_cpu = 0;
+    //   int has_gpu = 0;
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
     if (err)
     {
@@ -1585,43 +1585,43 @@ int variorum_print_energy(void)
     // If we have a CPU-only or CPU+GPU multi-platform build, we should print
     // the node-level energy.
     // First check if we have a CPU platform, then check for a GPU platform
-/*
-#if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
-    has_cpu = 1;
-#endif
-#if defined(VARIORUM_WITH_NVIDIA_GPU) || defined(VARIORUM_WITH_AMD_GPU) || defined(VARIORUM_WITH_INTEL_GPU)
-    has_gpu = 1;
-#endif
+    /*
+    #if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
+        has_cpu = 1;
+    #endif
+    #if defined(VARIORUM_WITH_NVIDIA_GPU) || defined(VARIORUM_WITH_AMD_GPU) || defined(VARIORUM_WITH_INTEL_GPU)
+        has_gpu = 1;
+    #endif
 
-    // CPU-only or multi-platform build
-    if ((has_cpu && has_gpu) || (has_cpu))
-    {
-*/
-        for (i = 0; i < P_NUM_PLATFORMS; i++)
+        // CPU-only or multi-platform build
+        if ((has_cpu && has_gpu) || (has_cpu))
         {
-            if (g_platform[i].variorum_print_energy == NULL)
-            {
-                variorum_error_handler("Feature not yet implemented or is not supported",
-                                       VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
-                                       __FUNCTION__, __LINE__);
-                return 0;
-            }
-            err = g_platform[i].variorum_print_energy(0);
-            if (err)
-            {
-                return -1;
-            }
-        }
- /*   }
-    else
+    */
+    for (i = 0; i < P_NUM_PLATFORMS; i++)
     {
-        // We have a GPU-only build, currently doesn't support get_energy
-        variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
-                               __FUNCTION__, __LINE__);
-        return 0;
+        if (g_platform[i].variorum_print_energy == NULL)
+        {
+            variorum_error_handler("Feature not yet implemented or is not supported",
+                                   VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                                   __FUNCTION__, __LINE__);
+            return 0;
+        }
+        err = g_platform[i].variorum_print_energy(0);
+        if (err)
+        {
+            return -1;
+        }
     }
-*/
+    /*   }
+       else
+       {
+           // We have a GPU-only build, currently doesn't support get_energy
+           variorum_error_handler("Feature not yet implemented or is not supported",
+                                  VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                                  __FUNCTION__, __LINE__);
+           return 0;
+       }
+    */
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
 
     if (err)
@@ -1635,8 +1635,8 @@ int variorum_print_verbose_energy(void)
 {
     int err = 0;
     int i;
-//    int has_cpu = 0;
-//    int has_gpu = 0;
+    //    int has_cpu = 0;
+    //    int has_gpu = 0;
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
     if (err)
     {
@@ -1647,42 +1647,42 @@ int variorum_print_verbose_energy(void)
     // If we have a CPU-only or CPU+GPU multi-platform build, we should print
     // the node-level energy.
     // First check if we have a CPU platform, then check for a GPU platform
-/*
-#if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
-    has_cpu = 1;
-#endif
-#if defined(VARIORUM_WITH_NVIDIA_GPU) || defined(VARIORUM_WITH_AMD_GPU) || defined(VARIORUM_WITH_INTEL_GPU)
-    has_gpu = 1;
-#endif
+    /*
+    #if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
+        has_cpu = 1;
+    #endif
+    #if defined(VARIORUM_WITH_NVIDIA_GPU) || defined(VARIORUM_WITH_AMD_GPU) || defined(VARIORUM_WITH_INTEL_GPU)
+        has_gpu = 1;
+    #endif
 
-    // CPU-only or multi-platform build
-    if ((has_cpu && has_gpu) || (has_cpu))
-    {
-*/
-        for (i = 0; i < P_NUM_PLATFORMS; i++)
+        // CPU-only or multi-platform build
+        if ((has_cpu && has_gpu) || (has_cpu))
         {
-            if (g_platform[i].variorum_print_energy == NULL)
-            {
-                variorum_error_handler("Feature not yet implemented or is not supported",
-                                       VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
-                                       __FUNCTION__, __LINE__);
-                return 0;
-            }
-            err = g_platform[i].variorum_print_energy(1);
-            if (err)
-            {
-                return -1;
-            }
-        }
-  /*  }
-    else
+    */
+    for (i = 0; i < P_NUM_PLATFORMS; i++)
     {
-        // We have a GPU-only build, currently doesn't support get_energy
-        variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
-                               __FUNCTION__, __LINE__);
-        return 0;
-    }*/
+        if (g_platform[i].variorum_print_energy == NULL)
+        {
+            variorum_error_handler("Feature not yet implemented or is not supported",
+                                   VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                                   __FUNCTION__, __LINE__);
+            return 0;
+        }
+        err = g_platform[i].variorum_print_energy(1);
+        if (err)
+        {
+            return -1;
+        }
+    }
+    /*  }
+      else
+      {
+          // We have a GPU-only build, currently doesn't support get_energy
+          variorum_error_handler("Feature not yet implemented or is not supported",
+                                 VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                                 __FUNCTION__, __LINE__);
+          return 0;
+      }*/
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
     if (err)
     {
@@ -1695,8 +1695,8 @@ int variorum_get_energy_json(char **get_energy_obj_str)
 {
     int err = 0;
     int i;
-//    int has_cpu = 0;
-//    int has_gpu = 0;
+    //    int has_cpu = 0;
+    //    int has_gpu = 0;
     char hostname[1024];
     uint64_t ts;
     struct timeval tv;
@@ -1720,46 +1720,46 @@ int variorum_get_energy_json(char **get_energy_obj_str)
     // If we have a CPU-only or CPU+GPU multi-platform build, we should print
     // the node-level energy.
     // First check if we have a CPU platform, then check for a GPU platform
-/*
-#if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
-    has_cpu = 1;
-#endif
-#if defined(VARIORUM_WITH_NVIDIA_GPU) || defined(VARIORUM_WITH_AMD_GPU) || defined(VARIORUM_WITH_INTEL_GPU)
-    has_gpu = 1;
-#endif
+    /*
+    #if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
+        has_cpu = 1;
+    #endif
+    #if defined(VARIORUM_WITH_NVIDIA_GPU) || defined(VARIORUM_WITH_AMD_GPU) || defined(VARIORUM_WITH_INTEL_GPU)
+        has_gpu = 1;
+    #endif
 
-    // CPU-only or multi-platform build
-    if ((has_cpu && has_gpu) || (has_cpu))
-    {
-*/
-        for (i = 0; i < P_NUM_PLATFORMS; i++)
+        // CPU-only or multi-platform build
+        if ((has_cpu && has_gpu) || (has_cpu))
         {
-            if (g_platform[i].variorum_get_energy_json == NULL)
-            {
-                variorum_error_handler("Feature not yet implemented or is not supported",
-                                       VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
-                                       getenv("HOSTNAME"), __FILE__,
-                                       __FUNCTION__, __LINE__);
-                return 0;
-            }
-            err = g_platform[i].variorum_get_energy_json(node_obj);
-            if (err)
-            {
-                printf("Error with variorum get frequency json platform %d\n", i);
-            }
-            *get_energy_obj_str = json_dumps(get_energy_obj, JSON_INDENT(4));
-        }
-  /*  }
-    else
+    */
+    for (i = 0; i < P_NUM_PLATFORMS; i++)
     {
-        // We have a GPU-only build, currently doesn't support get_energy
-        variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
-                               __FUNCTION__, __LINE__);
+        if (g_platform[i].variorum_get_energy_json == NULL)
+        {
+            variorum_error_handler("Feature not yet implemented or is not supported",
+                                   VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                                   getenv("HOSTNAME"), __FILE__,
+                                   __FUNCTION__, __LINE__);
+            return 0;
+        }
+        err = g_platform[i].variorum_get_energy_json(node_obj);
+        if (err)
+        {
+            printf("Error with variorum get frequency json platform %d\n", i);
+        }
         *get_energy_obj_str = json_dumps(get_energy_obj, JSON_INDENT(4));
-        return 0;
     }
-*/
+    /*  }
+      else
+      {
+          // We have a GPU-only build, currently doesn't support get_energy
+          variorum_error_handler("Feature not yet implemented or is not supported",
+                                 VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                                 __FUNCTION__, __LINE__);
+          *get_energy_obj_str = json_dumps(get_energy_obj, JSON_INDENT(4));
+          return 0;
+      }
+    */
 
     json_decref(get_energy_obj);
 


### PR DESCRIPTION
# Description

Extend the new energy API from v0.8 to include GPU energy on NVIDIA and AMD GPUs.

**6/26: This is WIP and won't compile/work just yet.**

To Do 6/27:

- [x] We're reporting deltas in the energy reporting API (CPU only) and the first call to GPU energy needs to be 0; this PR needs to be edited to do this correctly. Getting raw value from vendor API, need to store this value as the offset, and a do a diff from the offset for all subsequent samples.

To Do 4/9/25:
- [x] Deltas have been fixed in `print_energy API` on NVIDIA
- [ ] Update deltas for JSON API for NVIDIA
- [ ] Clean out the commented code from variorum.c
- [ ] Add AMD Rocm support with `rsmi_dev_energy_count_get()` by mimicking what we did for NVIDIA print_energy and json_energy --> target Tioga first (Mi250x)

Fixes #532.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

- [x] Lassen: GPU-only
- [ ] Lassen: CPU-only
- [ ] Lassen: CPU+GPU
- [ ] Corona: GPU-only
- [ ] Tioga: GPU-only
- [ ] Tioga: CPU+GPU (blocked due to the HSMP module issue, will be tested later.)

# Checklist:

- [ ] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [ ] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [ ] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
