### PR TITLE
Fix memory leak in some variorum JSON examples.

### DIFF
--- a/src/examples/variorum-get-energy-json-example.c
+++ b/src/examples/variorum-get-energy-json-example.c
@@ -64,6 +64,9 @@ int main(int argc, char **argv)
     /* Print the entire JSON object */
     puts(s);
 
+    /* Deallocate the string */
+    free(s);
+
 #ifdef SECOND_RUN
     for (i = 0; i < size; i++)
     {

--- a/src/examples/variorum-get-power-json-example.c
+++ b/src/examples/variorum-get-power-json-example.c
@@ -64,6 +64,9 @@ int main(int argc, char **argv)
     /* Print the entire JSON object */
     puts(s);
 
+    /* Deallocate the string */
+    free(s);
+
 #ifdef SECOND_RUN
     for (i = 0; i < size; i++)
     {

--- a/src/examples/variorum-get-utilization-json-example.c
+++ b/src/examples/variorum-get-utilization-json-example.c
@@ -63,6 +63,9 @@ int main(int argc, char **argv)
     /* Print the entire JSON object */
     puts(s);
 
+    /* Deallocate the string */
+    free(s);
+
 #ifdef SECOND_RUN
     for (i = 0; i < size; i++)
     {

--- a/src/examples/variorum-integration-using-json-example.c
+++ b/src/examples/variorum-integration-using-json-example.c
@@ -164,6 +164,9 @@ int main(void)
     puts(s);
     parse_json_power_obj(s, num_sockets);
 
+    /* Deallocate the string */
+    free(s);
+
 #ifdef SECOND_RUN
     for (i = 0; i < size; i++)
     {


### PR DESCRIPTION
# Description

Fixes memory leak in some variorum JSON examples as detected by `-fsanitize=address`.
Fixes #567 .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Tested on Lassen by adding `-fsanitize=address` in the `CMakeLists.txt` file in src/examples (the Variorum build to use address sanitizer checks will be updated as a separate PR.)

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
