### PR TITLE
update install directory for variorum.pc

### DIFF
--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -84,4 +84,4 @@ variorum.pc.in
 ${CMAKE_CURRENT_BINARY_DIR}/variorum.pc)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/variorum.pc
-        DESTINATION share)
+        DESTINATION share/pkgconfig)


### PR DESCRIPTION
# Description

Updates install directory for variorum.pc file. Previously `CMAKE_INSTALL_DIR/share` is now` `CMAKE_INSTALL_DIR/share/pkgconfig`.

Fixes #579 and addresses #414 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/architecture support (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Build/CI update