### PR TITLE
Add Intel GPU Energy APIs

### DIFF
--- a/src/variorum/Intel_GPU/GPU.c
+++ b/src/variorum/Intel_GPU/GPU.c
@@ -99,3 +99,43 @@ int intel_gpu_get_power_limit(int long_ver)
     }
     return 0;
 }
+
+int intel_gpu_get_energy(int long_ver)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    unsigned iter = 0;
+    unsigned nsockets = 0;
+#ifdef VARIORUM_WITH_INTEL_GPU
+    variorum_get_topology(&nsockets, NULL, NULL, P_INTEL_GPU_IDX);
+#endif
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        get_energy_data(iter, long_ver, stdout);
+    }
+    return 0;
+}
+
+int intel_gpu_get_energy_json(json_t *get_energy_obj)
+{
+    char *val = getenv("VARIORUM_LOG");
+    if (val != NULL && atoi(val) == 1)
+    {
+        printf("Running %s\n", __FUNCTION__);
+    }
+
+    unsigned iter = 0;
+    unsigned nsockets;
+    variorum_get_topology(&nsockets, NULL, NULL, P_INTEL_GPU_IDX);
+
+    for (iter = 0; iter < nsockets; iter++)
+    {
+        get_energy_json(iter, get_energy_obj);
+    }
+
+    return 0;
+}

--- a/src/variorum/Intel_GPU/GPU.h
+++ b/src/variorum/Intel_GPU/GPU.h
@@ -6,6 +6,8 @@
 #ifndef INTEL_GPU_H_INCLUDE
 #define INTEL_GPU_H_INCLUDE
 
+#include <jansson.h>
+
 extern int intel_gpu_get_power(
     int long_ver
 );
