### PR TITLE
Make mlock `static` to avoid a pesky Lassen-only bug.

### DIFF
--- a/src/variorum/IBM/Power9.c
+++ b/src/variorum/IBM/Power9.c
@@ -17,7 +17,7 @@
 #endif
 
 /* Figure out the right spot for this at some point */
-pthread_mutex_t mlock;
+static pthread_mutex_t mlock;
 struct thread_args th_args;
 pthread_attr_t mattr;
 pthread_t mthread;


### PR DESCRIPTION
# Description

Fixes #568 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI update

# How Has This Been Tested?

Tested on Lassen.

# Checklist:

- [x] I have run `./scripts/check-code-format.sh` and confirm my code code follows the style guidelines of variorum
- [x] I have added comments in my code
- [x] My changes generate no new warnings (build with `-DENABLE_WARNINGS=ON`)
- [x] New and existing unit tests pass with my changes

Thank you for taking the time to contribute to Variorum!
