### PR TITLE
Fix compiler warnings with ENABLE_WARNINGS=ON

### DIFF
--- a/src/examples/openmp-examples/variorum-print-power-limit-openmp-example.c
+++ b/src/examples/openmp-examples/variorum-print-power-limit-openmp-example.c
@@ -11,8 +11,7 @@
 
 int main(int argc, char **argv)
 {
-    int ret;
-    int tid;
+    int ret = 0;
 
     const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
@@ -32,9 +31,9 @@ int main(int argc, char **argv)
         }
     }
 
-    #pragma omp parallel private(tid)
+    #pragma omp parallel
     {
-        tid = omp_get_thread_num();
+        int tid = omp_get_thread_num();
 
         // higher-level software must check for thread and process safety
         // we assume thread 0 is responsible for monitor and control

--- a/src/examples/openmp-examples/variorum-print-power-openmp-example.c
+++ b/src/examples/openmp-examples/variorum-print-power-openmp-example.c
@@ -11,8 +11,7 @@
 
 int main(int argc, char **argv)
 {
-    int ret;
-    int tid;
+    int ret = 0;
 
     const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
@@ -32,9 +31,9 @@ int main(int argc, char **argv)
         }
     }
 
-    #pragma omp parallel private(tid)
+    #pragma omp parallel
     {
-        tid = omp_get_thread_num();
+        int tid = omp_get_thread_num();
 
         // higher-level software must check for thread and process safety
         // we assume thread 0 is responsible for monitor and control

--- a/src/examples/openmp-examples/variorum-print-verbose-power-limit-openmp-example.c
+++ b/src/examples/openmp-examples/variorum-print-verbose-power-limit-openmp-example.c
@@ -11,8 +11,7 @@
 
 int main(int argc, char **argv)
 {
-    int ret;
-    int tid;
+    int ret = 0;
 
     const char *usage = "Usage: %s [-h] [-v]\n";
     int opt;
@@ -32,9 +31,9 @@ int main(int argc, char **argv)
         }
     }
 
-    #pragma omp parallel private(tid)
+    #pragma omp parallel
     {
-        tid = omp_get_thread_num();
+        int tid = omp_get_thread_num();
 
         // higher-level software must check for thread and process safety
         // we assume thread 0 is responsible for monitor and control

--- a/src/examples/openmp-examples/variorum-print-verbose-power-openmp-example.c
+++ b/src/examples/openmp-examples/variorum-print-verbose-power-openmp-example.c
@@ -26,8 +26,7 @@ static inline double do_work(int input)
 
 int main(int argc, char **argv)
 {
-    int ret;
-    int tid;
+    int ret = 0;
 #ifdef SECOND_RUN
     int i;
     int size = 1E3;
@@ -52,9 +51,9 @@ int main(int argc, char **argv)
         }
     }
 
-    #pragma omp parallel private(tid)
+    #pragma omp parallel
     {
-        tid = omp_get_thread_num();
+        int tid = omp_get_thread_num();
 
         // higher-level software must check for thread and process safety
         // we assume thread 0 is responsible for monitor and control


### PR DESCRIPTION
# Description

Fixes the warnings I am seeing with `ENABLE_WARNINGS=ON` on ALCF's `sunspot` testbed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Compiling and testing on ALCF's `sunspot` testbed.

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