@@ -24,6 +26,15 @@ extern int intel_gpu_cap_each_gpu_power_limit(
 
 extern int intel_gpu_get_power_limit(
     int long_ver
+);
+
+
+extern int intel_gpu_get_energy(
+    int long_ver
+);
+
+extern int intel_gpu_get_energy_json(
+    json_t *get_energy_obj_str
 );
 
 #endif

--- a/src/variorum/Intel_GPU/config_intel_gpu.c
+++ b/src/variorum/Intel_GPU/config_intel_gpu.c
@@ -29,6 +29,8 @@ int set_intel_gpu_func_ptrs(int idx)
         g_platform[idx].variorum_cap_each_gpu_power_limit =
             intel_gpu_cap_each_gpu_power_limit;
         g_platform[idx].variorum_print_power_limit = intel_gpu_get_power_limit;
+        g_platform[idx].variorum_print_energy = intel_gpu_get_energy;
+        g_platform[idx].variorum_get_energy_json = intel_gpu_get_energy_json;
     }
     else
     {

--- a/src/variorum/Intel_GPU/intel_gpu_power_features.c
+++ b/src/variorum/Intel_GPU/intel_gpu_power_features.c
@@ -23,6 +23,12 @@ static char m_hostname[1024];
 static double *m_initial_energy_for_gpu;
 static int *m_init_energy;
 
+void releaseInitialEnergyForGPU()
+{
+    free(m_initial_energy_for_gpu);
+    free(m_init_energy);
+}
+
 void initAPMIDG(void)
 {
     int verbose = 0;
@@ -43,7 +49,7 @@ void initAPMIDG(void)
         m_initial_energy_for_gpu = (double *) malloc(sizeof(double) *
                                    m_total_unit_devices);
         m_init_energy = (int *) calloc(m_num_package, sizeof(int));
-
+        atexit(releaseInitialEnergyForGPU);
         init = 1;
     }
 

--- a/src/variorum/Intel_GPU/intel_gpu_power_features.h
+++ b/src/variorum/Intel_GPU/intel_gpu_power_features.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include <jansson.h>
+
 #include <libapmidg.h>
 
 void initAPMIDG(
@@ -46,6 +48,17 @@ void get_power_limit_data(
     int chipid,
     int verbose,
     FILE *output
+);
+
+void get_energy_data(
+    int chipid,
+    int verbose,
+    FILE *output
+);
+
+void get_energy_json(
+    int chipid,
+    json_t *output
 );
 
 #endif

--- a/src/variorum/variorum.c
+++ b/src/variorum/variorum.c
@@ -1573,52 +1573,26 @@ int variorum_print_energy(void)
 {
     int err = 0;
     int i;
-    int has_cpu = 0;
-    int has_gpu = 0;
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
     if (err)
     {
         return -1;
     }
 
-    // If we have a GPU-only build, we should exit with a helpful message.
-    // If we have a CPU-only or CPU+GPU multi-platform build, we should print
-    // the node-level energy.
-    // First check if we have a CPU platform, then check for a GPU platform
-
-#if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
-    has_cpu = 1;
-#endif
-#if defined(VARIORUM_WITH_NVIDIA_GPU) || defined(VARIORUM_WITH_AMD_GPU) || defined(VARIORUM_WITH_INTEL_GPU)
-    has_gpu = 1;
-#endif
-
-    // CPU-only or multi-platform build
-    if ((has_cpu && has_gpu) || (has_cpu))
+    for (i = 0; i < P_NUM_PLATFORMS; i++)
     {
-        for (i = 0; i < P_NUM_PLATFORMS; i++)
+        if (g_platform[i].variorum_print_energy == NULL)
         {
-            if (g_platform[i].variorum_print_energy == NULL)
-            {
-                variorum_error_handler("Feature not yet implemented or is not supported",
-                                       VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
-                                       __FUNCTION__, __LINE__);
-                return 0;
-            }
-            err = g_platform[i].variorum_print_energy(0);
-            if (err)
-            {
-                return -1;
-            }
+            variorum_error_handler("Feature not yet implemented or is not supported",
+                                   VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                                   __FUNCTION__, __LINE__);
+            return 0;
         }
-    }
-    else
-    {
-        // We have a GPU-only build, currently doesn't support get_energy
-        variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
-                               __FUNCTION__, __LINE__);
-        return 0;
+        err = g_platform[i].variorum_print_energy(0);
+        if (err)
+        {
+            return -1;
+        }
     }
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
 
@@ -1633,52 +1607,26 @@ int variorum_print_verbose_energy(void)
 {
     int err = 0;
     int i;
-    int has_cpu = 0;
-    int has_gpu = 0;
     err = variorum_enter(__FILE__, __FUNCTION__, __LINE__);
     if (err)
     {
         return -1;
     }
 
-    // If we have a GPU-only build, we should exit with a helpful message.
-    // If we have a CPU-only or CPU+GPU multi-platform build, we should print
-    // the node-level energy.
-    // First check if we have a CPU platform, then check for a GPU platform
-
-#if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
-    has_cpu = 1;
-#endif
-#if defined(VARIORUM_WITH_NVIDIA_GPU) || defined(VARIORUM_WITH_AMD_GPU) || defined(VARIORUM_WITH_INTEL_GPU)
-    has_gpu = 1;
-#endif
-
-    // CPU-only or multi-platform build
-    if ((has_cpu && has_gpu) || (has_cpu))
+    for (i = 0; i < P_NUM_PLATFORMS; i++)
     {
-        for (i = 0; i < P_NUM_PLATFORMS; i++)
+        if (g_platform[i].variorum_print_energy == NULL)
         {
-            if (g_platform[i].variorum_print_energy == NULL)
-            {
-                variorum_error_handler("Feature not yet implemented or is not supported",
-                                       VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
-                                       __FUNCTION__, __LINE__);
-                return 0;
-            }
-            err = g_platform[i].variorum_print_energy(1);
-            if (err)
-            {
-                return -1;
-            }
+            variorum_error_handler("Feature not yet implemented or is not supported",
+                                   VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
+                                   __FUNCTION__, __LINE__);
+            return 0;
         }
-    }
-    else
-    {
-        // We have a GPU-only build, currently doesn't support get_energy
-        variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
-                               __FUNCTION__, __LINE__);
-        return 0;
+        err = g_platform[i].variorum_print_energy(1);
+        if (err)
+        {
+            return -1;
+        }
     }
     err = variorum_exit(__FILE__, __FUNCTION__, __LINE__);
     if (err)
@@ -1692,8 +1640,6 @@ int variorum_get_energy_json(char **get_energy_obj_str)
 {
     int err = 0;
     int i;
-    int has_cpu = 0;
-    int has_gpu = 0;
     char hostname[1024];
     uint64_t ts;
     struct timeval tv;
@@ -1713,47 +1659,22 @@ int variorum_get_energy_json(char **get_energy_obj_str)
     ts = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
     json_object_set_new(node_obj, "timestamp", json_integer(ts));
 
-    // If we have a GPU-only build, we should exit with a helpful message.
-    // If we have a CPU-only or CPU+GPU multi-platform build, we should print
-    // the node-level energy.
-    // First check if we have a CPU platform, then check for a GPU platform
-
-#if defined(VARIORUM_WITH_INTEL_CPU) || defined(VARIORUM_WITH_AMD_CPU) || defined(VARIORUM_WITH_IBM_CPU)
-    has_cpu = 1;
-#endif
-#if defined(VARIORUM_WITH_NVIDIA_GPU) || defined(VARIORUM_WITH_AMD_GPU) || defined(VARIORUM_WITH_INTEL_GPU)
-    has_gpu = 1;
-#endif
-
-    // CPU-only or multi-platform build
-    if ((has_cpu && has_gpu) || (has_cpu))
+    for (i = 0; i < P_NUM_PLATFORMS; i++)
     {
-        for (i = 0; i < P_NUM_PLATFORMS; i++)
+        if (g_platform[i].variorum_get_energy_json == NULL)
         {
-            if (g_platform[i].variorum_get_energy_json == NULL)
-            {
-                variorum_error_handler("Feature not yet implemented or is not supported",
-                                       VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
-                                       getenv("HOSTNAME"), __FILE__,
-                                       __FUNCTION__, __LINE__);
-                return 0;
-            }
-            err = g_platform[i].variorum_get_energy_json(node_obj);
-            if (err)
-            {
-                printf("Error with variorum get frequency json platform %d\n", i);
-            }
-            *get_energy_obj_str = json_dumps(get_energy_obj, JSON_INDENT(4));
+            variorum_error_handler("Feature not yet implemented or is not supported",
+                                   VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED,
+                                   getenv("HOSTNAME"), __FILE__,
+                                   __FUNCTION__, __LINE__);
+            return 0;
         }
-    }
-    else
-    {
-        // We have a GPU-only build, currently doesn't support get_energy
-        variorum_error_handler("Feature not yet implemented or is not supported",
-                               VARIORUM_ERROR_FEATURE_NOT_IMPLEMENTED, getenv("HOSTNAME"), __FILE__,
-                               __FUNCTION__, __LINE__);
+        err = g_platform[i].variorum_get_energy_json(node_obj);
+        if (err)
+        {
+            printf("Error with variorum get frequency json platform %d\n", i);
+        }
         *get_energy_obj_str = json_dumps(get_energy_obj, JSON_INDENT(4));
-        return 0;
     }
 
     json_decref(get_energy_obj);


### PR DESCRIPTION
Merge after #559 

# Description

Corresponds to #559 for Intel GPUs using APMIDG. Outputs look like
```
> ./variorum-print-verbose-energy-example
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 0, DeviceID: 0, Energy: 682460.802429 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 0, DeviceID: 1, Energy: 789783.862792 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 0, DeviceID: 2, Energy: 776530.864990 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 1, DeviceID: 3, Energy: 687270.160583 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 1, DeviceID: 4, Energy: 568826.738464 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 1, DeviceID: 5, Energy: 710078.444824 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 0, DeviceID: 0, Energy: 683044.307495 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 0, DeviceID: 1, Energy: 790386.810180 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 0, DeviceID: 2, Energy: 777118.108947 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 1, DeviceID: 3, Energy: 687852.643859 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 1, DeviceID: 4, Energy: 569396.025085 J
_INTEL_GPU_ENERGY_USAGE Host: x1921c0s2b0n0, Socket: 1, DeviceID: 5, Energy: 710663.270080 J
```
The node has 6 GPUs with two tiles each for 12 GPU tiles in total. Thus, seeing 2 sockets with 3 devices is surprising but we should see similar output for existing Intel GPU APIs. This needs some investigation either in this pull request or elsewhere.
Also, #559 should probably be merged first.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Running on testing on ALCF's `sunspot` testbed.

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [ ] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes