### PR TITLE
Fix linking with APMIDG for Intel GPUs

### DIFF
--- a/src/variorum/CMakeLists.txt
+++ b/src/variorum/CMakeLists.txt
@@ -132,7 +132,7 @@ if(LIBJUSTIFY_FOUND)
 endif()
 
 if(VARIORUM_WITH_INTEL_GPU)
-target_link_libraries(variorum PUBLIC ${APMIDG_HEADER})
+target_link_libraries(variorum PUBLIC ${APMIDG_LIBRARY})
 endif()
 if(VARIORUM_WITH_NVIDIA_GPU)
 target_link_libraries(variorum PUBLIC ${NVML_HEADER})

--- a/src/variorum/Intel_GPU/intel_gpu_power_features.c
+++ b/src/variorum/Intel_GPU/intel_gpu_power_features.c
@@ -175,13 +175,13 @@ void get_clocks_data(int chipid, int verbose, FILE *output)
         if (verbose)
         {
 #ifdef LIBJUSTIFY_FOUND
-            cfprintf(output, "%s: %s, %s: %d, %s: %d, %s: %d %s\n"
-                     "_INTEL_GPU_CLOCKS Host", m_hostname, "Socket", chipid, "DeviceID", d,
-                     "GPU_Clock", (int)freq_MHz, "MHz");
+            cfprintf(output,
+                     "_INTEL_GPU_CLOCKS Host: %s, Socket: %d, DeviceID: %d, GPU_Clock: %d MHz\n",
+                     m_hostname, chipid, d, (int)freq_MHz);
 #else
-            fprintf(output, "%s: %s, %s: %d, %s: %d, %s: %d %s\n"
-                    "_INTEL_GPU_CLOCKS Host", m_hostname, "Socket", chipid, "DeviceID", d,
-                    "GPU_Clock", (int)freq_MHz, "MHz");
+            fprintf(output,
+                    "_INTEL_GPU_CLOCKS Host: %s, Socket: %d, DeviceID: %d, GPU_Clock: %d MHz\n",
+                    m_hostname, chipid, d, (int)freq_MHz);
 #endif
         }
         else

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1202,41 +1202,38 @@ int variorum_get_utilization_json(char **get_util_obj_str)
     {
         return -1;
     }
-    if (str != NULL)
+    token = strtok(str, d);
+    sum = 0;
+    // get required values to compute cpu utilizations
+    while (token != NULL)
     {
-        token = strtok(str, d);
-        sum = 0;
-        // get required values to compute cpu utilizations
-        while (token != NULL)
+        token = strtok(NULL, d);
+        if (token != NULL)
         {
-            token = strtok(NULL, d);
-            if (token != NULL)
+            sum += strtol(token, &p, 10);
+            if (i == 3)
             {
-                sum += strtol(token, &p, 10);
-                if (i == 3)
-                {
-                    idle = strtol(token, &p, 10);
-                }
-                if (i == 0)
-                {
-                    user_time = strtol(token, &p, 10);
-                }
-                if (i == 1)
-                {
-                    nice_time = strtol(token, &p, 10);
-                }
-                if (i == 2)
-                {
-                    sys_time = strtol(token, &p, 10);
-                }
-                if (i == 4)
-                {
-                    iowait = strtol(token, &p, 10);
-                }
-                sum_idle = idle + iowait;
-                sum_user_time = user_time + nice_time;
-                i++;
+                idle = strtol(token, &p, 10);
             }
+            if (i == 0)
+            {
+                user_time = strtol(token, &p, 10);
+            }
+            if (i == 1)
+            {
+                nice_time = strtol(token, &p, 10);
+            }
+            if (i == 2)
+            {
+                sys_time = strtol(token, &p, 10);
+            }
+            if (i == 4)
+            {
+                iowait = strtol(token, &p, 10);
+            }
+            sum_idle = idle + iowait;
+            sum_user_time = user_time + nice_time;
+            i++;
         }
     }
 


### PR DESCRIPTION
# Description

Without this pull request `Variorum` doesn't link against `APMIDG` resulting in linker errors. This pull request is also fixing some compiler warnings. In particular, the `str` array is never `NULL` making one check obsolete. The success of writing into this array via `fgets` is already checked above.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Building and testing on ALCF's `sunspot` testbed.

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
